### PR TITLE
Exceptions thrown by IUBundleContainer.cacheIUs are lost

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
@@ -402,6 +402,10 @@ public class TargetDefinition implements ITargetDefinition {
 						try {
 							synchronizer.synchronize(this,
 									subMonitor.split(synchronizerNumContainerMap.get(synchronizer).intValue() * 95));
+							IStatus containerStatus = container.getStatus();
+							if (containerStatus != null && !containerStatus.isOK()) {
+								status.add(containerStatus);
+							}
 						} catch (CoreException e) {
 							PDECore.log(e.getStatus());
 							status.add(e.getStatus());


### PR DESCRIPTION
These exceptions are recorded by IUBundleContainer.synchronizerChanged
but TargetDefinition.resolve(IProgressMonitor) only notices exceptions
that are thrown and does not consider the status that recorded in the
IContainerLocation.

No logging is needed because the exception was already logged when it
was recorded.

https://github.com/eclipse-pde/eclipse.pde/issues/126