### PR TITLE
Version bumps for 4.25 stream

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.2.900.qualifier
+Bundle-Version: 1.2.1000.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools/pom.xml
@@ -17,7 +17,7 @@
     <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.pde.api.tools</artifactId>
-  <version>1.2.900-SNAPSHOT</version>
+  <version>1.2.1000-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.10.0.qualifier
+Bundle-Version: 3.10.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",


### PR DESCRIPTION
Fixes comparator issues due to lambda order jdt bug.
Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/313