### PR TITLE
PDEPluginImages: fix NullPointerException #297

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPlugin.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -209,6 +209,7 @@ public class PDEPlugin extends AbstractUIPlugin implements IPDEUIConstants {
 		LogFilesManager.addLogFileProvider(fLogFileProvider);
 
 		TargetStatus.initializeTargetStatus();
+		PDEPluginImages.initialize(); // make sure it's done in Display thread
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPluginImages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPluginImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -315,13 +315,11 @@ public class PDEPluginImages {
 	}
 
 	public static Image get(String key) {
-		if (PLUGIN_REGISTRY == null)
-			initialize();
 		return PLUGIN_REGISTRY.get(key);
 	}
 
 	/* package */
-	private static final void initialize() {
+	static final void initialize() {
 		PLUGIN_REGISTRY = new ImageRegistry();
 		manage(IMG_ATT_CLASS_OBJ, DESC_ATT_CLASS_OBJ);
 		manage(IMG_ATT_FILE_OBJ, DESC_ATT_FILE_OBJ);


### PR DESCRIPTION
Images need to be initialized in Display tread.
ManifestContentAssistProcessor runs in background thread and use images.