### PR TITLE
Include package-providing fragments when computing requirements closure

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -202,7 +202,9 @@ public class DependencyManager {
 					// not included into the closure.
 					continue;
 				}
-				BundleRevision provider = getProvider(wire);
+				BundleRevision provider = wire.getCapability().getRevision();
+				// Use revision of required capability to support the case if
+				// fragments contribute new packages to their host's API.
 				if (provider instanceof BundleDescription && (includeOptional || !isOptional(wire.getRequirement()))) {
 					BundleDescription requiredBundle = (BundleDescription) provider;
 					addNewRequiredBundle(requiredBundle, closure, pending);
@@ -217,13 +219,6 @@ public class DependencyManager {
 		if (bundle != null && bundle.isResolved() && !bundle.isRemovalPending() && requiredBundles.add(bundle)) {
 			pending.add(bundle);
 		}
-	}
-
-	private static BundleRevision getProvider(BundleWire wire) {
-		// org.eclipse.osgi.internal.resolver.BundleDescriptionImpl.BundleWireImpl.getProvider()
-		// does not check for null
-		BundleWiring providerWiring = wire.getProviderWiring();
-		return providerWiring != null ? providerWiring.getRevision() : null;
 	}
 
 	private static boolean isOptional(BundleRequirement requirement) {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/DependencyManagerTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/DependencyManagerTest.java
@@ -252,6 +252,56 @@ public class DependencyManagerTest {
 	}
 
 	@Test
+	public void testFindRequirementsClosure_includeFragmentsProvidingPackages() throws Exception {
+
+		setTargetPlatform( //
+				bundle("bundle.a", "1.0.0", //
+						entry(EXPORT_PACKAGE, "pack.a" + version("1.0.0"))),
+				bundle("fragment.a", "1.0.0", //
+						entry(FRAGMENT_HOST, "bundle.a"), //
+						entry(EXPORT_PACKAGE, "pack.a,pack.a.frag")),
+
+				// host that imports package from a fragment
+				bundle("bundle.b", "1.0.0", //
+						entry(EXPORT_PACKAGE, "pack.b"), //
+						entry(IMPORT_PACKAGE, "pack.b.frag")),
+				bundle("fragment.b", "1.0.0", //
+						entry(FRAGMENT_HOST, "bundle.b"), //
+						entry(EXPORT_PACKAGE, "pack.b,pack.b.frag")),
+
+				bundle("bundle.z", "1.0.0", //
+						entry(IMPORT_PACKAGE, "pack.a")),
+				bundle("bundle.y", "1.0.0", //
+						entry(IMPORT_PACKAGE, "pack.a.frag")),
+				bundle("bundle.x", "1.0.0", //
+						entry(IMPORT_PACKAGE, "pack.b")),
+				bundle("bundle.w", "1.0.0", //
+						entry(IMPORT_PACKAGE, "pack.b.frag")));
+
+		BundleDescription bundleA = bundleDescription("bundle.a", "1.0.0");
+		BundleDescription fragmentA = bundleDescription("fragment.a", "1.0.0");
+		BundleDescription bundleB = bundleDescription("bundle.b", "1.0.0");
+		BundleDescription fragmentB = bundleDescription("fragment.b", "1.0.0");
+
+		BundleDescription bundleZ = bundleDescription("bundle.z", "1.0.0");
+		BundleDescription bundleY = bundleDescription("bundle.y", "1.0.0");
+		BundleDescription bundleX = bundleDescription("bundle.x", "1.0.0");
+		BundleDescription bundleW = bundleDescription("bundle.w", "1.0.0");
+
+		Set<BundleDescription> zClosure = findRequirementsClosure(Set.of(bundleZ));
+		assertThat(zClosure).isEqualTo(Set.of(bundleZ, bundleA));
+
+		Set<BundleDescription> yClosure = findRequirementsClosure(Set.of(bundleY));
+		assertThat(yClosure).isEqualTo(Set.of(bundleY, bundleA, fragmentA));
+
+		Set<BundleDescription> xClosure = findRequirementsClosure(Set.of(bundleX));
+		assertThat(xClosure).isEqualTo(Set.of(bundleX, bundleB, fragmentB));
+
+		Set<BundleDescription> wClosure = findRequirementsClosure(Set.of(bundleW));
+		assertThat(wClosure).isEqualTo(Set.of(bundleW, bundleB, fragmentB));
+	}
+
+	@Test
 	public void testFindRequirementsClosure_includeOptional() throws Exception {
 
 		setTargetPlatform( //


### PR DESCRIPTION
In rare cases fragments provide new packages to their host wiring.
In such case those fragments have to be included into the requirements closure, otherwise the resolution of the final set of bundles will fail.

One real world example from Eclipse is `o.e.egit.core`.
This bundle imports the package `o.e.jgit.gpg.bc` that is provided by the fragment with the same name. Its host is `o.e.jgit`, which does not export such package.
If one creates a product or launch config that includes (or requires) `o.e.egit.core` but not `o.e.jgit.gpg.bc` and enables automatic inclusion of requirements the pre-launch validation fails because for `o.e.egit.core` the package-import `o.e.jgit.gpg.bc` is not satisfied.

When a corresponding product is build with Tycho, the fragment that is the only provider/exporter of a required package is included automatically as well.

Adding the capability's revision of a required wire to the closure instead of the provider wiring's revision fixes the issue descried above because it adds the 'real' resource wired to the requirement (which is preferred the host, but if not otherwise possible a fragment). A wiring's revision is always the host-bundle.