### PR TITLE
Sort product editor outline view (fixes #172)

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductOutlinePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductOutlinePage.java
@@ -24,10 +24,6 @@ public class ProductOutlinePage extends FormOutlinePage {
 	}
 
 	@Override
-	public void sort(boolean sorting) {
-	}
-
-	@Override
 	protected Object[] getChildren(Object parent) {
 		if (parent instanceof DependenciesPage) {
 			DependenciesPage page = (DependenciesPage) parent;


### PR DESCRIPTION
The product editor outline has been unsorted since the very first commit
by overriding the sort() method as empty code. By removing the empty
override everything works well again, because the super class uses the
viewer comparator, and that uses the label provider.