### PR TITLE
Unnecessary local variable assignment removed in api.tools

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractProblemDetector.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractProblemDetector.java
@@ -672,8 +672,7 @@ public abstract class AbstractProblemDetector implements IApiProblemDetector {
 	 * @throws JavaModelException
 	 */
 	protected IField findFieldInType(IType type, IApiField field) throws JavaModelException {
-		IField match = null;
-		match = type.getField(field.getName());
+		IField match = type.getField(field.getName());
 		if (!match.exists()) {
 			IField[] fields = type.getFields();
 			// optimistically try to find the first match

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
@@ -575,8 +575,7 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 		}
 		Map<IApiComponent, IApiComponent[]> componentsForPackage = fComponentsProvidingPackageCache
 				.computeIfAbsent(packageName, x -> new ConcurrentHashMap<>(8));
-		IApiComponent[] cachedComponents = null;
-		cachedComponents = componentsForPackage.get(sourceComponent);
+		IApiComponent[] cachedComponents = componentsForPackage.get(sourceComponent);
 		if (cachedComponents != null && cachedComponents.length > 0) {
 			return cachedComponents;
 		}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/comparator/ApiComparator.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/comparator/ApiComparator.java
@@ -675,7 +675,6 @@ public class ApiComparator {
 								} else {
 									typeRoot2 = component2.findTypeRoot(typeName, id);
 								}
-								String deltaComponentID = null;
 								IApiComponent provider = null;
 								IApiDescription providerApiDesc = null;
 								boolean reexported = false;
@@ -715,7 +714,7 @@ public class ApiComparator {
 									providerApiDesc = apiDescription2;
 								}
 								visitMonitor.setWorkRemaining(1).split(1);
-								deltaComponentID = Util.getDeltaComponentVersionsId(component2);
+								String deltaComponentID = Util.getDeltaComponentVersionsId(component2);
 								if (typeRoot2 == null) {
 									if ((visibility & visibilityModifiers) == 0) {
 										// we skip the class file according to

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseScanReferenceVisitor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseScanReferenceVisitor.java
@@ -58,8 +58,6 @@ public class UseScanReferenceVisitor extends UseScanVisitor {
 	// Visit only for the specific types, if supplied.
 	@Override
 	public boolean visitMember(IMemberDescriptor referencedMember) {
-		boolean found = false;
-
 		String referencedMemberRootType;
 		if (referencedMember instanceof IReferenceTypeDescriptor) {
 			referencedMemberRootType = ((IReferenceTypeDescriptor) referencedMember).getQualifiedName();
@@ -69,7 +67,7 @@ public class UseScanReferenceVisitor extends UseScanVisitor {
 		if (referencedMemberRootType.indexOf('$') > -1) {
 			referencedMemberRootType = referencedMemberRootType.substring(0, referencedMemberRootType.indexOf('$'));
 		}
-		found = fLookupMemberTypes == null || fLookupMemberTypes.contains(referencedMemberRootType);
+		boolean found = fLookupMemberTypes == null || fLookupMemberTypes.contains(referencedMemberRootType);
 		fCurrentReferencedMemberRootType = referencedMemberRootType;
 		fCurrentReferencedMember = referencedMember;
 

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/XmlReferenceDescriptorWriter.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/XmlReferenceDescriptorWriter.java
@@ -468,9 +468,8 @@ public class XmlReferenceDescriptorWriter {
 	 * @param reference
 	 */
 	private void writeReference(Document document, Element parent, IReferenceDescriptor reference) throws CoreException {
-		Element kelement = null;
 		Integer kind = Integer.valueOf(reference.getReferenceKind());
-		kelement = findKindElement(parent, kind);
+		Element kelement = findKindElement(parent, kind);
 		if (kelement == null) {
 			kelement = document.createElement(IApiXmlConstants.REFERENCE_KIND);
 			kelement.setAttribute(IApiXmlConstants.ATTR_REFERENCE_KIND_NAME, Reference.getReferenceText(kind.intValue()));


### PR DESCRIPTION
Using JDT cleanup, the unnecessary assignments were removed to have
shorter code.