### PR TITLE
Enforce a deterministic Manifest-Header order when inserting new keys

### DIFF
--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/AbstractEditingModel.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/AbstractEditingModel.java
@@ -46,7 +46,7 @@ public abstract class AbstractEditingModel extends PlatformObject implements IEd
 	private Charset fCharset;
 	private IResource fUnderlyingResource;
 	private String fInstallLocation;
-	private boolean fStale;
+	private volatile boolean fStale;
 
 	public AbstractEditingModel(IDocument document, boolean isReconciling) {
 		fDocument = document;

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/BundleModel.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/BundleModel.java
@@ -61,7 +61,7 @@ public class BundleModel extends AbstractEditingModel implements IBundleModel {
 	}
 
 	@Override
-	public void adjustOffsets(IDocument document) {
+	public synchronized void adjustOffsets(IDocument document) {
 		((Bundle) getBundle()).clearOffsets();
 		((Bundle) getBundle()).adjustOffsets(document);
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/context/InputContext.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/context/InputContext.java
@@ -230,6 +230,10 @@ public abstract class InputContext {
 				if (fModel instanceof IEditingModel)
 					((IEditingModel) fModel).setStale(true);
 				edit.apply(doc);
+				if (fModel instanceof IEditingModel) {
+					IEditingModel editingModel = (IEditingModel) fModel;
+					editingModel.reconciled(doc);
+				}
 				fEditOperations.clear();
 			} catch (MalformedTreeException | BadLocationException e) {
 				PDEPlugin.logException(e);


### PR DESCRIPTION
Currently, when adding a manifest header the new value is always placed
at the bottom. This has the disadvantage, that the order of manifest
headers is determined by the order of inserts.

Especially if headers are added/removed (e.g. DS) automatically this can
lead to modified manifest that are semantically equivalent.

To prevent this, but still keep user-order of manifest headers, the
following algorithm is applied to have always the same insertion place:

1) All headers of the manifest are fetched
2) Special headers, that need to be retained at the top are ignored
3) All remaining headers are sorted ignoring their case
4) The header that is before the header to insert in this alphabetical
list is chosen as the insertion point
5) if the is no predecessor, the Bundle-ManifestVersion header is chosen
6) if nothing matches the header is inserted at the end

This ensures that (given this algorithm was applied at least once) there
is always a deterministic insertion point even in the case where a
header is removed and later added back.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/74