### PR TITLE
Add required o.e.osgi bundle for subclasses of EquinoxLaunchConfig too

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -111,7 +111,8 @@ public class BundleLauncherHelper {
 
 	private static void addRequiredBundles(Map<IPluginModelBase, String> bundle2startLevel, ILaunchConfiguration configuration) throws CoreException {
 
-		RequirementHelper.addApplicationLaunchRequirements(bundle2startLevel, configuration);
+		List<String> appRequirements = RequirementHelper.getApplicationLaunchRequirements(configuration);
+		RequirementHelper.addApplicationLaunchRequirements(appRequirements, configuration, bundle2startLevel);
 
 		boolean includeOptional = configuration.getAttribute(IPDELauncherConstants.INCLUDE_OPTIONAL, true);
 		Set<BundleDescription> requiredDependencies = includeOptional //
@@ -167,7 +168,8 @@ public class BundleLauncherHelper {
 
 		if (addRequirements) {
 			// Add all missing  plug-ins required by the application/product set in the config
-			RequirementHelper.addApplicationLaunchRequirements(configuration, launchPlugins, launchPlugins::add);
+			List<String> appRequirements = RequirementHelper.getApplicationLaunchRequirements(configuration);
+			RequirementHelper.addApplicationLaunchRequirements(appRequirements, configuration, launchPlugins, launchPlugins::add);
 
 			// Get all required plugins
 			Set<BundleDescription> additionalBundles = DependencyManager.getDependencies(launchPlugins);

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/RequirementHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/RequirementHelper.java
@@ -78,16 +78,15 @@ public class RequirementHelper {
 		return requirementsFunction != null ? Objects.requireNonNull(requirementsFunction.getRequiredBundleIds(config)) : Collections.emptyList();
 	}
 
-	public static boolean addApplicationLaunchRequirements(Map<IPluginModelBase, String> bundle2startLevel, ILaunchConfiguration configuration) throws CoreException {
+	public static boolean addApplicationLaunchRequirements(List<String> appRequirements, ILaunchConfiguration configuration, Map<IPluginModelBase, String> bundle2startLevel) throws CoreException {
 		Consumer<IPluginModelBase> addPlugin = b -> BundleLauncherHelper.addDefaultStartingBundle(bundle2startLevel, b);
-		return addApplicationLaunchRequirements(configuration, bundle2startLevel.keySet(), addPlugin);
+		return addApplicationLaunchRequirements(appRequirements, configuration, bundle2startLevel.keySet(), addPlugin);
 	}
 
-	public static boolean addApplicationLaunchRequirements(ILaunchConfiguration configuration, Set<IPluginModelBase> containedPlugins, Consumer<IPluginModelBase> addPlugin) throws CoreException {
+	public static boolean addApplicationLaunchRequirements(List<String> appRequirements, ILaunchConfiguration configuration, Set<IPluginModelBase> containedPlugins, Consumer<IPluginModelBase> addPlugin) throws CoreException {
 		boolean isFeatureBasedLaunch = configuration.getAttribute(IPDELauncherConstants.USE_CUSTOM_FEATURES, false);
 		String pluginResolution = isFeatureBasedLaunch ? configuration.getAttribute(IPDELauncherConstants.FEATURE_PLUGIN_RESOLUTION, IPDELauncherConstants.LOCATION_WORKSPACE) : IPDELauncherConstants.LOCATION_WORKSPACE;
 
-		List<String> appRequirements = getApplicationLaunchRequirements(configuration);
 		boolean allRequirementsSatisfied = true;
 		for (String requiredBundleId : appRequirements) {
 			ModelEntry entry = PluginRegistry.findEntry(requiredBundleId);

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
@@ -164,7 +164,7 @@ public class EquinoxLaunchConfiguration extends AbstractPDELaunchConfiguration {
 	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, true);
 
-		if (!RequirementHelper.addApplicationLaunchRequirements(fModels, configuration)) {
+		if (!RequirementHelper.addApplicationLaunchRequirements(List.of(IPDEBuildConstants.BUNDLE_OSGI), configuration, fModels)) {
 			throw new CoreException(Status.error(PDEMessages.EquinoxLaunchConfiguration_oldTarget));
 		}
 		fAllBundles = fModels.keySet().stream().collect(Collectors.groupingBy(m -> m.getPluginBase().getId(), HashMap::new, Collectors.toCollection(ArrayList::new)));

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/EquinoxLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/EquinoxLaunchConfiguration.java
@@ -30,7 +30,6 @@ import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.launching.IPDEConstants;
 import org.eclipse.pde.internal.launching.PDEMessages;
 import org.eclipse.pde.internal.launching.launcher.*;
-import org.eclipse.pde.launching.IPDELauncherConstants;
 
 /**
  * A launch delegate for launching the Equinox framework
@@ -162,7 +161,7 @@ public class EquinoxLaunchConfiguration extends AbstractPDELaunchConfiguration {
 	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, true);
 
-		if (!RequirementHelper.addApplicationLaunchRequirements(fModels, configuration)) {
+		if (!RequirementHelper.addApplicationLaunchRequirements(List.of(IPDEBuildConstants.BUNDLE_OSGI), configuration, fModels)) {
 			throw new CoreException(Status.error(PDEMessages.EquinoxLaunchConfiguration_oldTarget));
 		}
 		fAllBundles = fModels.keySet().stream().collect(Collectors.groupingBy(m -> m.getPluginBase().getId(),


### PR DESCRIPTION
This PR aims to fix https://github.com/eclipse-pde/eclipse.pde.ui/issues/32.

My first attempt was to add the requirements associated to a launch-configuration-type to all sub-classes of the corresponding LaunchConfigurationDelegate. But besides the the launch-configuration this would also require the launche's mode to obtain the correct delegate and this is not always trivial and would require a medium amount of changes.
Furthermore it is not correct because just because a launch-delegate extends EclipseApplicationLaunchConfiguration it does not mean that the launch-type of the sub-class has the same requirements.
So I have limited this fix to the previous specialty of the Equinox-Launch to add the required o.e.osgi and ensured that it is added.

If there is a demand to register own requirements for custom Launch-Delegates we have to decide how to provide an API to do that. But this was not yet requested.

@ifurnadjiev can you test if this PR really satisfies your needs?

@jhonnen what do you think about this?