### PR TITLE
Use the actual system-packages from the JVM for Product/Site export

### DIFF
--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)",
  org.eclipse.equinox.p2.repository.tools;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
  org.eclipse.equinox.p2.director.app;bundle-version="1.0.200",
  org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0",
- org.eclipse.jdt.core;bundle-version="[3.28.0,4.0.0)"
+ org.eclipse.jdt.core;bundle-version="[3.28.0,4.0.0)",
+ org.eclipse.jdt.launching;bundle-version="[3.19.700,4.0.0)"
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.equinox.internal.p2.engine,

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -409,13 +409,7 @@ public class TargetPlatformHelper {
 		if (vm == null || !JavaRuntime.isModularJava(vm)) {
 			return null;
 		}
-
-		String release = null;
-		Map<String, String> complianceOptions = environment.getComplianceOptions();
-		if (complianceOptions != null) {
-			release = complianceOptions.get(JavaCore.COMPILER_COMPLIANCE);
-		}
-
+		String release = environment.getProfileProperties().getProperty(JavaCore.COMPILER_COMPLIANCE);
 		try {
 			Collection<String> packages = new TreeSet<>();
 			String jrtPath = "lib/" + org.eclipse.jdt.internal.compiler.util.JRTUtil.JRT_FS_JAR; //$NON-NLS-1$
@@ -440,12 +434,10 @@ public class TargetPlatformHelper {
 		if (defaultVM != null) {
 			return defaultVM;
 		}
-
 		IVMInstall[] compatible = environment.getCompatibleVMs();
 		if (compatible.length == 0) {
 			return null;
 		}
-
 		for (IVMInstall vm : compatible) {
 			if (environment.isStrictlyCompatible(vm)) {
 				return vm;


### PR DESCRIPTION
As reported in https://github.com/eclipse-pde/eclipse.pde/pull/221#issuecomment-1198011695 #194 can also occur when exporting Products.

This applies the same fix to PDE-build. In my little test-case that worked.

Since pde.core depends on pde.build I had to copy the code from `TargetPlatformHelper` to PDE build. Looking at other places this is not the first time the dependency issue was solved like that.

Additionally this applies a minor shortcut for `TargetPlatformHelper.querySystemPackages()`