### PR TITLE
Add support for dynamically contribute bundle source locations

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.16.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -394,4 +394,9 @@
              type="Target">
        </targetLocation>
     </extension>
+    <extension
+          point="org.eclipse.pde.core.source">
+          <locator class="org.eclipse.pde.internal.core.ColocationPluginSourcePathLocator" />
+          <locator class="org.eclipse.pde.internal.core.LocalMavenPluginSourcePathLocator" />
+    </extension>
 </plugin>

--- a/ui/org.eclipse.pde.core/pom.xml
+++ b/ui/org.eclipse.pde.core/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.core</artifactId>
-  <version>3.15.300-SNAPSHOT</version>
+  <version>3.16.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/ui/org.eclipse.pde.core/schema/source.exsd
+++ b/ui/org.eclipse.pde.core/schema/source.exsd
@@ -21,9 +21,10 @@ In addition, it should contain any file or directory specified in the build.prop
          </appInfo>
       </annotation>
       <complexType>
-         <sequence>
-            <element ref="location" minOccurs="1" maxOccurs="unbounded"/>
-         </sequence>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="location"/>
+            <element ref="locator"/>
+         </choice>
          <attribute name="point" type="string" use="required">
             <annotation>
                <documentation>
@@ -66,14 +67,20 @@ In addition, it should contain any file or directory specified in the build.prop
       </complexType>
    </element>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         No Java code is required for this extension point.
-      </documentation>
-   </annotation>
+   <element name="locator">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Provides the locator used to find the source-path for the given plugin model
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.pde.core.IPluginSourcePathLocator"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
 
    <annotation>
       <appInfo>
