### PR TITLE
Don't unconditionally dereference ClasspathJrt.getModule()

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -422,7 +422,11 @@ public class TargetPlatformHelper {
 			String path = new File(vm.getInstallLocation(), jrtPath).toString(); // $NON-NLS-1$
 			var jrt = org.eclipse.jdt.internal.core.builder.ClasspathLocation.forJrtSystem(path, null, null, release);
 			for (String moduleName : jrt.getModuleNames(null)) {
-				for (var packageExport : jrt.getModule(moduleName).exports()) {
+				var module = jrt.getModule(moduleName);
+				if (module == null) {
+					continue;
+				}
+				for (var packageExport : module.exports()) {
 					if (!packageExport.isQualified()) {
 						packages.add(new String(packageExport.name()));
 					}


### PR DESCRIPTION
While fixing https://github.com/eclipse-jdt/eclipse.jdt.core/pull/245
I've noticed that TargetPlatformHelper is the only caller of
ClasspathJrt.getModule() that does not check for null return, which is
however fully valid result.

Simply added a NP check to avoid NPE in
TargetPlatformHelper.querySystemPackages()