### PR TITLE
4.26 I-Build: I20220915-0110 - Comparator Errors Found

### DIFF
--- a/ui/org.eclipse.pde.launching/forceQualifierUpdate.txt
+++ b/ui/org.eclipse.pde.launching/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 
 Bug 578351 - Lambda generation order is unstable in ecj 
 Bug 579126 - 4.24 I-Build: I20220307-0340 - Comparator Errors Found
+4.26 I-Build: I20220915-0110 - Comparator Errors Found


### PR DESCRIPTION
The issue is with lambda order 