### PR TITLE
Revert "Don't unconditionally dereference ClasspathJrt.getModule()"

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -422,11 +422,7 @@ public class TargetPlatformHelper {
 			String path = new File(vm.getInstallLocation(), jrtPath).toString(); // $NON-NLS-1$
 			var jrt = org.eclipse.jdt.internal.core.builder.ClasspathLocation.forJrtSystem(path, null, null, release);
 			for (String moduleName : jrt.getModuleNames(null)) {
-				var module = jrt.getModule(moduleName);
-				if (module == null) {
-					continue;
-				}
-				for (var packageExport : module.exports()) {
+				for (var packageExport : jrt.getModule(moduleName).exports()) {
 					if (!packageExport.isQualified()) {
 						packages.add(new String(packageExport.name()));
 					}


### PR DESCRIPTION
This reverts commit 063f6862855c37835ebfe8c7b83f2ab1a7531126.

To see if that causes failures on Jenkins (see #232)