### PR TITLE
Add support for the OSGi Bundle and Versioning Annotations

### DIFF
--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -394,4 +394,10 @@
              type="Target">
        </targetLocation>
     </extension>
+    <extension
+          point="org.eclipse.pde.core.pluginClasspathContributors">
+       <contributor
+             class="org.eclipse.pde.internal.core.OSGiAnnotationsClasspathContributor">
+       </contributor>
+    </extension>
 </plugin>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/OSGiAnnotationsClasspathContributor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IAccessRule;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.pde.core.IClasspathContributor;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+
+/**
+ * This makes the <a href=
+ * "https://docs.osgi.org/specification/osgi.core/7.0.0/framework.api.html#org.osgi.annotation.bundle">OSGi
+ * Bundle Annotations</a> and <a href=
+ * "https://docs.osgi.org/specification/osgi.core/7.0.0/framework.api.html#org.osgi.annotation.versioning">OSGi
+ * Versioning Annotations</a> available to plugin projects if they are part of
+ * the target platform.
+ *
+ */
+public class OSGiAnnotationsClasspathContributor implements IClasspathContributor {
+
+	private Collection<String> OSGI_ANNOTATIONS = List.of("org.osgi.annotation.versioning", //$NON-NLS-1$
+			"org.osgi.annotation.bundle"); //$NON-NLS-1$
+
+	@Override
+	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
+		IPluginModelBase model = PluginRegistry.findModel(project);
+		if (model != null) {
+			return OSGI_ANNOTATIONS.stream().map(PluginRegistry::findModel).filter(Objects::nonNull)
+					.filter(IPluginModelBase::isEnabled).map(IPluginModelBase::getInstallLocation)
+					.filter(Objects::nonNull).map(Path::new).map(path -> JavaCore.newLibraryEntry(path, path, Path.ROOT,
+							new IAccessRule[0], new IClasspathAttribute[0], false))
+					.collect(Collectors.toList());
+		}
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<IClasspathEntry> getEntriesForDependency(BundleDescription project, BundleDescription addedDependency) {
+		return Collections.emptyList();
+	}
+
+}


### PR DESCRIPTION
OSGi has support for annotations that are only retained at the class
file (but not on the runtime) to help tools generating meta-data or
perform several checks.

This adding them to the compile-classpath without requiring the bundle
developer to import them (what would create an undesired runtime binding
to those packages) if they are found in the target platform.

This is part of https://github.com/eclipse-pde/eclipse.pde/issues/69

### To test this I did the following, because even though the annotations are part of the SDK target they are not available in the SDK-IDE Target platform state:

1. Start an Eclipse with this patch
2. download https://mvnrepository.com/artifact/org.osgi/org.osgi.annotation.versioning/1.1.2 and https://mvnrepository.com/artifact/org.osgi/org.osgi.annotation.bundle/2.0.0
3. create a simple project named "target", create a folder lib, put both files in and add the following target
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<?pde version="3.8"?>
<target name="annotations">
	<locations>
		<location path="${eclipse_home}" type="Profile"/>
		<location path="${project_loc:/targets}/lib" type="Directory"/>
	</locations>
</target>
```