### PR TITLE
Revert "PDEPluginImages: fix NullPointerException #297"

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPlugin.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2019 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -209,7 +209,6 @@ public class PDEPlugin extends AbstractUIPlugin implements IPDEUIConstants {
 		LogFilesManager.addLogFileProvider(fLogFileProvider);
 
 		TargetStatus.initializeTargetStatus();
-		PDEPluginImages.initialize(); // make sure it's done in Display thread
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPluginImages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPluginImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -315,11 +315,13 @@ public class PDEPluginImages {
 	}
 
 	public static Image get(String key) {
+		if (PLUGIN_REGISTRY == null)
+			initialize();
 		return PLUGIN_REGISTRY.get(key);
 	}
 
 	/* package */
-	static final void initialize() {
+	private static final void initialize() {
 		PLUGIN_REGISTRY = new ImageRegistry();
 		manage(IMG_ATT_CLASS_OBJ, DESC_ATT_CLASS_OBJ);
 		manage(IMG_ATT_FILE_OBJ, DESC_ATT_FILE_OBJ);


### PR DESCRIPTION
This reverts commit 6dd163d3eb45e587b04ff32796dbb804e69105de.
See https://github.com/eclipse-pde/eclipse.pde/issues/297#issuecomment-1236603988