### PR TITLE
Update of Contribution guide

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -19,16 +19,16 @@ more.
 
 The project maintains the following source code repositories
 
-* http://git.eclipse.org/c/pde/eclipse.pde.ui.git
-* http://git.eclipse.org/c/pde/eclipse.pde.build.git
+* https://github.com/eclipse-pde/eclipse.pde/
 
-This project uses Bugzilla to track ongoing development and issues.
+This project uses Github issues and pull requests to track ongoing development and issues.
 
-* Search for issues: https://eclipse.org/bugs/buglist.cgi?product=PDE
-* Create a new report: https://eclipse.org/bugs/enter_bug.cgi?product=PDE
+* Issues: https://github.com/eclipse-pde/eclipse.pde/issues
+* Pull requests: https://github.com/eclipse-pde/eclipse.pde/pulls
 
-Be sure to search for existing bugs before you create another one. Remember that
-contributions are always welcome!
+Pull requests are always welcome!
+See also https://github.com/eclipse-platform/#community
+
 
 ## Eclipse Contributor Agreement
 
@@ -48,6 +48,6 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Contact
 
-Contact the project developers via the project's "dev" list.
+Contact the project developers via Github discussions
 
-* https://dev.eclipse.org/mailman/listinfo/pde-dev
+* https://github.com/eclipse-pde/eclipse.pde/discussions

--- a/README.md
+++ b/README.md
@@ -40,26 +40,15 @@ You need Maven 3.3.1 installed. After this you can run the build via the followi
 mvn clean verify -Pbuild-individual-bundles
 
 
-Search for bugs:
+See https://github.com/eclipse-pde/eclipse.pde/blob/master/CONTRIBUTING if you want to report and issue, request or contribute a bug fix orfeature 
 ----------------
-
-This project uses Bugzilla to track ongoing development and issues.
-
-- <https://bugs.eclipse.org/bugs/buglist.cgi?bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&product=PDE&query_format=advanced>
-
-Create a new bug:
------------------
-
-Be sure to search for existing bugs before you create another one. Remember that contributions are always welcome!
-
-- <https://bugs.eclipse.org/bugs/enter_bug.cgi?product=PDE;component=UI>
 
 Contact:
 --------
 
-Contact the project developers via the project's "dev" list.
+Contact the project developers via Github discussions
 
-- <https://dev.eclipse.org/mailman/listinfo/pde-dev>
+- https://github.com/eclipse-pde/eclipse.pde/discussions
 
 License
 -------


### PR DESCRIPTION
https://wiki.eclipse.org/PDE/Contributor_Guide has been updated to point
to https://github.com/eclipse-pde/eclipse.pde/blob/master/CONTRIBUTING

Fixes #12