### PR TITLE
Exclude unresolved fragments when launching with all active plug-ins

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -82,9 +82,10 @@ public class BundleLauncherHelper {
 
 			if (wc.getAttribute(IPDELauncherConstants.USE_DEFAULT, true)) {
 				Map<IPluginModelBase, String> map = new LinkedHashMap<>();
-				IPluginModelBase[] models = PluginRegistry.getActiveModels();
-				for (IPluginModelBase model : models) {
-					addBundleToMap(map, model, DEFAULT_START_LEVELS);
+				for (IPluginModelBase model : PluginRegistry.getActiveModels()) {
+					if (!isFragmentForOtherPlatform(model)) { // Filter out platform-specific fragments that cannot resolve
+						addBundleToMap(map, model, DEFAULT_START_LEVELS);
+					}
 				}
 				return map;
 			}
@@ -103,6 +104,10 @@ public class BundleLauncherHelper {
 			addRequiredBundles(selectedBundles, configuration);
 		}
 		return selectedBundles;
+	}
+
+	private static boolean isFragmentForOtherPlatform(IPluginModelBase model) {
+		return model.isFragmentModel() && !model.getBundleDescription().isResolved() && !TargetPlatformHelper.matchesCurrentEnvironment(model);
 	}
 
 	public static Map<IPluginModelBase, String> getAllSelectedPluginBundles(ILaunchConfiguration config) throws CoreException {


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/68

For example JUnit Plug-in tests that usually include all available bundles (Plug-ins and Fragments) when being launched often suffer from messages about unresolved bundles due to unsatisfied environment constraints (e.g. when having platform specific fragments for multiple different platforms there are always some unsatisfied on the current platform).

Only exclude fragments because sometimes unresolved bundles (non-fragments) are wanted in the launched application.

I verified that unresolved fragments (may it be due to wrong environment or missing dependencies) are excluded, but I was not yet able to reproduce the failed resolution messages from the launched application in my minimal reproducer, although I have seen them before.