### PR TITLE
Stop promoting update site creation via the feature editor

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.13.500.qualifier
+Bundle-Version: 3.13.600.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -873,9 +873,6 @@ public class PDEUIMessages extends NLS {
 	public static String FeatureEditor_InfoPage_PackagingSection_title;
 	public static String FeatureEditor_InfoPage_PackagingSection_text;
 
-	public static String FeatureEditor_InfoPage_PublishingSection_title;
-	public static String FeatureEditor_InfoPage_PublishingSection_text;
-
 	public static String FeatureOptionsTab_0;
 
 	public static String FeatureOutlinePage_discoverUrls;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureFormPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureFormPage.java
@@ -80,7 +80,6 @@ public class FeatureFormPage extends PDEFormPage implements IHyperlinkListener {
 
 		createContentSection(managedForm, right, toolkit);
 		createPackagingSection(managedForm, right, toolkit);
-		createPublishingSection(managedForm, right, toolkit);
 
 		managedForm.addPart(fSpecSection);
 		managedForm.addPart(fPortabilitySection);
@@ -124,23 +123,6 @@ public class FeatureFormPage extends PDEFormPage implements IHyperlinkListener {
 		return section;
 	}
 
-	private Section createPublishingSection(IManagedForm managedForm, Composite parent, FormToolkit toolkit) {
-		Section section = createStaticSection(parent, toolkit);
-		section.setText(PDEUIMessages.FeatureEditor_InfoPage_PublishingSection_title);
-		// ImageHyperlink info = new ImageHyperlink(section, SWT.NULL);
-		// toolkit.adapt(info, true, true);
-		// Image image =
-		// PDEPlugin.getDefault().getLabelProvider().get(PDEPluginImages.DESC_HELP);
-		// info.setImage(image);
-		// info.addHyperlinkListener(new HyperlinkAdapter() {
-		// public void linkActivated(HyperlinkEvent e) {
-		// }
-		// });
-		// info.setBackground(section.getTitleBarGradientBackground());
-		// section.setTextClient(info);
-		createClient(section, PDEUIMessages.FeatureEditor_InfoPage_PublishingSection_text, toolkit);
-		return section;
-	}
 
 	private FormText createClient(Section section, String content, FormToolkit toolkit) {
 		FormText text = toolkit.createFormText(section, true);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -279,13 +279,6 @@ FeatureEditor_InfoPage_PackagingSection_text=<form>\
 <li style="text" value="3." bindent="5">Export the feature in a format suitable for deployment using the <a href="export">Export Wizard</a></li>\
 </form>
 
-FeatureEditor_InfoPage_PublishingSection_title = Publishing
-FeatureEditor_InfoPage_PublishingSection_text=<form>\
-<p>To publish the feature on an update site:</p>\
-<li style="text" value="1." bindent="5">Create an <a href="siteProject">Update Site Project</a></li>\
-<li style="text" value="2." bindent="5">Use the site editor to add the feature to the site, and build the site</li>\
-</form>
-
 FeatureOptionsTab_0=Not a category definition file
 FeatureOutlinePage_discoverUrls = Sites to Visit
 


### PR DESCRIPTION
Publishing a feature can be done via multiple means, for command line
publishing Tycho is frequently used and the latest Tycho version stopped
supporting update sites. Therefore, remove the "advertisement" of using
update sites from the feature editor, an editor should not promote an
publishing alternative which is not supported anymore by the most
popular build tool.