### PR TITLE
If a file or directory doesnt exist while adding a target, make it an

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditDirectoryContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditDirectoryContainerPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * Copyright (c) 2009, 2012 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -319,7 +319,7 @@ public class EditDirectoryContainerPage extends WizardPage implements IEditBundl
 
 		// Check if directory exists
 		if (!location.isDirectory()) {
-			setMessage(Messages.AddDirectoryContainerPage_6, IMessageProvider.WARNING);
+			setMessage(Messages.AddDirectoryContainerPage_6, IMessageProvider.ERROR);
 		} else {
 			setMessage(getDefaultMessage());
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditTargetContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditTargetContainerPage.java
@@ -313,7 +313,7 @@ public class EditTargetContainerPage extends WizardPage implements IEditBundleCo
 				File file = new File(location);
 				if (!file.isFile()) {
 					setMessage(NLS.bind(Messages.EditTargetContainerPage_Not_A_File, file.getAbsolutePath()),
-							IMessageProvider.WARNING);
+							IMessageProvider.ERROR);
 					return true;
 				}
 			}


### PR DESCRIPTION
If a file or directory doesnt exist while adding a target, make it an error (fixes #187)

Change-Id: I06216a81a29930086e2941f1cc73e940bb6c3f25
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>