### PR TITLE
Bug 533490 - Find unused dependencies does not respect indirectly referenced class files

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
@@ -170,15 +170,8 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 			for (IPackageFragment pkgFragment : packageFragments) {
 				SubMonitor iterationMonitor = subMonitor.split(2);
 				if (pkgFragment.hasChildren()) {
-					Requestor requestor = new Requestor();
-					engine.search(SearchPattern.createPattern(pkgFragment, IJavaSearchConstants.REFERENCES),
-							new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope,
-							requestor, iterationMonitor.split(1));
-					if (requestor.foundMatches()) {
-						if (provideJavaClasses(pkgFragment, engine, searchScope,
-								iterationMonitor.split(1))) {
-							return true;
-						}
+					if (provideJavaClasses(pkgFragment, engine, searchScope, iterationMonitor.split(1))) {
+						return true;
 					}
 				}
 			}
@@ -203,12 +196,15 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 			if (types != null) {
 				SubMonitor iterationMonitor = subMonitor.split(1).setWorkRemaining(types.length);
 				for (IType type : types) {
-					requestor = new Requestor();
-					engine.search(SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES),
+					IType[] allTypes = type.newSupertypeHierarchy(iterationMonitor.split(1)).getAllTypes();
+					for (IType currType : allTypes) {
+						requestor = new Requestor();
+						engine.search(SearchPattern.createPattern(currType, IJavaSearchConstants.REFERENCES),
 							new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope,
 							requestor, iterationMonitor.split(1));
-					if (requestor.foundMatches()) {
-						return true;
+						if (requestor.foundMatches()) {
+							return true;
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
This PR resolves [Bug 533490 ](https://bugs.eclipse.org/bugs/show_bug.cgi?id=533490 )

It was first addressed in [Eclipse Gerrit Change 138143](https://git.eclipse.org/r/c/pde/eclipse.pde.ui/+/138143) but abandoned because it was not completed at the time of the move.

@iloveeclipse you created the mentioned Gerrit as a base for further discussions.
I can try to complete this in the near future and can also check the mentioned performance concerns.