### PR TITLE
Fix copyright year wrongly introduced in last commit

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditDirectoryContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditDirectoryContainerPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2012 IBM Corporation and others.
+ * Copyright (c) 2009, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
Fix copyright year

Change-Id: I2448d4ce143ae171901f5d6cf252f4c554798c0d
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>