### PR TITLE
Fully reflect merge of pde.build in PDE's Oomph setup

### DIFF
--- a/releng/org.eclipse.pde.setup/PDE.setup
+++ b/releng/org.eclipse.pde.setup/PDE.setup
@@ -58,7 +58,7 @@
   <setupTask
       xsi:type="setup:EclipseIniTask"
       option="-Doomph.redirection.pde"
-      value="=https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/releng/org.eclipse.pde.setup/->${github.clone.pde.core.location|uri}/releng/org.eclipse.pde.setup/"
+      value="=https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/releng/org.eclipse.pde.setup/->${github.clone.pde.location|uri}/releng/org.eclipse.pde.setup/"
       vm="true">
     <description>Set an Oomph redirection system property to redirect the logical location of this setup to its physical location in the Git clone.</description>
   </setupTask>
@@ -98,7 +98,7 @@
       location="${jre.location-11}"/>
   <setupTask
       xsi:type="git:GitCloneTask"
-      id="github.clone.pde.core"
+      id="github.clone.pde"
       remoteURI="eclipse-pde/eclipse.pde">
     <annotation
         source="http://www.eclipse.org/oomph/setup/InducedChoices">
@@ -151,7 +151,7 @@
       <requirement
           name="org.eclipse.equinox.executable.feature.group"/>
       <sourceLocator
-          rootFolder="${github.clone.pde.core.location}"/>
+          rootFolder="${github.clone.pde.location}"/>
       <repositoryList
           name="CBI+Orbit">
         <repository
@@ -165,7 +165,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup.workingsets:WorkingSetTask"
-      id="pde.core.workingsets">
+      id="pde.workingsets">
     <workingSet
         name="PDE">
       <predicate
@@ -175,7 +175,7 @@
             project="org.eclipse.pde"/>
         <operand
             xsi:type="workingsets:ExclusionPredicate"
-            excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20API%20Tools'] //'pde.core.workingsets'/@workingSets[name='PDE%20Tests'] //'pde.core.workingsets'/@workingSets[name='PDE%20Build']"/>
+            excludedWorkingSet="//'pde.workingsets'/@workingSets[name='PDE%20API%20Tools'] //'pde.workingsets'/@workingSets[name='PDE%20Tests'] //'pde.workingsets'/@workingSets[name='PDE%20Build']"/>
       </predicate>
     </workingSet>
     <workingSet
@@ -190,7 +190,7 @@
             pattern=".*\.api\..*"/>
         <operand
             xsi:type="workingsets:ExclusionPredicate"
-            excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20Tests']"/>
+            excludedWorkingSet="//'pde.workingsets'/@workingSets[name='PDE%20Tests']"/>
       </predicate>
     </workingSet>
     <workingSet
@@ -217,7 +217,7 @@
             pattern=".*\.tests.*"/>
         <operand
             xsi:type="workingsets:ExclusionPredicate"
-            excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20Build']"/>
+            excludedWorkingSet="//'pde.workingsets'/@workingSets[name='PDE%20Build']"/>
       </predicate>
     </workingSet>
   </setupTask>

--- a/releng/org.eclipse.pde.setup/PDE.setup
+++ b/releng/org.eclipse.pde.setup/PDE.setup
@@ -20,6 +20,26 @@
         href="PDEConfiguration.setup#/"/>
   </annotation>
   <setupTask
+      xsi:type="setup:CompoundTask"
+      name="Preferences">
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.core.resources">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.core.resources/refresh.enabled"
+          value="true"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.jdt.core">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.forbiddenReference"
+          value="warning"/>
+    </setupTask>
+  </setupTask>
+  <setupTask
       xsi:type="setup.p2:P2Task">
     <requirement
         name="org.eclipse.platform.feature.group"/>
@@ -35,6 +55,13 @@
       option="-Xmx"
       value="2048m"
       vm="true"/>
+  <setupTask
+      xsi:type="setup:EclipseIniTask"
+      option="-Doomph.redirection.pde"
+      value="=https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/releng/org.eclipse.pde.setup/->${github.clone.pde.core.location|uri}/releng/org.eclipse.pde.setup/"
+      vm="true">
+    <description>Set an Oomph redirection system property to redirect the logical location of this setup to its physical location in the Git clone.</description>
+  </setupTask>
   <setupTask
       xsi:type="setup:ResourceCreationTask"
       excludedTriggers="STARTUP MANUAL"
@@ -70,6 +97,27 @@
       version="JavaSE-11"
       location="${jre.location-11}"/>
   <setupTask
+      xsi:type="git:GitCloneTask"
+      id="github.clone.pde.core"
+      remoteURI="eclipse-pde/eclipse.pde">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/InducedChoices">
+      <detail
+          key="inherit">
+        <value>github.remoteURIs</value>
+      </detail>
+      <detail
+          key="label">
+        <value>PDE Github Repository</value>
+      </detail>
+      <detail
+          key="target">
+        <value>remoteURI</value>
+      </detail>
+    </annotation>
+    <description>PDE</description>
+  </setupTask>
+  <setupTask
       xsi:type="setup.targlets:TargletTask"
       targetName="Modular API Baseline Target"
       activateTarget="false">
