### PR TITLE
APi tools should import package ASM instead of require bundle it

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -12,10 +12,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.filebuffers;bundle-version="[3.4.0,4.0.0)",
- org.objectweb.asm;bundle-version="[9.3.0,10.0.0)",
  org.eclipse.equinox.frameworkadmin;bundle-version="[2.0.0,3.0.0)",
- org.eclipse.core.variables;bundle-version="[3.2.0,4.0.0)",
- org.objectweb.asm.tree;bundle-version="[9.2.0,10.0.0)"
+ org.eclipse.core.variables;bundle-version="[3.2.0,4.0.0)"
 Export-Package: org.eclipse.pde.api.tools.internal;x-friends:="org.eclipse.pde.api.tools.tests,org.eclipse.pde.api.tools.ui,org.eclipse.pde.api.tools.generator",
  org.eclipse.pde.api.tools.internal.builder;x-friends:="org.eclipse.pde.api.tools.ui,org.eclipse.pde.api.tools.tests",
  org.eclipse.pde.api.tools.internal.comparator;x-friends:="org.eclipse.pde.api.tools.ui,org.eclipse.pde.api.tools.tests",
@@ -35,7 +33,10 @@ Export-Package: org.eclipse.pde.api.tools.internal;x-friends:="org.eclipse.pde.a
  org.eclipse.pde.api.tools.internal.util;x-friends:="org.eclipse.pde.api.tools.tests,org.eclipse.pde.api.tools.ui,org.eclipse.pde.api.tools.generator",
  org.eclipse.pde.api.tools.internal.util.profiles;x-internal:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Import-Package: com.ibm.icu.util
+Import-Package: com.ibm.icu.util,
+ org.objectweb.asm;version="[9.3.0,10.0.0)",
+ org.objectweb.asm.signature;version="[9.3.0,10.0.0)",
+ org.objectweb.asm.tree;version="[9.3.0,10.0.0)"
 Bundle-Activator: org.eclipse.pde.api.tools.internal.provisional.ApiPlugin
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Fix https://github.com/eclipse-pde/eclipse.pde/issues/42

FYI @bjhargrave @jonahgraham 