### PR TITLE
Update manifest header by given OSGi annotations

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Export-Package:
    org.eclipse.pde.ua.core,
    org.eclipse.pde.api.tools.tests,
    org.eclipse.pde.unittest.junit",
+ org.eclipse.pde.internal.core.annotations;x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.internal.core.build;x-friends:="org.eclipse.pde.ui,org.eclipse.pde.ds.ui,org.eclipse.pde.ua.ui",
  org.eclipse.pde.internal.core.builders;x-friends:="org.eclipse.pde.ui,org.eclipse.pde.launching,org.eclipse.pde.ds.core",
  org.eclipse.pde.internal.core.bundle;x-friends:="org.eclipse.pde.ui,org.eclipse.pde.ds.ui",

--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -397,7 +397,7 @@
     <extension
           point="org.eclipse.pde.core.pluginClasspathContributors">
        <contributor
-             class="org.eclipse.pde.internal.core.OSGiAnnotationsClasspathContributor">
+             class="org.eclipse.pde.internal.core.annotations.OSGiAnnotationsClasspathContributor">
        </contributor>
     </extension>
 </plugin>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/CustomHeaderAnnotationProcessor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/CustomHeaderAnnotationProcessor.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.annotations;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.pde.core.IBaseModel;
+import org.eclipse.pde.internal.core.ibundle.IBundle;
+import org.eclipse.pde.internal.core.ibundle.IBundleModel;
+import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
+
+/**
+ * Processes {@link OSGiAnnotations#ANNOTATION_BUNDLE_HEADER}
+ * and{@link OSGiAnnotations#ANNOTATION_BUNDLE_HEADERS}
+ *
+ */
+public class CustomHeaderAnnotationProcessor implements OSGiAnnotationProcessor {
+
+	private final List<Entry<String, String>> headers = new ArrayList<>();
+
+	@Override
+	public void processAnnotation(Annotation annotation, String type) {
+		if (OSGiAnnotations.ANNOTATION_BUNDLE_HEADERS.equals(type)) {
+			OSGiAnnotationProcessor.expressions(annotation).filter(Annotation.class::isInstance)
+					.map(Annotation.class::cast).forEach(this::addHeaderValue);
+		} else if (OSGiAnnotations.ANNOTATION_BUNDLE_HEADER.equals(type)) {
+			addHeaderValue(annotation);
+		}
+	}
+
+	private void addHeaderValue(Annotation annotation) {
+		OSGiAnnotationProcessor.member(annotation, "name").flatMap(OSGiAnnotationProcessor::stringValue) //$NON-NLS-1$
+				.flatMap(name -> {
+					return OSGiAnnotationProcessor.member(annotation, "value") //$NON-NLS-1$
+							.flatMap(OSGiAnnotationProcessor::stringValue).map(value -> new SimpleEntry<>(name, value));
+				}).ifPresent(headers::add);
+	}
+
+	@Override
+	public void apply(IBaseModel model) {
+		if (model instanceof IBundlePluginModelBase) {
+			IBundlePluginModelBase pluginModel = (IBundlePluginModelBase) model;
+			IBundleModel bundleModel = pluginModel.getBundleModel();
+			IBundle bundle = bundleModel.getBundle();
+			for (Entry<String, String> entry : headers) {
+				bundle.setHeader(entry.getKey(), entry.getValue());
+			}
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/ExportPackageAnnotationProcessor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/ExportPackageAnnotationProcessor.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.annotations;
+
+import java.util.Optional;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.pde.core.IBaseModel;
+import org.eclipse.pde.internal.core.ibundle.IBundle;
+import org.eclipse.pde.internal.core.ibundle.IBundleModel;
+import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
+import org.eclipse.pde.internal.core.ibundle.IManifestHeader;
+import org.eclipse.pde.internal.core.text.bundle.ExportPackageHeader;
+import org.eclipse.pde.internal.core.text.bundle.ExportPackageObject;
+import org.osgi.framework.Constants;
+
+/**
+ * Processes {@value OSGiAnnotations#ANNOTATION_BUNDLE_EXPORT} and
+ * {@value OSGiAnnotations#ANNOTATION_VERSIONING_VERSION} annotations.
+ */
+public class ExportPackageAnnotationProcessor implements OSGiAnnotationProcessor {
+
+	private boolean exportPackage = false;
+	private Optional<String> version = Optional.empty();
+	private String packageName;
+
+	public ExportPackageAnnotationProcessor(String packageName) {
+		this.packageName = packageName;
+	}
+
+	@Override
+	public void processAnnotation(Annotation annotation, String type) {
+		exportPackage |= OSGiAnnotations.ANNOTATION_BUNDLE_EXPORT.equals(type);
+		if (OSGiAnnotations.ANNOTATION_VERSIONING_VERSION.equals(type)) {
+			version = OSGiAnnotationProcessor.value(annotation).flatMap(OSGiAnnotationProcessor::stringValue);
+		}
+	}
+
+	@Override
+	public void apply(IBaseModel model) {
+		if (exportPackage) {
+			ExportPackageObject packageObject = getExportPackage(model, packageName);
+			if (packageObject != null) {
+				packageObject.setVersion(version.orElse(null));
+			}
+		}
+	}
+
+	private static ExportPackageObject getExportPackage(IBaseModel model, String packageName) {
+		if (model instanceof IBundlePluginModelBase) {
+			IBundlePluginModelBase pluginModel = (IBundlePluginModelBase) model;
+			IBundleModel bundleModel = pluginModel.getBundleModel();
+			IBundle bundle = bundleModel.getBundle();
+			IManifestHeader header = bundle.getManifestHeader(Constants.EXPORT_PACKAGE);
+			if (header == null) {
+				bundle.setHeader(Constants.EXPORT_PACKAGE, packageName);
+				header = bundle.getManifestHeader(Constants.EXPORT_PACKAGE);
+			}
+			if (header instanceof ExportPackageHeader) {
+				ExportPackageHeader exportPackageHeader = (ExportPackageHeader) header;
+				ExportPackageObject packageObject = exportPackageHeader.getPackage(packageName);
+				if (packageObject == null) {
+					return exportPackageHeader.addPackage(packageName);
+				}
+				return packageObject;
+			}
+		}
+		return null;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationProcessor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationProcessor.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.annotations;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.ArrayInitializer;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.pde.core.IBaseModel;
+
+public interface OSGiAnnotationProcessor {
+	/**
+	 * process the given annotation of the given type
+	 *
+	 * @param annotation
+	 *            the annotation to process
+	 * @param type
+	 *            the fully qualified type name of the annotation to process
+	 */
+	void processAnnotation(Annotation annotation, String type);
+
+	/**
+	 * applies the processed annotation actions (if any) to the given model
+	 *
+	 * @param model
+	 */
+	void apply(IBaseModel model);
+
+	/**
+	 * Optionally converts the given Expression to the string literal value
+	 *
+	 * @param expression
+	 *            the expression to convert
+	 * @return an Optional holding the string literal value or an empty optional
+	 *         if it could not be converted
+	 */
+	static Optional<String> stringValue(Expression expression) {
+		return Optional.ofNullable(expression).filter(StringLiteral.class::isInstance).map(StringLiteral.class::cast)
+				.map(StringLiteral::getLiteralValue);
+	}
+
+	/**
+	 * Explodes an expression into a stream of child expressions. If the
+	 * expression could not be exploded, it is returned as a single item.
+	 *
+	 * @param expression
+	 *            the expression
+	 * @return a stream of exploded expressions, or the expression itself
+	 */
+	static Stream<Expression> expressions(Expression expression) {
+		Expression unwrap = value(expression).orElse(expression);
+		if (unwrap instanceof ArrayInitializer) {
+			ArrayInitializer arrayInitializer = (ArrayInitializer) unwrap;
+			return arrayInitializer.expressions().stream().filter(Expression.class::isInstance)
+					.map(Expression.class::cast);
+		}
+		return Stream.of(expression);
+	}
+
+	/**
+	 * Optionally retrieves the 'value' of an annotation
+	 *
+	 * @param annotation
+	 *            the annotation to retrieve the value from
+	 * @return the Expression that represents the value or an empty optional if
+	 *         the value is not found
+	 */
+	static Optional<Expression> value(Expression annotation) {
+		return member(annotation, "value"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Optionally retrieves the given member from an annotation
+	 *
+	 * @param annotation
+	 *            the annotation to retrieve the member from
+	 * @param memberName
+	 *            the name of the member to retrieve
+	 * @return the retrieved value of the member with the given name or an empty
+	 *         optional if no such member exits.
+	 */
+	static Optional<Expression> member(Expression annotation, String memberName) {
+		if (annotation instanceof NormalAnnotation) {
+			NormalAnnotation normalAnnotation = (NormalAnnotation) annotation;
+			for (Object value : normalAnnotation.values()) {
+				if (value instanceof MemberValuePair) {
+					MemberValuePair pair = (MemberValuePair) value;
+					SimpleName name = pair.getName();
+					if (name != null && name.toString().equals(memberName)) {
+						return Optional.ofNullable(pair.getValue());
+					}
+				}
+			}
+		}
+		if (annotation instanceof SingleMemberAnnotation && "value".equals(memberName)) { //$NON-NLS-1$
+			SingleMemberAnnotation singleMemberAnnotation = (SingleMemberAnnotation) annotation;
+			return Optional.ofNullable(singleMemberAnnotation.getValue());
+		}
+		return Optional.empty();
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotations.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotations.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.annotations;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface OSGiAnnotations {
+
+	String ANNOTATION_BUNDLE_EXPORT = "org.osgi.annotation.bundle.Export"; //$NON-NLS-1$
+	String ANNOTATION_BUNDLE_HEADER = "org.osgi.annotation.bundle.Header"; //$NON-NLS-1$
+	String ANNOTATION_BUNDLE_HEADERS = "org.osgi.annotation.bundle.Headers"; //$NON-NLS-1$
+	String ANNOTATION_VERSIONING_VERSION = "org.osgi.annotation.versioning.Version"; //$NON-NLS-1$
+	Collection<String> SUPPORTED_ANNOTATIONS = List.of(ANNOTATION_VERSIONING_VERSION,
+			ANNOTATION_BUNDLE_EXPORT, ANNOTATION_BUNDLE_HEADER, ANNOTATION_BUNDLE_HEADERS);
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.pde.internal.core;
+package org.eclipse.pde.internal.core.annotations;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -2376,4 +2376,16 @@
       	</action>
       </objectContribution>
   </extension>
+      <extension
+         point="org.eclipse.jdt.core.compilationParticipant">
+      <compilationParticipant
+            class="org.eclipse.pde.internal.ui.annotations.OSGiAnnotationsCompilationParticipant"
+            createsProblems="true"
+            id="org.eclipse.pde.internal.ui.annotations.OSGiAnnotationsCompilationParticipant"
+            requiredSourceLevel="1.5">
+         <managedMarker
+               markerType="org.eclipse.pde.osgi.annotations.problem">
+         </managedMarker>
+      </compilationParticipant>
+   </extension>
 </plugin>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/annotations/OSGiAnnotationsASTRequestor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/annotations/OSGiAnnotationsASTRequestor.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.annotations;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+final class OSGiAnnotationsASTRequestor extends ASTRequestor {
+
+	@Override
+	public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+		ast.accept(new OSGiAnnotationsASTVisitor(ast));
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/annotations/OSGiAnnotationsASTVisitor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/annotations/OSGiAnnotationsASTVisitor.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.annotations;
+
+import java.util.List;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.dom.*;
+import org.eclipse.pde.core.IBaseModel;
+import org.eclipse.pde.core.IModel;
+import org.eclipse.pde.internal.core.WorkspaceModelManager;
+import org.eclipse.pde.internal.core.annotations.*;
+import org.eclipse.pde.internal.core.natures.PDE;
+import org.eclipse.pde.internal.ui.util.ModelModification;
+import org.eclipse.pde.internal.ui.util.PDEModelUtility;
+
+public class OSGiAnnotationsASTVisitor extends ASTVisitor {
+
+	private CompilationUnit unit;
+
+	public OSGiAnnotationsASTVisitor(CompilationUnit compilationUnit) {
+		this.unit = compilationUnit;
+	}
+
+	@Override
+	public boolean visit(PackageDeclaration packageDeclaration) {
+		ITypeRoot typeRoot = unit.getTypeRoot();
+		if (typeRoot == null || !"package-info.java".equals(typeRoot.getElementName())) { //$NON-NLS-1$
+			return true;
+		}
+		IJavaProject javaProject = typeRoot.getJavaProject();
+		if (javaProject == null) {
+			return true;
+		}
+		IProject project = javaProject.getProject();
+		if (!PDE.hasPluginNature(project) || WorkspaceModelManager.isBinaryProject(project)) {
+			return true;
+		}
+		List<OSGiAnnotationProcessor> processors = getPackageProcessors(packageDeclaration.getName().toString());
+		for (Object item : packageDeclaration.annotations()) {
+			if (item instanceof Annotation) {
+				Annotation annotation = (Annotation) item;
+				IAnnotationBinding annotationBinding = annotation.resolveAnnotationBinding();
+				if (annotationBinding == null) {
+					// not resolvable
+					continue;
+				}
+				String name = annotationBinding.getAnnotationType().getQualifiedName();
+				for (OSGiAnnotationProcessor processor : processors) {
+					processor.processAnnotation(annotation, name);
+				}
+			}
+		}
+		PDEModelUtility.modifyModel(new ModelModification(project) {
+			@Override
+			protected void modifyModel(IBaseModel model, IProgressMonitor monitor) throws CoreException {
+				if (model instanceof IModel) {
+					if (isDerived(((IModel) model).getUnderlyingResource())) {
+						// do not modify a derived manifest...
+						return;
+					}
+				}
+				for (OSGiAnnotationProcessor processor : processors) {
+					processor.apply(model);
+				}
+			}
+		}, null);
+		return true;
+	}
+
+	private static boolean isDerived(IResource resource) {
+		if (resource != null) {
+			if (resource.isDerived()) {
+				return true;
+			}
+			return isDerived(resource.getParent());
+		}
+		return false;
+	}
+
+	private static List<OSGiAnnotationProcessor> getPackageProcessors(String packageName) {
+		return List.of(new ExportPackageAnnotationProcessor(packageName), new CustomHeaderAnnotationProcessor());
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/annotations/OSGiAnnotationsCompilationParticipant.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/annotations/OSGiAnnotationsCompilationParticipant.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.annotations;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.*;
+import org.eclipse.jdt.core.compiler.BuildContext;
+import org.eclipse.jdt.core.compiler.CompilationParticipant;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.pde.internal.core.WorkspaceModelManager;
+import org.eclipse.pde.internal.core.annotations.OSGiAnnotations;
+import org.eclipse.pde.internal.core.natures.PDE;
+
+public class OSGiAnnotationsCompilationParticipant extends CompilationParticipant {
+
+	@Override
+	public boolean isAnnotationProcessor() {
+		return true;
+	}
+
+	@Override
+	public boolean isActive(IJavaProject javaProject) {
+		IProject project = javaProject.getProject();
+		if (project.isOpen() && PDE.hasPluginNature(project) && !WorkspaceModelManager.isBinaryProject(project)) {
+			for (String annotation : OSGiAnnotations.SUPPORTED_ANNOTATIONS) {
+				try {
+					IType annotationType = javaProject.findType(annotation);
+					if (annotationType != null && annotationType.isAnnotation()) {
+						return true;
+					}
+				} catch (JavaModelException e) {
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void processAnnotations(BuildContext[] files) {
+		for (BuildContext file : files) {
+			ICompilationUnit cu = JavaCore.createCompilationUnitFrom(file.getFile());
+			if (cu == null) {
+				// can't process...
+				continue;
+			}
+			@SuppressWarnings("deprecation")
+			ASTParser parser = ASTParser.newParser(AST.JLS3);
+			parser.setResolveBindings(true);
+			parser.setBindingsRecovery(true);
+			parser.setProject(cu.getJavaProject());
+			parser.setKind(ASTParser.K_COMPILATION_UNIT);
+			parser.createASTs(new ICompilationUnit[] { cu }, new String[0],
+					new OSGiAnnotationsASTRequestor(), null);
+		}
+	}
+}


### PR DESCRIPTION
Now we have support in PDE to use the OSGi annotations, we can start to
process them by the tooling.

This adds support for Version/Export/Header annotations and updates the
manifest accordingly.

Part of https://github.com/eclipse-pde/eclipse.pde/issues/69