### PR TITLE
Fix E4 template to include osgi jars

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.pde.ui.templates;singleton:=true
-Bundle-Version: 3.7.600.qualifier
+Bundle-Version: 3.7.700.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.pde.internal.ui.templates;x-internal:=true,

--- a/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
@@ -79,7 +79,16 @@
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
       <plugin id="org.eclipse.osgi.services"/>
+      <plugin id="org.osgi.service.cm" />
+      <plugin id="org.osgi.service.component" />
+      <plugin id="org.osgi.service.device" />
+      <plugin id="org.osgi.service.event" />
+      <plugin id="org.osgi.service.metatype" />
       <plugin id="org.osgi.service.prefs" />
+      <plugin id="org.osgi.service.provisioning" />
+      <plugin id="org.osgi.service.upnp" />
+      <plugin id="org.osgi.service.useradmin" />
+      <plugin id="org.osgi.service.wireadmin" />
       <plugin id="org.osgi.util.function"/>
       <plugin id="org.osgi.util.promise"/>
       <plugin id="org.eclipse.swt"/>


### PR DESCRIPTION
They were embedded in equinox bundles but not anymore.
Fixes:
```
java.lang.AssertionError:
Generated product fails validation:
[Missing Constraint: Import-Package: org.osgi.service.event;
version="1.3.0", Missing Constraint: Require-Bundle:
org.osgi.service.metatype; bundle-version="[1.4.0,1.5.0)", Missing
Constraint: Require-Bundle: org.osgi.service.upnp;
bundle-version="[1.2.0,1.3.0)", Missing Constraint: Require-Bundle:
org.osgi.service.wireadmin; bundle-version="[1.0.0,1.1.0)", Missing
Constraint: Import-Package: org.osgi.service.event;
version="[1.3.0,1.5.0)", Missing Constraint: Import-Package:
org.osgi.service.component.runtime; version="[1.5.0,1.6.0)", Missing
Constraint: Require-Bundle: org.osgi.service.cm;
bundle-version="[1.6.0,1.7.0)", Missing Constraint: Require-Bundle:
org.osgi.service.component; bundle-version="[1.5.0,1.6.0)", Missing
Constraint: Require-Bundle: org.osgi.service.useradmin;
bundle-version="[1.1.0,1.2.0)", Missing Constraint: Require-Bundle:
org.osgi.service.device; bundle-version="[1.1.0,1.2.0)", Missing
Constraint: Import-Package: org.osgi.service.component;
version="[1.5.0,1.6.0)", Missing Constraint: Import-Package:
org.osgi.service.component.runtime.dto; version="[1.5.0,2.0.0)", Missing
Constraint: Require-Bundle: org.osgi.service.provisioning;
bundle-version="[1.2.0,1.3.0)", Missing Constraint: Require-Bundle:
org.osgi.service.event; bundle-version="[1.4.0,1.5.0)"]
	at org.eclipse.pde.ui.templates.tests.TestPDETemplates.validateProduct(TestPDETemplates.java:193)
```
in latest builds/tests.