### PR TITLE
Ignore optional-requirements by default for plugin-product launches

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
@@ -382,6 +382,7 @@ public class LaunchAction extends Action {
 		wc.setAttribute(IPDELauncherConstants.AUTOMATIC_ADD, false);
 		wc.setAttribute(IPDELauncherConstants.PRODUCT_FILE, fPath);
 		wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_SOURCE_PATH_PROVIDER, PDESourcePathProvider.ID);
+		wc.setAttribute(IPDELauncherConstants.INCLUDE_OPTIONAL, false);
 		return refreshConfiguration(wc);
 	}
 


### PR DESCRIPTION
To create similar applications like when build with Tycho, optional-requirements should be ignored by default when assembling the bundles that are included in a plug-in based product-application launched from the IDE.
If a user want's to include optional dependencies it can be re-enabled in the launch-config dialog by checking the corresponding box. 
The attribute is only set for newly created launch-configs to not change the value of existing configs that were set manually.

@jhonnen what do you think? This changes the default behavior for plug-in based products and should then be mentioned in the N&N.