### PR TITLE
The Reload button in the target platform Edit... wizard is a no-op

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/target/TargetDefinitionContentPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/target/TargetDefinitionContentPage.java
@@ -228,6 +228,7 @@ public class TargetDefinitionContentPage extends TargetDefinitionPage {
 		};
 		fContentTree.addTargetChangedListener(listener);
 		fLocationTree.addTargetChangedListener(listener);
+		fLocationTree.addTargetReloadListener(listener);
 	}
 
 	@Override


### PR DESCRIPTION
TargetDefinitionContentPage.initializeListeners() should also listen to reloads.

https://github.com/eclipse-pde/eclipse.pde/issues/128