### PR TITLE
Log the exception when failing to update the target profile cache

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IUBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IUBundleContainer.java
@@ -371,6 +371,7 @@ public class IUBundleContainer extends AbstractBundleContainer {
 			cacheBundles(target);
 			cacheFeatures(target);
 		} catch (CoreException e) {
+			PDECore.logException(e, e.getMessage());
 			fBundles = new TargetBundle[0];
 			fFeatures = new TargetFeature[0];
 			fResolutionStatus = e.getStatus();


### PR DESCRIPTION
An error during this step causes the number of available artifacts to be
empty. So the error log should reflect that something went wrong.