### PR TITLE
Clean up product launching

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -697,12 +697,15 @@ public class TargetPlatformHelper {
 	}
 
 	public static boolean matchesCurrentEnvironment(IPluginModelBase model) {
-		BundleContext context = PDECore.getDefault().getBundleContext();
-		Dictionary<String, String> environment = getTargetEnvironment();
 		BundleDescription bundle = model.getBundleDescription();
 		String filterSpec = bundle != null ? bundle.getPlatformFilter() : null;
+		if (filterSpec == null) {
+			return true;
+		}
+		BundleContext context = PDECore.getDefault().getBundleContext();
+		Dictionary<String, String> environment = getTargetEnvironment();
 		try {
-			return filterSpec == null || context.createFilter(filterSpec).match(environment);
+			return context.createFilter(filterSpec).match(environment);
 		} catch (InvalidSyntaxException e) {
 			return false;
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -340,6 +340,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String ProductEditor_exportTooltip;
 
+	public static String ProductEditor_launchFailed;
+
 	public static String RemoveSplashHandlerBindingAction_msgProgressRemoveProductBindings;
 
 	public static String RenamePluginAction_label;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/DependenciesPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/DependenciesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2015 Code 9 Corporation and others.
+ * Copyright (c) 2008, 2022 Code 9 Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,13 +21,12 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.FormEditor;
-import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 
 public class DependenciesPage extends PDEFormPage {
 
-	public static final String PLUGIN_ID = "plugin-dependencies"; //$NON-NLS-1$
-	public static final String FEATURE_ID = "feature-dependencies"; //$NON-NLS-1$
+	static final String PLUGIN_ID = "plugin-dependencies"; //$NON-NLS-1$
+	static final String FEATURE_ID = "feature-dependencies"; //$NON-NLS-1$
 
 	private boolean fUseFeatures;
 	private PluginSection fPluginSection = null;
@@ -46,14 +45,13 @@ public class DependenciesPage extends PDEFormPage {
 	protected void createFormContent(IManagedForm managedForm) {
 		super.createFormContent(managedForm);
 		ScrolledForm form = managedForm.getForm();
-		FormToolkit toolkit = managedForm.getToolkit();
 		form.setImage(PDEPlugin.getDefault().getLabelProvider().get(PDEPluginImages.DESC_REQ_PLUGINS_OBJ));
 		form.setText(PDEUIMessages.Product_DependenciesPage_title);
-		fillBody(managedForm, toolkit);
+		fillBody(managedForm);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(form.getBody(), IHelpContextIds.CONFIGURATION_PAGE);
 	}
 
-	private void fillBody(IManagedForm managedForm, FormToolkit toolkit) {
+	private void fillBody(IManagedForm managedForm) {
 		Composite body = managedForm.getForm().getBody();
 		body.setLayout(FormLayoutFactory.createFormGridLayout(false, 1));
 
@@ -65,6 +63,6 @@ public class DependenciesPage extends PDEFormPage {
 	}
 
 	public boolean includeOptionalDependencies() {
-		return (fPluginSection != null) ? fPluginSection.includeOptionalDependencies() : false;
+		return fPluginSection != null && fPluginSection.includeOptionalDependencies();
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/IntroSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/IntroSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2015 IBM Corporation and others.
+ * Copyright (c) 2005, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -124,10 +124,9 @@ public class IntroSection extends PDESection {
 	private void loadManifestAndIntroIds(boolean onlyLoadManifest) {
 		TreeSet<String> result = new TreeSet<>();
 		String introId;
-		IExtension[] extensions = PDECore.getDefault().getExtensionsRegistry().findExtensions("org.eclipse.ui.intro", true); //$NON-NLS-1$
+		IExtension[] extensions = PDECore.getDefault().getExtensionsRegistry().findExtensions(INTRO_PLUGIN_ID, true);
 		for (IExtension extension : extensions) {
-			IConfigurationElement[] children = extension.getConfigurationElements();
-			for (IConfigurationElement element : children) {
+			for (IConfigurationElement element : extension.getConfigurationElements()) {
 				if ("introProductBinding".equals(element.getName())) {//$NON-NLS-1$
 					String attribute = element.getAttribute("productId"); //$NON-NLS-1$
 					if (attribute != null && attribute.equals(getProduct().getProductId())) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductValidateAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductValidateAction.java
@@ -13,20 +13,17 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
-import java.util.*;
+import java.util.Set;
 import org.eclipse.core.runtime.*;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.pde.core.plugin.*;
-import org.eclipse.pde.internal.core.*;
-import org.eclipse.pde.internal.core.ifeature.*;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
-import org.eclipse.pde.internal.core.iproduct.IProductFeature;
-import org.eclipse.pde.internal.core.iproduct.IProductPlugin;
 import org.eclipse.pde.internal.launching.launcher.*;
 import org.eclipse.pde.internal.ui.*;
+import org.eclipse.pde.internal.ui.launcher.LaunchAction;
 import org.eclipse.swt.SWT;
 
 public class ProductValidateAction extends Action {
@@ -41,23 +38,7 @@ public class ProductValidateAction extends Action {
 
 	@Override
 	public void run() {
-		Set<IPluginModelBase> launchPlugins = new HashSet<>();
-		if (fProduct.useFeatures()) {
-			IFeatureModel[] features = getUniqueFeatures();
-			for (IFeatureModel feature : features) {
-				addFeaturePlugins(feature.getFeature(), launchPlugins);
-			}
-		} else {
-			IProductPlugin[] plugins = fProduct.getPlugins();
-			for (IProductPlugin plugin : plugins) {
-				String id = plugin.getId();
-				if (id == null)
-					continue;
-				IPluginModelBase model = PluginRegistry.findModel(id);
-				if (model != null && !launchPlugins.contains(model) && TargetPlatformHelper.matchesCurrentEnvironment(model))
-					launchPlugins.add(model);
-			}
-		}
+		Set<IPluginModelBase> launchPlugins = LaunchAction.getModels(fProduct);
 		try {
 			LaunchValidationOperation operation = new ProductValidationOperation(launchPlugins);
 			LaunchPluginValidator.runValidationOperation(operation, new NullProgressMonitor());
@@ -71,46 +52,6 @@ public class ProductValidateAction extends Action {
 				return;
 			}
 			PDEPlugin.logException(e);
-		}
-	}
-
-	private void addFeaturePlugins(IFeature feature, Set<IPluginModelBase> launchPlugins) {
-		IFeaturePlugin[] plugins = feature.getPlugins();
-		for (IFeaturePlugin plugin : plugins) {
-			String id = plugin.getId();
-			String version = plugin.getVersion();
-			if (id == null || version == null)
-				continue;
-			IPluginModelBase model = PluginRegistry.findModel(id, version, IMatchRules.EQUIVALENT, null);
-			if (model == null)
-				model = PluginRegistry.findModel(id);
-			if (model != null && !launchPlugins.contains(model) && TargetPlatformHelper.matchesCurrentEnvironment(model))
-				launchPlugins.add(model);
-		}
-	}
-
-	private IFeatureModel[] getUniqueFeatures() {
-		ArrayList<IFeatureModel> list = new ArrayList<>();
-		IProductFeature[] features = fProduct.getFeatures();
-		for (IProductFeature feature : features) {
-			String id = feature.getId();
-			String version = feature.getVersion();
-			addFeatureAndChildren(id, version, list);
-		}
-		return list.toArray(new IFeatureModel[list.size()]);
-	}
-
-	private void addFeatureAndChildren(String id, String version, List<IFeatureModel> list) {
-		FeatureModelManager manager = PDECore.getDefault().getFeatureModelManager();
-		IFeatureModel model = manager.findFeatureModel(id, version);
-		if (model == null || list.contains(model))
-			return;
-
-		list.add(model);
-
-		IFeatureChild[] children = model.getFeature().getIncludedFeatures();
-		for (IFeatureChild child : children) {
-			addFeatureAndChildren(child.getId(), child.getVersion(), list);
 		}
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2084,6 +2084,7 @@ ProductExportWizardPage_wrongExtension=A product configuration file name must ha
 ProductExportWizardPage_fileSelection=File Selection
 ProductIntroWizardPage_invalidIntroId=Invalid Intro ID.  Legal characters are: a-z A-Z 0-9 .
 ProductEditor_exportTooltip=Export an Eclipse product
+ProductEditor_launchFailed=Failed to launch product from Editor
 ProductExportWizardPage_productSelection=Select a product configuration
 ProductExportWizardPage_exportOptionsGroup=Export Options
 ProductExportWizardPage_syncText=Synchronization of the product configuration with the product's defining plug-in ensures that the plug-in does not contain stale data.


### PR DESCRIPTION
Clean up Product LaunchAction: format, use braces and minor clean-ups
+ Replace arrays by collections

Simplify Product LaunchAction and associated classes
- Make recursive collection of child features iterative
- Reuse code to collect plugin-models from LaunchAction in other places
