### PR TITLE
Require the bundle/version annotation bundles when installing PDE

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -21,6 +21,8 @@
 
    <requires>
       <import feature="org.eclipse.jdt" version="3.15.0" match="compatible"/>
+      <import plugin="org.osgi.annotation.versioning"/>
+      <import plugin="org.osgi.annotation.bundle"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
If found in the repository then include the optional bundle/version annotation bundles so they are available when choosing the "The running platform" as a target, this will also include them in update-sites so people can install them from the SDK. 