### PR TITLE
Clear workspace before each API-tools test class

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
@@ -73,6 +73,8 @@ import org.eclipse.ui.dialogs.IOverwriteQuery;
 import org.eclipse.ui.wizards.datatransfer.FileSystemStructureProvider;
 import org.eclipse.ui.wizards.datatransfer.ImportOperation;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 import org.osgi.service.prefs.BackingStoreException;
 
 import junit.framework.Test;
@@ -84,6 +86,10 @@ import junit.framework.TestSuite;
  * @since 1.0
  */
 public abstract class ApiBuilderTest extends BuilderTests {
+
+	@ClassRule
+	public static final TestRule CLEAR_WORKSPACE = org.eclipse.pde.ui.tests.util.ProjectUtils.DELETE_ALL_WORKSPACE_PROJECTS_BEFORE_AND_AFTER;
+
 	/**
 	 * Debug flag
 	 */


### PR DESCRIPTION
When looking closer at the failures of https://github.com/eclipse-pde/eclipse.pde/issues/232 I noticed that at least some tests like the `BundleVersionTests` fail with a missing `bundle.a` in the API baseline. When I run that test case in the IDE, in the `setupTest(String)` method there is no such project in the workspace and therefore it is not searched for such project in the API-baseline. From the test code I also can find a reason why a project called `bundle.a` should be present.

Therefore I suspect that `bundle.a` is leaking into the workspace from another test case. And maybe it helps to add an extra clean of the workspace.
But actually the workspace should be cleaned already before. But lets see, maybe we are lucky.

