### PR TITLE
Minor changes to TestPDETemplates

### DIFF
--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -15,10 +15,8 @@
 package org.eclipse.pde.ui.templates.tests;
 
 import static java.util.stream.Collectors.toSet;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -65,7 +63,7 @@ public class TestPDETemplates {
 	}
 
 	@BeforeClass
-	public static void setTargetPlatform() throws IOException, CoreException, InterruptedException {
+	public static void setTargetPlatform() throws CoreException, InterruptedException {
 		TargetPlatformUtil.setRunningPlatformAsTarget();
 	}
 
@@ -166,7 +164,7 @@ public class TestPDETemplates {
 			markers = new IMarker[0];
 		}
 
-		assertThat("Template '" + template.getLabel() + "' generates errors.", markers, equalTo(new IMarker[0]));
+		assertEquals("Template '" + template.getLabel() + "' generates errors.", 0, markers.length);
 	}
 
 	@Test


### PR DESCRIPTION
* Stop using assertThat(message, variable equalTo(constant). It's just
complicated way to write assertEquals(message, constant, variable) which
even calls out to yet another library.
* Remove needless throws declaration.

Seen while investigating #55

Change-Id: If4b7a6937a9ec9acac88e435c21c52f7e7e6f1d8