### PR TITLE
Remove m2e nature and builder from org.eclipse.pde.unittest.junit

### DIFF
--- a/ui/org.eclipse.pde.unittest.junit/.project
+++ b/ui/org.eclipse.pde.unittest.junit/.project
@@ -25,14 +25,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>


### PR DESCRIPTION
This causes errors in the workspace's pom.xml when m2e is installed.