### PR TITLE
New feature to run JUnit5 failures needs RemotePluginTestRunner change

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime.tests/src/org/eclipse/pde/junit/runtime/tests/JUnit5SuiteExecutionTest.java
+++ b/ui/org.eclipse.pde.junit.runtime.tests/src/org/eclipse/pde/junit/runtime/tests/JUnit5SuiteExecutionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2021 Julian Honnen
+ *  Copyright (c) 2021, 2022 Julian Honnen
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,8 @@ public class JUnit5SuiteExecutionTest {
 	@BeforeClass
 	public static void setupProjects() throws Exception {
 		Assert.assertNotNull("org.junit.platform.suite.engine bundle missing", Platform.getBundle("org.junit.platform.suite.engine"));
-		
+		Assert.assertNotNull("org.eclipse.jdt.junit5.runtime bundle missing", Platform.getBundle("org.eclipse.jdt.junit5.runtime"));
+			
 		JUnitExecutionTest.setupProjects();
 		input = new TestInput("JUnit5 Suite", "verification.tests.junit5.suite");
 	}

--- a/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/RemotePluginTestRunner.java
+++ b/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/RemotePluginTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2003, 2018 IBM Corporation and others.
+ *  Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -82,8 +82,13 @@ public class RemotePluginTestRunner extends RemoteTestRunner {
 		if (testBundle == null) {
 			throw new IllegalArgumentException("Bundle \"" + testPluginName + "\" not found. Possible causes include missing dependencies, too restrictive version ranges, or a non-matching required execution environment."); //$NON-NLS-1$ //$NON-NLS-2$
 		}
+		Bundle junit5RuntimeBundle = Platform.getBundle("org.eclipse.jdt.junit5.runtime"); //$NON-NLS-1$
+		if (junit5RuntimeBundle == null) {
+			throw new IllegalArgumentException("Bundle \"" + junit5RuntimeBundle + "\" not found."); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		List<Bundle> platformEngineBundles = findTestEngineBundles();
 		platformEngineBundles.add(testBundle);
+		platformEngineBundles.add(junit5RuntimeBundle);
 		return new MultiBundleClassLoader(platformEngineBundles);
 	}
 


### PR DESCRIPTION
- add org.eclipse.jdt.junit5.runtime bundle to JUnit5 bundles so that
  the MethodOrderer class for running JUnit5 failures first can be
  accessed by the platform engine
- modify JUnit5SuiteExecutionTest to assert that the bundle is added
- fixes #117