### PR TITLE
Handle missing plug-ins in source-lookup and use List instead of arrays

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/pom.xml
+++ b/ui/org.eclipse.pde.core/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.core</artifactId>
-  <version>3.15.200-SNAPSHOT</version>
+  <version>3.15.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/sourcelookup/PDESourceLookupQuery.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/sourcelookup/PDESourceLookupQuery.java
@@ -16,6 +16,8 @@ package org.eclipse.pde.internal.launching.sourcelookup;
 
 import com.sun.jdi.VMDisconnectedException;
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.debug.core.DebugException;
@@ -304,11 +306,11 @@ public class PDESourceLookupQuery implements ISafeRunnable {
 	}
 
 	private Object findJreSourceElement(String sourcePath) throws CoreException {
-		ISourceContainer[] jreSourceContainers = fDirector.getJreSourceContainers();
+		List<ISourceContainer> jreSourceContainers = Arrays.asList(fDirector.getJreSourceContainers());
 		return findSourceElement(jreSourceContainers, sourcePath);
 	}
 
-	private Object findSourceElement(ISourceContainer[] containers, String typeName) throws CoreException {
+	private Object findSourceElement(List<ISourceContainer> containers, String typeName) throws CoreException {
 		for (ISourceContainer container : containers) {
 			Object[] result = container.findSourceElements(typeName);
 			if (result.length > 0)
@@ -317,7 +319,7 @@ public class PDESourceLookupQuery implements ISafeRunnable {
 		return null;
 	}
 
-	protected ISourceContainer[] getSourceContainers(String location, String id) throws CoreException {
+	protected List<ISourceContainer> getSourceContainers(String location, String id) throws CoreException {
 		return fDirector.getSourceContainers(location, id);
 	}
 

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PDE JUnit Tests
 Bundle-SymbolicName: org.eclipse.pde.ui.tests; singleton:=true
-Bundle-Version: 3.11.800.qualifier
+Bundle-Version: 3.11.900.qualifier
 Bundle-ClassPath: tests.jar
 Bundle-Activator: org.eclipse.pde.ui.tests.PDETestsPlugin
 Bundle-Vendor: Eclipse.org

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.tests</artifactId>
-  <version>3.11.800-SNAPSHOT</version>
+  <version>3.11.900-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathresolver/ClasspathResolverTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathresolver/ClasspathResolverTest.java
@@ -104,7 +104,7 @@ public class ClasspathResolverTest {
 		}
 
 		@Override // Make super.getSourceContainers() visible
-		public ISourceContainer[] getSourceContainers(String location, String id) throws CoreException {
+		public List<ISourceContainer> getSourceContainers(String location, String id) throws CoreException {
 			return super.getSourceContainers(location, id);
 		}
 	}
@@ -137,12 +137,12 @@ public class ClasspathResolverTest {
 		PDESourceLookupDirector d = new PDESourceLookupDirector();
 		_PDESourceLookupQuery q = new _PDESourceLookupQuery(d, project);
 
-		ISourceContainer[] containers = q.getSourceContainers(project.getLocation().toOSString(), bundleName);
+		List<ISourceContainer> containers = q.getSourceContainers(project.getLocation().toOSString(), bundleName);
 
-		assertEquals(2, containers.length);
-		assertEquals(JavaCore.create(project), ((JavaProjectSourceContainer) containers[0]).getJavaProject());
+		assertEquals(2, containers.size());
+		assertEquals(JavaCore.create(project), ((JavaProjectSourceContainer) containers.get(0)).getJavaProject());
 		assertEquals(project.getFolder("cpe").getLocation().toFile(),
-				((DirectorySourceContainer) containers[1]).getDirectory());
+				((DirectorySourceContainer) containers.get(1)).getDirectory());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/133

Since the problem likely exists for a while I suggest to consider this for the next release.