### PR TITLE
Replace o.e.osgi.util in PDE E4-app template product

### DIFF
--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for PDE templates
 Bundle-SymbolicName: org.eclipse.pde.ui.templates.tests
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: tests.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/ui/org.eclipse.pde.ui.templates.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.templates.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.templates.tests</artifactId>
-  <version>1.1.100-SNAPSHOT</version>
+  <version>1.1.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -72,9 +72,8 @@ public class TestPDETemplates {
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<WizardElement> allTemplateWizards() {
-		return Arrays.asList(new NewPluginProjectWizard().getAvailableCodegenWizards().getChildren()).stream() //
-				.filter(o -> (o instanceof WizardElement)) //
-				.map(o -> (WizardElement) o) //
+		return Arrays.stream(new NewPluginProjectWizard().getAvailableCodegenWizards().getChildren()) //
+				.filter(WizardElement.class::isInstance).map(WizardElement.class::cast) //
 				.collect(Collectors.toList());
 	}
 

--- a/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
@@ -79,7 +79,8 @@
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
       <plugin id="org.eclipse.osgi.services"/>
-      <plugin id="org.eclipse.osgi.util"/>
+      <plugin id="org.osgi.util.function"/>
+      <plugin id="org.osgi.util.promise"/>
       <plugin id="org.eclipse.swt"/>
       <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.linux.ppc64" fragment="true"/>


### PR DESCRIPTION
With the latest changes in Equinox o.e.osgi.util was replaced by the
corresponding 'original' OSGi-reference bundles that are
required+reexported by o.e.osgi.util. Unfortunately the re-export does
not help in this product launch. Therefore o.e.osgi.util is replaced by
the actually needed plugins.

And apply one minor code improvement in TestPDETemplates.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/55