### PR TITLE
Fix NPE -New 4.24 JDT feature to run JUnit5 failures first requires

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/RemotePluginTestRunner.java
+++ b/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/RemotePluginTestRunner.java
@@ -83,12 +83,10 @@ public class RemotePluginTestRunner extends RemoteTestRunner {
 			throw new IllegalArgumentException("Bundle \"" + testPluginName + "\" not found. Possible causes include missing dependencies, too restrictive version ranges, or a non-matching required execution environment."); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		Bundle junit5RuntimeBundle = Platform.getBundle("org.eclipse.jdt.junit5.runtime"); //$NON-NLS-1$
-		if (junit5RuntimeBundle == null) {
-			throw new IllegalArgumentException("Bundle \"" + junit5RuntimeBundle + "\" not found."); //$NON-NLS-1$ //$NON-NLS-2$
-		}
 		List<Bundle> platformEngineBundles = findTestEngineBundles();
 		platformEngineBundles.add(testBundle);
-		platformEngineBundles.add(junit5RuntimeBundle);
+		if (junit5RuntimeBundle != null)
+			platformEngineBundles.add(junit5RuntimeBundle);
 		return new MultiBundleClassLoader(platformEngineBundles);
 	}
 


### PR DESCRIPTION
change to RemotePluginTestRunner

Change-Id: I596221951aec54cff3690e5084077b2e817c5cce
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>