### PR TITLE
E4 toolbar contribution template fixed

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.pde.ui.templates;singleton:=true
-Bundle-Version: 3.7.700.qualifier
+Bundle-Version: 3.7.800.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.pde.internal.ui.templates;x-internal:=true,

--- a/ui/org.eclipse.pde.ui.templates/src/org/eclipse/pde/internal/ui/templates/e4/E4ToolbarContributionTemplate.java
+++ b/ui/org.eclipse.pde.ui.templates/src/org/eclipse/pde/internal/ui/templates/e4/E4ToolbarContributionTemplate.java
@@ -113,7 +113,7 @@ public class E4ToolbarContributionTemplate extends PDETemplateSection {
 		extension.setId(getValue(KEY_PACKAGE_NAME) + ".fragment"); //$NON-NLS-1$
 
 		element.setName("fragment"); //$NON-NLS-1$
-		element.setAttribute("apply", "apply"); //$NON-NLS-1$ //$NON-NLS-2$
+		element.setAttribute("apply", "always"); //$NON-NLS-1$ //$NON-NLS-2$
 		element.setAttribute("uri", E4_FRAGMENT_FILE); //$NON-NLS-1$
 
 		extension.add(element);


### PR DESCRIPTION
Currently the E4 toolbar template uses 	element.setAttribute("apply", "apply") which is incorrect, apply is not a valid entry, we should use always.