### PR TITLE
Enable matrix build for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -40,7 +44,7 @@ jobs:
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
       with:
-        name: test-results
+        name: test-results-${{ matrix.os }}
         if-no-files-found: error
         path: '**/target/surefire-reports/*.xml'
 


### PR DESCRIPTION
Windows is an important development platform for PDE we should also test
a PR on these platforms as it has shown to having issues (e.g. different
path handling) in the past.