### PR TITLE
Add o.osgi.service.prefs in PDE E4-app template product

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
@@ -79,6 +79,7 @@
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
       <plugin id="org.eclipse.osgi.services"/>
+      <plugin id="org.osgi.service.prefs" />
       <plugin id="org.osgi.util.function"/>
       <plugin id="org.osgi.util.promise"/>
       <plugin id="org.eclipse.swt"/>


### PR DESCRIPTION
With the latest changes in Equinox o.e.equinox.preferences was replaced
by the
corresponding 'original' OSGi-reference bundles that are
required+reexported by it. Unfortunately the re-export does
not help in this product launch. Therefore o.osgi.service.prefs is
actually added to needed plug-ins.