### PR TITLE
Bug 579310 - Remove broken "Enable/Disable" action from Plug-in Registry

### DIFF
--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/PDERuntimeMessages.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/PDERuntimeMessages.java
@@ -45,11 +45,9 @@ public class PDERuntimeMessages extends NLS {
 	public static String RegistryView_titleSummary;
 	public static String RegistryView_startAction_label;
 	public static String RegistryView_stopAction_label;
-	public static String RegistryView_enableAction_label;
 	public static String RegistryView_diag_dialog_title;
 
 	public static String RegistryView_diagnoseAction_label;
-	public static String RegistryView_disableAction_label;
 	public static String RegistryView_no_unresolved_constraints;
 
 	public static String MessageHelper_missing_optional_required_bundle;

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/pderuntimeresources.properties
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/pderuntimeresources.properties
@@ -57,10 +57,8 @@ RegistryBrowserLabelProvider_UsingBundles=Using bundles
 RegistryView_titleSummary = Filter matched {0} of {1} {2}.
 RegistryView_startAction_label = Start
 RegistryView_stopAction_label = Stop
-RegistryView_enableAction_label = Enable
 RegistryView_diag_dialog_title=Diagnosis
 RegistryView_diagnoseAction_label=Diagnose
-RegistryView_disableAction_label = Disable
 RegistryView_no_unresolved_constraints=No problems detected.
 
 MessageHelper_missing_optional_required_bundle=Missing optionally required bundle {0}

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/RegistryBrowserLabelProvider.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/RegistryBrowserLabelProvider.java
@@ -41,7 +41,6 @@ public class RegistryBrowserLabelProvider extends StyledCellLabelProvider implem
 	private Image fReqPluginImage;
 	private Image fPluginsImage;
 	private Image fLocationImage;
-	private Image fDisabledImage;
 	private Image fExporterImage;
 	private Image fImporterImage;
 	private Image fServiceImage;
@@ -78,9 +77,6 @@ public class RegistryBrowserLabelProvider extends StyledCellLabelProvider implem
 		ImageDescriptor activePluginDesc = new OverlayIcon(PDERuntimePluginImages.DESC_PLUGIN_OBJ, new ImageDescriptor[][] {{PDERuntimePluginImages.DESC_RUN_CO}});
 		fActivePluginImage = activePluginDesc.createImage();
 
-		ImageDescriptor disabledPluginDesc = new OverlayIcon(PDERuntimePluginImages.DESC_PLUGIN_OBJ, new ImageDescriptor[][] {{PDERuntimePluginImages.DESC_ERROR_CO}});
-		fDisabledImage = disabledPluginDesc.createImage();
-
 		ImageDescriptor unresolvedPluginDesc = new OverlayIcon(PDERuntimePluginImages.DESC_PLUGIN_OBJ, new ImageDescriptor[][] {{PDERuntimePluginImages.DESC_ERROR_CO}});
 		fUnresolvedPluginImage = unresolvedPluginDesc.createImage();
 
@@ -109,7 +105,6 @@ public class RegistryBrowserLabelProvider extends StyledCellLabelProvider implem
 		fGenericAttrImage.dispose();
 		fRuntimeImage.dispose();
 		fLocationImage.dispose();
-		fDisabledImage.dispose();
 		fImporterImage.dispose();
 		fExporterImage.dispose();
 		fServiceImage.dispose();
@@ -143,17 +138,11 @@ public class RegistryBrowserLabelProvider extends StyledCellLabelProvider implem
 			if (bundle.getFragmentHost() != null)
 				return fFragmentImage;
 
-			if (!bundle.isEnabled())
-				return fDisabledImage;
-
 			switch (bundle.getState()) {
 				case Bundle.ACTIVE :
 					return fActivePluginImage;
 				case Bundle.UNINSTALLED :
 					return fUnresolvedPluginImage;
-				case Bundle.INSTALLED :
-					if (!bundle.isEnabled())
-						return fUnresolvedPluginImage;
 				default :
 					return fPluginImage;
 			}

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/Bundle.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/Bundle.java
@@ -25,7 +25,6 @@ public class Bundle extends ModelObject {
 
 	private String symbolicName;
 	private String location;
-	private boolean isEnabled;
 	private BundlePrerequisite[] imports = new BundlePrerequisite[0];
 	private String version;
 	private int state;
@@ -80,10 +79,6 @@ public class Bundle extends ModelObject {
 		this.id = id;
 	}
 
-	public void setEnabled(boolean enabled) {
-		isEnabled = enabled;
-	}
-
 	public void setLibraries(BundleLibrary[] libraries) {
 		if (libraries == null)
 			throw new IllegalArgumentException();
@@ -93,10 +88,6 @@ public class Bundle extends ModelObject {
 
 	public String getSymbolicName() {
 		return symbolicName;
-	}
-
-	public boolean isEnabled() {
-		return isEnabled;
 	}
 
 	public BundlePrerequisite[] getImports() {
@@ -133,18 +124,6 @@ public class Bundle extends ModelObject {
 		if (model == null)
 			return;
 		model.backend.stop(id);
-	}
-
-	public void enable() {
-		if (model == null)
-			return;
-		model.backend.setEnabled(id, true);
-	}
-
-	public void disable() {
-		if (model == null)
-			return;
-		model.backend.setEnabled(id, false);
 	}
 
 	public MultiStatus diagnose() {

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/LocalRegistryBackend.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/LocalRegistryBackend.java
@@ -152,7 +152,6 @@ public class LocalRegistryBackend implements IRegistryEventListener, BundleListe
 		adapter.setVersion(bundle.getHeaders().get(org.osgi.framework.Constants.BUNDLE_VERSION));
 		adapter.setState(bundle.getState());
 		adapter.setId(bundle.getBundleId());
-		adapter.setEnabled(getIsEnabled(bundle));
 		adapter.setLocation(createLocation(bundle));
 
 		String fragmentHost = bundle.getHeaders().get(Constants.FRAGMENT_HOST);
@@ -282,14 +281,6 @@ public class LocalRegistryBackend implements IRegistryEventListener, BundleListe
 			service.setProperties(properties);
 		}
 		return service;
-	}
-
-	private static boolean getIsEnabled(org.osgi.framework.Bundle bundle) {
-		PlatformAdmin plaformAdmin = PDERuntimePlugin.getDefault().getPlatformAdmin();
-		State state = plaformAdmin.getState(false);
-
-		BundleDescription description = state.getBundle(bundle.getBundleId());
-		return (state.getDisabledInfos(description)).length == 0;
 	}
 
 	private static String createLocation(org.osgi.framework.Bundle bundle) {
@@ -478,21 +469,4 @@ public class LocalRegistryBackend implements IRegistryEventListener, BundleListe
 		listener.removeExtensionPoints(createExtensionPointAdapters(extensionPoints));
 	}
 
-	@Override
-	public void setEnabled(long id, boolean enabled) {
-		State state = PDERuntimePlugin.getDefault().getState();
-		BundleDescription desc = state.getBundle(id);
-
-		if (enabled) {
-			DisabledInfo[] infos = state.getDisabledInfos(desc);
-			for (DisabledInfo info : infos) {
-				PlatformAdmin platformAdmin = PDERuntimePlugin.getDefault().getPlatformAdmin();
-				platformAdmin.removeDisabledInfo(info);
-			}
-		} else {
-			DisabledInfo info = new DisabledInfo("org.eclipse.pde.ui", "Disabled via PDE", desc); //$NON-NLS-1$ //$NON-NLS-2$
-			PlatformAdmin platformAdmin = PDERuntimePlugin.getDefault().getPlatformAdmin();
-			platformAdmin.addDisabledInfo(info);
-		}
-	}
 }

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/RegistryBackend.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/RegistryBackend.java
@@ -23,8 +23,6 @@ public interface RegistryBackend {
 
 	public void disconnect();
 
-	public void setEnabled(long id, boolean enabled);
-
 	public void start(long id) throws BundleException;
 
 	public void stop(long id) throws BundleException;


### PR DESCRIPTION
As described in [Bug 579310](https://bugs.eclipse.org/bugs/show_bug.cgi?id=579310) the `Enable/Disable` action of the `Plug-in Registry` is broken because the compatibility implementation of the `org.eclipse.osgi.service.resolver.PlatformAdmin` does not support addition/removal of `DisableInfo`.

This is broken for a while already and since nobody has complained I suggest to simply remove those actions and the whole disable/enable story.

![grafik](https://user-images.githubusercontent.com/44067969/188745704-ef4796d0-6a74-4357-b174-555ab1278b4b.png)

If the others I agree I have to check that I didn't miss to remove anything related and didn't remove too much.