### PR TITLE
Always provide the official annotations if present in target

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -23,6 +23,7 @@
       <import feature="org.eclipse.jdt" version="3.15.0" match="compatible"/>
       <import plugin="org.osgi.annotation.versioning"/>
       <import plugin="org.osgi.annotation.bundle"/>
+      <import plugin="org.osgi.service.component.annotations"/>
    </requires>
 
    <plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -40,7 +40,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 public class OSGiAnnotationsClasspathContributor implements IClasspathContributor {
 
 	private Collection<String> OSGI_ANNOTATIONS = List.of("org.osgi.annotation.versioning", //$NON-NLS-1$
-			"org.osgi.annotation.bundle"); //$NON-NLS-1$
+			"org.osgi.annotation.bundle", "org.osgi.service.component.annotations"); //$NON-NLS-1$ //$NON-NLS-2$
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {


### PR DESCRIPTION
Currently PDE ships an (outdated) version of the DS annotations, like
with the bunde/version annotations it would be better to simply fetch
the latest version from the given users target.