### PR TITLE
Add support for dynamically contribute bundle source locations

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.15.400.qualifier
+Bundle-Version: 3.16.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -16,6 +16,7 @@
 <plugin>
 
      <extension-point id="source" name="%expoint.source.name" schema="schema/source.exsd"/>
+     <extension-point id="dynamicSource" name="%expoint.source.name" schema="schema/dynamicSource.exsd"/>
      <extension-point id="javadoc" name="%expoint.javadoc.name" schema="schema/javadoc.exsd"/>
      <extension-point id="targets" name="%expoint.target.name" schema="schema/targets.exsd"/>
      <extension-point id="targetLocations" name="%expoint.targetlocation.name" schema="schema/targetLocations.exsd"/>
@@ -400,4 +401,9 @@
              class="org.eclipse.pde.internal.core.annotations.OSGiAnnotationsClasspathContributor">
        </contributor>
     </extension>
+        <extension
+          point="org.eclipse.pde.core.dynamicSource">
+          <locator class="org.eclipse.pde.internal.core.EclipsePluginSourcePathLocator" />
+          <locator class="org.eclipse.pde.internal.core.LocalMavenPluginSourcePathLocator" />
+    </extension> 
 </plugin>

--- a/ui/org.eclipse.pde.core/schema/dynamicSource.exsd
+++ b/ui/org.eclipse.pde.core/schema/dynamicSource.exsd
@@ -20,30 +20,7 @@
          <choice minOccurs="1" maxOccurs="unbounded">
             <element ref="locator"/>
          </choice>
-         <attribute name="point" type="string" use="required">
-            <annotation>
-               <documentation>
-                  
-               </documentation>
-            </annotation>
-         </attribute>
-         <attribute name="id" type="string">
-            <annotation>
-               <documentation>
-                  
-               </documentation>
-            </annotation>
-         </attribute>
-         <attribute name="name" type="string">
-            <annotation>
-               <documentation>
-                  
-               </documentation>
-               <appInfo>
-                  <meta.attribute translatable="true"/>
-               </appInfo>
-            </annotation>
-         </attribute>
+         <attribute name="point" type="string" use="required"/>
       </complexType>
    </element>
 
@@ -76,14 +53,14 @@
          <meta.section type="examples"/>
       </appInfo>
       <documentation>
-         The following is an example of the &lt;code&gt;source&lt;/code&gt; extension:
+         The following is an example of the &lt;code&gt;dynamicSource&lt;/code&gt; extension:
 &lt;pre&gt;
- &lt;extension point = &quot;org.eclipse.pde.core.source&quot;&gt;
-     &lt;location path=&quot;src&quot;/&gt;
+ &lt;extension point = &quot;org.eclipse.pde.core.dynamicSource&quot;&gt;
+     &lt;locator class=&quot;foo.bar.CustomSourcePathLocator&quot; /&gt;
   &lt;/extension&gt;
 &lt;/pre&gt;
 
-In the example above, the source location &lt;code&gt;src&lt;/code&gt; in the contributing plug-in has been registered.
+In the example above, the new &lt;code&gt;foo.bar.CustomSourcePathLocator&lt;/code&gt; in the contributing plug-in has been registered.
       </documentation>
    </annotation>
 
@@ -92,7 +69,7 @@ In the example above, the source location &lt;code&gt;src&lt;/code&gt; in the co
          <meta.section type="apiInfo"/>
       </appInfo>
       <documentation>
-         No Java code is required for this extension point.
+         Each contributor must provide a class that implements &lt;code&gt;org.eclipse.pde.core.IPluginSourcePathLocator&lt;/code&gt;
       </documentation>
    </annotation>
 
@@ -110,7 +87,7 @@ In the example above, the source location &lt;code&gt;src&lt;/code&gt; in the co
          <meta.section type="copyright"/>
       </appInfo>
       <documentation>
-         Copyright (c) 2004 IBM Corporation and others.
+         Copyright (c) 2022 Christoph Läubrich and others.
 &lt;br&gt;
 
 This program and the accompanying materials are made 

