### PR TITLE
Also save HTML to Clipboard when we save RTF (#89)

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildEditor.java
@@ -147,7 +147,11 @@ public class BuildEditor extends MultiSourceEditor {
 	protected boolean hasKnownTypes() {
 		try {
 			TransferData[] types = getClipboard().getAvailableTypes();
-			Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+			Transfer[] transfers = new Transfer[] {
+					TextTransfer.getInstance(),
+					HTMLTransfer.getInstance(),
+					RTFTransfer.getInstance()
+			};
 			for (TransferData type : types) {
 				for (Transfer transfer : transfers) {
 					if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryDetailsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryDetailsSection.java
@@ -112,7 +112,11 @@ public class CategoryDetailsSection extends PDESection implements IPartSelection
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/IUDetailsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/IUDetailsSection.java
@@ -60,7 +60,11 @@ abstract class IUDetailsSection<T extends IVersionable> extends PDESection imple
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] { TextTransfer.getInstance(), RTFTransfer.getInstance() };
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type)) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/DataPortabilitySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/DataPortabilitySection.java
@@ -110,7 +110,11 @@ public class DataPortabilitySection extends PDESection implements IPartSelection
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureEditor.java
@@ -341,7 +341,11 @@ public class FeatureEditor extends MultiSourceEditor implements IShowEditorInput
 	protected boolean hasKnownTypes() {
 		try {
 			TransferData[] types = getClipboard().getAvailableTypes();
-			Transfer[] transfers = new Transfer[] { TextTransfer.getInstance(), RTFTransfer.getInstance() };
+			Transfer[] transfers = new Transfer[] {
+					TextTransfer.getInstance(),
+					HTMLTransfer.getInstance(),
+					RTFTransfer.getInstance()
+			};
 			for (TransferData type : types) {
 				for (Transfer transfer : transfers) {
 					if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureSpecSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureSpecSection.java
@@ -552,7 +552,11 @@ public class FeatureSpecSection extends PDESection {
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/IncludedFeaturesPortabilitySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/IncludedFeaturesPortabilitySection.java
@@ -110,7 +110,11 @@ public class IncludedFeaturesPortabilitySection extends PDESection implements IP
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/PortabilitySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/PortabilitySection.java
@@ -106,7 +106,11 @@ public class PortabilitySection extends PDESection {
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/URLDetailsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/URLDetailsSection.java
@@ -219,7 +219,11 @@ public class URLDetailsSection extends PDESection implements IPartSelectionListe
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/CategoryDetailsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/CategoryDetailsSection.java
@@ -114,7 +114,11 @@ public class CategoryDetailsSection extends PDESection implements IPartSelection
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/DescriptionSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/DescriptionSection.java
@@ -207,7 +207,11 @@ public class DescriptionSection extends PDESection {
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/FeatureDetailsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/FeatureDetailsSection.java
@@ -83,7 +83,11 @@ public class FeatureDetailsSection extends PDESection implements IPartSelectionL
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/MirrorsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/MirrorsSection.java
@@ -127,7 +127,11 @@ public class MirrorsSection extends PDESection {
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/PortabilitySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/PortabilitySection.java
@@ -115,7 +115,11 @@ public class PortabilitySection extends PDESection implements IPartSelectionList
 	@Override
 	public boolean canPaste(Clipboard clipboard) {
 		TransferData[] types = clipboard.getAvailableTypes();
-		Transfer[] transfers = new Transfer[] {TextTransfer.getInstance(), RTFTransfer.getInstance()};
+		Transfer[] transfers = new Transfer[] {
+				TextTransfer.getInstance(),
+				HTMLTransfer.getInstance(),
+				RTFTransfer.getInstance()
+		};
 		for (TransferData type : types) {
 			for (Transfer transfer : transfers) {
 				if (transfer.isSupportedType(type))


### PR DESCRIPTION
TLDR:

A few weeks ago we added HTML support when copying to Clipboard from StyledText.
It used to be RTF only.

This PR changes code that explicitly use `TextTransfer` and `RTFTransfer` to also use `HTMLTransfer`. 

---

The original bug was filed here:
https://github.com/eclipse-platform/eclipse.platform.text/issues/101

Very likely that is the wrong place, but at the time I didn't know where the fix will end up.
Let me know if you want me to file an equivalent bug here (or close than one and open it here)

Thank you,
Mihai