@@ -97,6 +104,15 @@ In addition, it should contain any file or directory specified in the build.prop
 &lt;/pre&gt;
 
 In the example above, the source location &lt;code&gt;src&lt;/code&gt; in the contributing plug-in has been registered.
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiInfo"/>
+      </appInfo>
+      <documentation>
+         No Java code is required for this extension point.
       </documentation>
    </annotation>
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IPluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IPluginSourcePathLocator.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.core;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.pde.core.plugin.IPluginBase;
+
+/**
+ * A plugin source path locator is capable of locating the path of the source
+ * for a given plugin.
+ * <p>
+ * A plugin source path locator is declared as an extension
+ * (<code>org.eclipse.pde.core.source</code>).
+ * </p>
+ *
+ * @since 3.16
+ */
+public interface IPluginSourcePathLocator {
+
+	IPath locateSource(IPluginBase plugin);
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -192,25 +192,6 @@ public class ClasspathUtilCore {
 			SourceLocationManager manager = PDECore.getDefault().getSourceLocationManager();
 			path = manager.findSourcePath(model.getPluginBase(), new Path(zipName));
 		}
-		// search a co-located source bundle
-		if (path == null && isJarShape) {
-			// ...for example in a bundle pool blah-123.jar => blah.source-123.jar...
-			File loc = new File(model.getInstallLocation());
-			File sourceFile = new File(loc.getParentFile(),
-					model.getPluginBase().getId() + ".source_" + model.getPluginBase().getVersion() + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
-			if (sourceFile.isFile()) {
-				path = new Path(sourceFile.getAbsolutePath());
-			} else if (model.getInstallLocation() != null) {
-				// ... or in usual Maven covention blah-123.jar =>
-				// blah-123-sources.jar
-				String bundleFileName = loc.getName();
-				String sourceFileName = bundleFileName.substring(0, bundleFileName.indexOf(".jar")) + "-sources.jar"; //$NON-NLS-1$ //$NON-NLS-2$
-				sourceFile = new File(loc.getParentFile(), sourceFileName);
-				if (sourceFile.isFile()) {
-					path = new Path(sourceFile.getAbsolutePath());
-				}
-			}
-		}
 		return path;
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/EclipsePluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/EclipsePluginSourcePathLocator.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.io.File;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.pde.core.IPluginSourcePathLocator;
+import org.eclipse.pde.core.plugin.IPluginBase;
+import org.eclipse.pde.core.plugin.ISharedPluginModel;
+
+/**
+ * A plugin source path locator that uses for a co-located source bundle in the
+ * same directory. This could be e.g the case for bundle pools or products with
+ * a plugin folder.
+ */
+public class EclipsePluginSourcePathLocator implements IPluginSourcePathLocator {
+
+	@Override
+	public IPath locateSource(IPluginBase plugin) {
+		ISharedPluginModel model = plugin.getModel();
+		String installLocation = model.getInstallLocation();
+		if (installLocation != null) {
+			File path = new File(installLocation);
+			if (path.isFile()) {
+				File sourceFile = new File(path.getParentFile(),
+						plugin.getId() + ".source_" + plugin.getVersion() + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
+				if (sourceFile.isFile()) {
+					return new Path(sourceFile.getAbsolutePath());
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/LocalMavenPluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/LocalMavenPluginSourcePathLocator.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - extracted from ClasspathUtilCore
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.io.File;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.pde.core.IPluginSourcePathLocator;
+import org.eclipse.pde.core.plugin.IPluginBase;
+import org.eclipse.pde.core.plugin.ISharedPluginModel;
+
+/**
+ * Check if there is already a local maven source bundle available
+ *
+ */
+public class LocalMavenPluginSourcePathLocator implements IPluginSourcePathLocator {
+
+	@Override
+	public IPath locateSource(IPluginBase plugin) {
+		ISharedPluginModel model = plugin.getModel();
+		String installLocation = model.getInstallLocation();
+		if (installLocation != null) {
+			File path = new File(installLocation);
+			if (path.isFile()) {
+				// The usual Maven covention blah-123.jar =>
+				// blah-123-sources.jar
+				String bundleFileName = path.getName();
+				String sourceFileName = bundleFileName.substring(0, bundleFileName.indexOf(".jar")) + "-sources.jar"; //$NON-NLS-1$ //$NON-NLS-2$
+				File sourceFile = new File(path.getParentFile(), sourceFileName);
+				if (sourceFile.isFile()) {
+					return new Path(sourceFile.getAbsolutePath());
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2013 IBM Corporation and others.
+ *  Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - Issue #202
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
@@ -21,16 +22,23 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.runtime.spi.RegistryContributor;
 import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.pde.core.IPluginSourcePathLocator;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.ModelEntry;
@@ -46,7 +54,7 @@ public class SourceLocationManager implements ICoreConstants {
 	/**
 	 * List of source locations that have been discovered using extension points
 	 */
-	private List<SourceLocation> fExtensionLocations = null;
+	private SourceExtensions fExtensionLocations;
 
 	/**
 	 * Manages locations of individual source bundles
@@ -74,7 +82,7 @@ public class SourceLocationManager implements ICoreConstants {
 		if (result == null) {
 			result = searchBundleManifestLocations(pluginBase);
 			if (result == null) {
-				result = searchExtensionLocations(relativePath);
+				result = searchExtensionLocations(relativePath, pluginBase);
 			}
 		}
 		return result;
@@ -108,7 +116,7 @@ public class SourceLocationManager implements ICoreConstants {
 					PDECore.log(e);
 				}
 			}
-			result = searchExtensionLocations(relativePath);
+			result = searchExtensionLocations(relativePath, pluginBase);
 		}
 		if (result != null) {
 			try {
@@ -211,7 +219,11 @@ public class SourceLocationManager implements ICoreConstants {
 	/**
 	 * @return array of source locations that have been added via extension point
 	 */
-	public List<SourceLocation> getExtensionLocations() {
+	public Collection<SourceLocation> getExtensionLocations() {
+		return getExtensions().locations;
+	}
+
+	private SourceExtensions getExtensions() {
 		if (fExtensionLocations == null) {
 			fExtensionLocations = processExtensions();
 		}
@@ -288,21 +300,26 @@ public class SourceLocationManager implements ICoreConstants {
 	}
 
 	/**
-	 * Searches through all known source locations added via extension points, appending
-	 * the relative path and checking if that file exists.
-	 * @param relativePath location of source file within the source location
-	 * @return path to the source file or <code>null</code> if one could not be found or if the file does not exist
+	 * Searches through all known source locations added via extension points,
+	 * appending the relative path and checking if that file exists.
+	 *
+	 * @param relativePath
+	 *            location of source file within the source location
+	 * @param plugin
+	 * @return path to the source file or <code>null</code> if one could not be
+	 *         found or if the file does not exist
 	 */
-	private IPath searchExtensionLocations(IPath relativePath) {
-		List<SourceLocation> extensionLocations = getExtensionLocations();
-		for (SourceLocation location : extensionLocations) {
+	private IPath searchExtensionLocations(IPath relativePath, IPluginBase plugin) {
+		for (SourceLocation location : getExtensionLocations()) {
 			IPath fullPath = location.getPath().append(relativePath);
 			File file = fullPath.toFile();
 			if (file.exists()) {
 				return fullPath;
 			}
 		}
-		return null;
+		return getExtensions().locators.stream().map(locator -> locator.locateSource(plugin)).filter(Objects::nonNull)
+				.findFirst()
+				.orElse(null);
 	}
 
 	/**
@@ -362,9 +379,10 @@ public class SourceLocationManager implements ICoreConstants {
 	/**
 	 * @return array of source locations that were added via extension point
 	 */
-	private static List<SourceLocation> processExtensions() {
-		ArrayList<SourceLocation> result = new ArrayList<>();
-		IExtension[] extensions = PDECore.getDefault().getExtensionsRegistry().findExtensions(PDECore.PLUGIN_ID + ".source", false); //$NON-NLS-1$
+	private static SourceExtensions processExtensions() {
+		SourceExtensions result = new SourceExtensions();
+		PDEExtensionRegistry extensionsRegistry = PDECore.getDefault().getExtensionsRegistry();
+		IExtension[] extensions = extensionsRegistry.findExtensions(PDECore.PLUGIN_ID + ".source", false); //$NON-NLS-1$
 		for (IExtension extension : extensions) {
 			IConfigurationElement[] children = extension.getConfigurationElements();
 			RegistryContributor contributor = (RegistryContributor) extension.getContributor();
@@ -394,9 +412,21 @@ public class SourceLocationManager implements ICoreConstants {
 					if (path.toFile().exists()) {
 						SourceLocation location = new SourceLocation(path);
 						location.setUserDefined(false);
-						if (!result.contains(location)) {
-							result.add(location);
-						}
+						result.locations.add(location);
+					}
+				}
+			}
+		}
+		// For the source locators we need to query the platform registry
+		IExtensionRegistry registry = Platform.getExtensionRegistry();
+		IExtensionPoint point = registry.getExtensionPoint(PDECore.PLUGIN_ID, "source"); //$NON-NLS-1$
+		for (IExtension extension : point.getExtensions()) {
+			for (IConfigurationElement element : extension.getConfigurationElements()) {
+				if (element.getName().equals("locator")) { //$NON-NLS-1$
+					try {
+						result.locators.add((IPluginSourcePathLocator) element.createExecutableExtension("class")); //$NON-NLS-1$
+					} catch (CoreException e) {
+						PDECore.log(e.getStatus());
 					}
 				}
 			}
@@ -415,4 +445,8 @@ public class SourceLocationManager implements ICoreConstants {
 		return manager;
 	}
 
+	private static final class SourceExtensions {
+		Collection<SourceLocation> locations = new LinkedHashSet<>();
+		List<IPluginSourcePathLocator> locators = new ArrayList<>();
+	}
 }

--- a/ui/org.eclipse.pde.ui/.settings/.api_filters
+++ b/ui/org.eclipse.pde.ui/.settings/.api_filters
@@ -3,7 +3,13 @@
     <resource path="META-INF/MANIFEST.MF">
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="923795461">
             <message_arguments>
-                <message_argument value="3.13.600"/>
+                <message_argument value="3.14"/>
+                <message_argument value="3.14"/>
+            </message_arguments>
+        </filter>
+        <filter id="923795461">
+            <message_arguments>
+                <message_argument value="3.14.0"/>
                 <message_argument value="3.13.500"/>
             </message_arguments>
         </filter>
@@ -12,7 +18,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.AbstractPDELaunchConfiguration"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -20,7 +26,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.EclipseApplicationLaunchConfiguration"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -28,7 +34,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.EquinoxLaunchConfiguration"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -36,7 +42,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.EquinoxPluginsTab"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -44,7 +50,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.EquinoxSettingsTab"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -52,7 +58,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.IPDELauncherConstants"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -60,7 +66,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.JUnitLaunchConfigurationDelegate"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -68,7 +74,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.OSGiLaunchConfigurationDelegate"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -76,7 +82,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.OSGiLaunchConfigurationInitializer"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>
@@ -84,7 +90,7 @@
         <filter comment="Removed lasses deprecated for removal to complete removal process for Bug 564563" id="305324134">
             <message_arguments>
                 <message_argument value="org.eclipse.pde.ui.launcher.PDESourcePathProvider"/>
-                <message_argument value="org.eclipse.pde.ui_3.13.600"/>
+                <message_argument value="org.eclipse.pde.ui_3.14"/>
             </message_arguments>
         </filter>
     </resource>

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.14.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
@@ -74,7 +74,7 @@ Export-Package:
  org.eclipse.pde.ui.templates,
  org.eclipse.ui.internal.views.log.jdt;x-internal:=true
 Require-Bundle: 
- org.eclipse.pde.core;bundle-version="[3.13.0,4.0.0)";visibility:=reexport,
+ org.eclipse.pde.core;bundle-version="[3.16.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.osgi.services;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.8.0,2.0.0)",


### PR DESCRIPTION
Currently a plugin can contribute source locations inside the plugin
itself through the extension point

org.eclipse.pde.core.source

this has the limitation that the source must be embedded and known in
advance. In some situations it would be required to provide external
locations dynamically e.g. maven has the concept of source artifacts
that could be queried, if a bundle contains a Bundle-Source-Location one
could checkout one could have a "source-repository" and so on.

This adds the necessary parts to the extension point and a extracts the
implementation that search for a Eclipse/Maven co-located source
bundles.

Part of https://github.com/eclipse-pde/eclipse.pde/issues/202