--- a/ui/org.eclipse.pde.core/schema/dynamicSource.exsd
+++ b/ui/org.eclipse.pde.core/schema/dynamicSource.exsd
@@ -1,0 +1,125 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.pde.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.eclipse.pde.core" id="dynamicSource" name="Dynamic Source Locations"/>
+      </appInfo>
+      <documentation>
+         This extension point allows PDE to find source archives for libraries at runtime.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="locator"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="locator">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Provides the locator used to find the source-path for the given plugin model
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.pde.core.IPluginSourcePathLocator"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         2.0
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         The following is an example of the &lt;code&gt;source&lt;/code&gt; extension:
+&lt;pre&gt;
+ &lt;extension point = &quot;org.eclipse.pde.core.source&quot;&gt;
+     &lt;location path=&quot;src&quot;/&gt;
+  &lt;/extension&gt;
+&lt;/pre&gt;
+
+In the example above, the source location &lt;code&gt;src&lt;/code&gt; in the contributing plug-in has been registered.
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiInfo"/>
+      </appInfo>
+      <documentation>
+         No Java code is required for this extension point.
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         Eclipse SDK comes with source plug-ins that contain source information for all the plug-ins and fragments in Eclipse SDK.
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="copyright"/>
+      </appInfo>
+      <documentation>
+         Copyright (c) 2004 IBM Corporation and others.
+&lt;br&gt;
+
+This program and the accompanying materials are made 
+available under the terms of the Eclipse Public License 2.0 which 
+accompanies this distribution, and is available at 
+&lt;a href=&quot;https://www.eclipse.org/legal/epl-2.0&quot;&gt;https://www.eclipse.org/legal/epl-v20.html&lt;/a&gt;/
+
+SPDX-License-Identifier: EPL-2.0.
+      </documentation>
+   </annotation>
+
+</schema>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IPluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IPluginSourcePathLocator.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.core;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.pde.core.plugin.IPluginBase;
+
+/**
+ * A plugin source path locator is capable of locating the path of the source
+ * for a given plugin.
+ * <p>
+ * A plugin source path locator is declared as an extension
+ * (<code>org.eclipse.pde.core.source</code>).
+ * </p>
+ *
+ * @since 3.16
+ */
+public interface IPluginSourcePathLocator {
+
+	IPath locateSource(IPluginBase plugin);
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -192,25 +192,6 @@ public class ClasspathUtilCore {
 			SourceLocationManager manager = PDECore.getDefault().getSourceLocationManager();
 			path = manager.findSourcePath(model.getPluginBase(), new Path(zipName));
 		}
-		// search a co-located source bundle
-		if (path == null && isJarShape) {
-			// ...for example in a bundle pool blah-123.jar => blah.source-123.jar...
-			File loc = new File(model.getInstallLocation());
-			File sourceFile = new File(loc.getParentFile(),
-					model.getPluginBase().getId() + ".source_" + model.getPluginBase().getVersion() + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
-			if (sourceFile.isFile()) {
-				path = new Path(sourceFile.getAbsolutePath());
-			} else if (model.getInstallLocation() != null) {
-				// ... or in usual Maven covention blah-123.jar =>
-				// blah-123-sources.jar
-				String bundleFileName = loc.getName();
-				String sourceFileName = bundleFileName.substring(0, bundleFileName.indexOf(".jar")) + "-sources.jar"; //$NON-NLS-1$ //$NON-NLS-2$
-				sourceFile = new File(loc.getParentFile(), sourceFileName);
-				if (sourceFile.isFile()) {
-					path = new Path(sourceFile.getAbsolutePath());
-				}
-			}
-		}
 		return path;
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/EclipsePluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/EclipsePluginSourcePathLocator.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.io.File;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.pde.core.IPluginSourcePathLocator;
+import org.eclipse.pde.core.plugin.IPluginBase;
+import org.eclipse.pde.core.plugin.ISharedPluginModel;
+
+/**
+ * A plugin source path locator that uses for a co-located source bundle in the
+ * same directory. This could be e.g the case for bundle pools or products with
+ * a plugin folder.
+ */
+public class EclipsePluginSourcePathLocator implements IPluginSourcePathLocator {
+
+	@Override
+	public IPath locateSource(IPluginBase plugin) {
+		ISharedPluginModel model = plugin.getModel();
+		String installLocation = model.getInstallLocation();
+		if (installLocation != null) {
+			File path = new File(installLocation);
+			if (path.isFile()) {
+				File sourceFile = new File(path.getParentFile(),
+						plugin.getId() + ".source_" + plugin.getVersion() + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
+				if (sourceFile.isFile()) {
+					return new Path(sourceFile.getAbsolutePath());
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/EclipsePluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/EclipsePluginSourcePathLocator.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.pde.core.IPluginSourcePathLocator;
 import org.eclipse.pde.core.plugin.IPluginBase;
-import org.eclipse.pde.core.plugin.ISharedPluginModel;
 
 /**
  * A plugin source path locator that uses for a co-located source bundle in the
@@ -29,16 +28,13 @@ public class EclipsePluginSourcePathLocator implements IPluginSourcePathLocator 
 
 	@Override
 	public IPath locateSource(IPluginBase plugin) {
-		ISharedPluginModel model = plugin.getModel();
-		String installLocation = model.getInstallLocation();
+		String installLocation = plugin.getModel().getInstallLocation();
 		if (installLocation != null) {
-			File path = new File(installLocation);
-			if (path.isFile()) {
-				File sourceFile = new File(path.getParentFile(),
-						plugin.getId() + ".source_" + plugin.getVersion() + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
-				if (sourceFile.isFile()) {
-					return new Path(sourceFile.getAbsolutePath());
-				}
+			// For example in a bundle pool foo_123.jar => foo.source_123.jar...
+			File container = new File(installLocation).getParentFile();
+			File sourceFile = new File(container, plugin.getId() + ".source_" + plugin.getVersion() + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
+			if (sourceFile.isFile()) {
+				return new Path(sourceFile.getAbsolutePath());
 			}
 		}
 		return null;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/LocalMavenPluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/LocalMavenPluginSourcePathLocator.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - extracted from ClasspathUtilCore
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.io.File;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.pde.core.IPluginSourcePathLocator;
+import org.eclipse.pde.core.plugin.IPluginBase;
+import org.eclipse.pde.core.plugin.ISharedPluginModel;
+
+/**
+ * Check if there is already a local maven source bundle available
+ *
+ */
+public class LocalMavenPluginSourcePathLocator implements IPluginSourcePathLocator {
+
+	@Override
+	public IPath locateSource(IPluginBase plugin) {
+		ISharedPluginModel model = plugin.getModel();
+		String installLocation = model.getInstallLocation();
+		if (installLocation != null) {
+			File path = new File(installLocation);
+			if (path.isFile()) {
+				// The usual Maven covention blah-123.jar =>
+				// blah-123-sources.jar
+				String bundleFileName = path.getName();
+				String sourceFileName = bundleFileName.substring(0, bundleFileName.indexOf(".jar")) + "-sources.jar"; //$NON-NLS-1$ //$NON-NLS-2$
+				File sourceFile = new File(path.getParentFile(), sourceFileName);
+				if (sourceFile.isFile()) {
+					return new Path(sourceFile.getAbsolutePath());
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/LocalMavenPluginSourcePathLocator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/LocalMavenPluginSourcePathLocator.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.pde.core.IPluginSourcePathLocator;
 import org.eclipse.pde.core.plugin.IPluginBase;
-import org.eclipse.pde.core.plugin.ISharedPluginModel;
 
 /**
  * Check if there is already a local maven source bundle available
@@ -28,19 +27,15 @@ public class LocalMavenPluginSourcePathLocator implements IPluginSourcePathLocat
 
 	@Override
 	public IPath locateSource(IPluginBase plugin) {
-		ISharedPluginModel model = plugin.getModel();
-		String installLocation = model.getInstallLocation();
+		String installLocation = plugin.getModel().getInstallLocation();
 		if (installLocation != null) {
 			File path = new File(installLocation);
-			if (path.isFile()) {
-				// The usual Maven covention blah-123.jar =>
-				// blah-123-sources.jar
-				String bundleFileName = path.getName();
-				String sourceFileName = bundleFileName.substring(0, bundleFileName.indexOf(".jar")) + "-sources.jar"; //$NON-NLS-1$ //$NON-NLS-2$
-				File sourceFile = new File(path.getParentFile(), sourceFileName);
-				if (sourceFile.isFile()) {
-					return new Path(sourceFile.getAbsolutePath());
-				}
+			// The usual Maven covention foo-123.jar => foo-123-sources.jar
+			String bundleFileName = path.getName();
+			String sourceFileName = bundleFileName.substring(0, bundleFileName.indexOf(".jar")) + "-sources.jar"; //$NON-NLS-1$ //$NON-NLS-2$
+			File sourceFile = new File(path.getParentFile(), sourceFileName);
+			if (sourceFile.isFile()) {
+				return new Path(sourceFile.getAbsolutePath());
 			}
 		}
 		return null;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
@@ -318,8 +318,7 @@ public class SourceLocationManager implements ICoreConstants {
 			}
 		}
 		return getExtensions().locators.stream().map(locator -> locator.locateSource(plugin)).filter(Objects::nonNull)
-				.findFirst()
-				.orElse(null);
+				.findFirst().orElse(null);
 	}
 
 	/**
@@ -446,7 +445,7 @@ public class SourceLocationManager implements ICoreConstants {
 	}
 
 	private static final class SourceExtensions {
-		Collection<SourceLocation> locations = new LinkedHashSet<>();
-		List<IPluginSourcePathLocator> locators = new ArrayList<>();
+		final Collection<SourceLocation> locations = new LinkedHashSet<>();
+		final List<IPluginSourcePathLocator> locators = new ArrayList<>();
 	}
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2013 IBM Corporation and others.
+ *  Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - Issue #202
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
@@ -21,16 +22,23 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.runtime.spi.RegistryContributor;
 import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.pde.core.IPluginSourcePathLocator;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.ModelEntry;
@@ -46,7 +54,7 @@ public class SourceLocationManager implements ICoreConstants {
 	/**
 	 * List of source locations that have been discovered using extension points
 	 */
-	private List<SourceLocation> fExtensionLocations = null;
+	private SourceExtensions fExtensionLocations;
 
 	/**
 	 * Manages locations of individual source bundles
@@ -74,7 +82,7 @@ public class SourceLocationManager implements ICoreConstants {
 		if (result == null) {
 			result = searchBundleManifestLocations(pluginBase);
 			if (result == null) {
-				result = searchExtensionLocations(relativePath);
+				result = searchExtensionLocations(relativePath, pluginBase);
 			}
 		}
 		return result;
@@ -108,7 +116,7 @@ public class SourceLocationManager implements ICoreConstants {
 					PDECore.log(e);
 				}
 			}
-			result = searchExtensionLocations(relativePath);
+			result = searchExtensionLocations(relativePath, pluginBase);
 		}
 		if (result != null) {
 			try {
@@ -211,7 +219,11 @@ public class SourceLocationManager implements ICoreConstants {
 	/**
 	 * @return array of source locations that have been added via extension point
 	 */
-	public List<SourceLocation> getExtensionLocations() {
+	public Collection<SourceLocation> getExtensionLocations() {
+		return getExtensions().locations;
+	}
+
+	private SourceExtensions getExtensions() {
 		if (fExtensionLocations == null) {
 			fExtensionLocations = processExtensions();
 		}
@@ -288,21 +300,26 @@ public class SourceLocationManager implements ICoreConstants {
 	}
 
 	/**
-	 * Searches through all known source locations added via extension points, appending
-	 * the relative path and checking if that file exists.
-	 * @param relativePath location of source file within the source location
-	 * @return path to the source file or <code>null</code> if one could not be found or if the file does not exist
+	 * Searches through all known source locations added via extension points,
+	 * appending the relative path and checking if that file exists.
+	 *
+	 * @param relativePath
+	 *            location of source file within the source location
+	 * @param plugin
+	 * @return path to the source file or <code>null</code> if one could not be
+	 *         found or if the file does not exist
 	 */
-	private IPath searchExtensionLocations(IPath relativePath) {
-		List<SourceLocation> extensionLocations = getExtensionLocations();
-		for (SourceLocation location : extensionLocations) {
+	private IPath searchExtensionLocations(IPath relativePath, IPluginBase plugin) {
+		for (SourceLocation location : getExtensionLocations()) {
 			IPath fullPath = location.getPath().append(relativePath);
 			File file = fullPath.toFile();
 			if (file.exists()) {
 				return fullPath;
 			}
 		}
-		return null;
+		return getExtensions().locators.stream().map(locator -> locator.locateSource(plugin)).filter(Objects::nonNull)
+				.findFirst()
+				.orElse(null);
 	}
 
 	/**
@@ -362,9 +379,10 @@ public class SourceLocationManager implements ICoreConstants {
 	/**
 	 * @return array of source locations that were added via extension point
 	 */
-	private static List<SourceLocation> processExtensions() {
-		ArrayList<SourceLocation> result = new ArrayList<>();
-		IExtension[] extensions = PDECore.getDefault().getExtensionsRegistry().findExtensions(PDECore.PLUGIN_ID + ".source", false); //$NON-NLS-1$
+	private static SourceExtensions processExtensions() {
+		SourceExtensions result = new SourceExtensions();
+		PDEExtensionRegistry extensionsRegistry = PDECore.getDefault().getExtensionsRegistry();
+		IExtension[] extensions = extensionsRegistry.findExtensions(PDECore.PLUGIN_ID + ".source", false); //$NON-NLS-1$
 		for (IExtension extension : extensions) {
 			IConfigurationElement[] children = extension.getConfigurationElements();
 			RegistryContributor contributor = (RegistryContributor) extension.getContributor();
@@ -394,9 +412,21 @@ public class SourceLocationManager implements ICoreConstants {
 					if (path.toFile().exists()) {
 						SourceLocation location = new SourceLocation(path);
 						location.setUserDefined(false);
-						if (!result.contains(location)) {
-							result.add(location);
-						}
+						result.locations.add(location);
+					}
+				}
+			}
+		}
+		// For the source locators we need to query the platform registry
+		IExtensionRegistry registry = Platform.getExtensionRegistry();
+		IExtensionPoint point = registry.getExtensionPoint(PDECore.PLUGIN_ID, "dynamicSource"); //$NON-NLS-1$
+		for (IExtension extension : point.getExtensions()) {
+			for (IConfigurationElement element : extension.getConfigurationElements()) {
+				if (element.getName().equals("locator")) { //$NON-NLS-1$
+					try {
+						result.locators.add((IPluginSourcePathLocator) element.createExecutableExtension("class")); //$NON-NLS-1$
+					} catch (CoreException e) {
+						PDECore.log(e.getStatus());
 					}
 				}
 			}
@@ -415,4 +445,8 @@ public class SourceLocationManager implements ICoreConstants {
 		return manager;
 	}
 
+	private static final class SourceExtensions {
+		Collection<SourceLocation> locations = new LinkedHashSet<>();
+		List<IPluginSourcePathLocator> locators = new ArrayList<>();
+	}
 }


### PR DESCRIPTION
Currently a plugin can contribute source locations inside the plugin itself through the extension point

org.eclipse.pde.core.source

this has the limitation that the source must be embedded and known in advance. In some situations it would be required to provide external locations dynamically e.g. maven has the concept of source artifacts that could be queried, if a bundle contains a Bundle-Source-Location one could checkout one could have a "source-repository" and so on.

This adds the necessary parts for a new extension point

org.eclipse.pde.core.dynamicSource

and a extracts the implementation that search for Eclipse/Maven co-located source bundles.

Part of #202