@@ -93,6 +141,8 @@
         name="PDE"
         activeRepositoryList="CBI+Orbit">
       <requirement
+          name="*"/>
+      <requirement
           name="org.eclipse.platform.feature.group"/>
       <requirement
           name="org.eclipse.jdt.feature.group"/>
@@ -100,6 +150,8 @@
           name="org.eclipse.pde.feature.group"/>
       <requirement
           name="org.eclipse.equinox.executable.feature.group"/>
+      <sourceLocator
+          rootFolder="${github.clone.pde.core.location}"/>
       <repositoryList
           name="CBI+Orbit">
         <repository
@@ -112,115 +164,65 @@
     </targlet>
   </setupTask>
   <setupTask
-      xsi:type="setup:CompoundTask"
-      name="Preferences">
-    <setupTask
-        xsi:type="setup:CompoundTask"
-        name="org.eclipse.core.resources">
-      <setupTask
-          xsi:type="setup:PreferenceTask"
-          key="/instance/org.eclipse.core.resources/refresh.enabled"
-          value="true"/>
-    </setupTask>
-    <setupTask
-        xsi:type="setup:CompoundTask"
-        name="org.eclipse.jdt.core">
-      <setupTask
-          xsi:type="setup:PreferenceTask"
-          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.forbiddenReference"
-          value="warning"/>
-    </setupTask>
+      xsi:type="setup.workingsets:WorkingSetTask"
+      id="pde.core.workingsets">
+    <workingSet
+        name="PDE">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.pde"/>
+        <operand
+            xsi:type="workingsets:ExclusionPredicate"
+            excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20API%20Tools'] //'pde.core.workingsets'/@workingSets[name='PDE%20Tests'] //'pde.core.workingsets'/@workingSets[name='PDE%20Build']"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="PDE API Tools">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.pde"/>
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern=".*\.api\..*"/>
+        <operand
+            xsi:type="workingsets:ExclusionPredicate"
+            excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20Tests']"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="PDE Build">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.pde"/>
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern="org\.eclipse\.pde\.build(\.tests)?"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="PDE Tests">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.pde"/>
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern=".*\.tests.*"/>
+        <operand
+            xsi:type="workingsets:ExclusionPredicate"
+            excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20Build']"/>
+      </predicate>
+    </workingSet>
   </setupTask>
-  <project name="core"
-      label="Core">
-    <setupTask
-        xsi:type="git:GitCloneTask"
-        id="github.clone.pde.core"
-        remoteURI="eclipse-pde/eclipse.pde">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/InducedChoices">
-        <detail
-            key="inherit">
-          <value>github.remoteURIs</value>
-        </detail>
-        <detail
-            key="label">
-          <value>PDE UI Github Repository</value>
-        </detail>
-        <detail
-            key="target">
-          <value>remoteURI</value>
-        </detail>
-      </annotation>
-      <description>PDE Core</description>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.targlets:TargletTask">
-      <targlet
-          name="PDE UI"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="*"/>
-        <sourceLocator
-            rootFolder="${github.clone.pde.core.location}"/>
-      </targlet>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask"
-        id="pde.core.workingsets">
-      <workingSet
-          name="PDE">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="org.eclipse.pde"/>
-          <operand
-              xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20API%20Tools'] //'pde.core.workingsets'/@workingSets[name='PDE%20Tests']"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="PDE API Tools">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="org.eclipse.pde"/>
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern=".*\.api\..*"/>
-          <operand
-              xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//'pde.core.workingsets'/@workingSets[name='PDE%20Tests']"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="PDE Tests">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="org.eclipse.pde"/>
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern=".*\.tests.*"/>
-        </predicate>
-      </workingSet>
-    </setupTask>
-    <stream
-        name="master"
-        label="Master">
-      <setupTask
-          xsi:type="setup:EclipseIniTask"
-          option="-Doomph.redirection.pde"
-          value="=https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/releng/org.eclipse.pde.setup/->${github.clone.pde.core.location|uri}/releng/org.eclipse.pde.setup/"
-          vm="true">
-        <description>Set an Oomph redirection system property to redirect the logical location of this setup to its physical location in the Git clone.</description>
-      </setupTask>
-    </stream>
-    <description>The PDE Core</description>
-  </project>
+  <stream name="master"
+      label="Master"/>
   <logicalProjectContainer
       xsi:type="setup:ProjectCatalog"
       href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']"/>

--- a/releng/org.eclipse.pde.setup/PDEConfiguration.setup
+++ b/releng/org.eclipse.pde.setup/PDEConfiguration.setup
@@ -31,7 +31,7 @@
       name="pde.workspace"
       label="PDE Workspace">
     <stream
-        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='pde']/@projects[name='core']/@streams[name='master']"/>
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='pde']/@streams[name='master']"/>
     <description>The PDE workspace provides the source code of the Eclipse Plug-in Development Environment.</description>
   </workspace>
   <description>


### PR DESCRIPTION
This PR inlines the `PDE Core` Project and adds a `PDE Build` Working-Set.
Furthermore it removes the 'core' element from ids.

Just like for the renaming of the project from PDE UI to PDE Core we have to provide a way to inform users that they have to update the Project-stream referenced in their workspace setup. Otherwise the setup is broken.
@merks can you please review this?