### PR TITLE
Also take metatype annotations into account

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -24,6 +24,7 @@
       <import plugin="org.osgi.annotation.versioning"/>
       <import plugin="org.osgi.annotation.bundle"/>
       <import plugin="org.osgi.service.component.annotations"/>
+      <import plugin="org.osgi.service.metatype.annotations" />
    </requires>
 
    <plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -39,8 +39,9 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
  */
 public class OSGiAnnotationsClasspathContributor implements IClasspathContributor {
 
-	private Collection<String> OSGI_ANNOTATIONS = List.of("org.osgi.annotation.versioning", //$NON-NLS-1$
-			"org.osgi.annotation.bundle", "org.osgi.service.component.annotations"); //$NON-NLS-1$ //$NON-NLS-2$
+	private static final Collection<String> OSGI_ANNOTATIONS = List.of("org.osgi.annotation.versioning", //$NON-NLS-1$
+			"org.osgi.annotation.bundle", "org.osgi.service.component.annotations", //$NON-NLS-1$ //$NON-NLS-2$
+			"org.osgi.service.metatype.annotations"); //$NON-NLS-1$
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {


### PR DESCRIPTION
The Metatype Service Specification defines a set of annotations to allow defining possible configuration options of a service as code.

These annotations are only retained at class level and can the used at build time to generate the proper XML definition, we should enable PDE users to use these annotations as well, so this information can then be used for example in Tycho or BND builds.

This depends on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/653