### PR TITLE
Import the service.event package instead of require the equinox bundle

### DIFF
--- a/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
@@ -15,7 +15,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources;bundle-version="3.8.100",
  org.eclipse.jdt.core;bundle-version="3.9.0",
  org.eclipse.jdt.ui;bundle-version="3.9.0",
- org.eclipse.osgi.services;bundle-version="3.3.100",
  org.eclipse.e4.ui.services;bundle-version="1.0.0",
  org.eclipse.jface.databinding,
  org.eclipse.core.databinding.observable,
@@ -24,7 +23,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.databinding.property;bundle-version="1.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.annotation;version="1.2.0"
+Import-Package: javax.annotation;version="1.2.0",
+ org.osgi.service.event;version="[1.4.0,2.0.0)"
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.spy.event
 Automatic-Module-Name: org.eclipse.e4.tools.event.spy

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -76,7 +76,6 @@ Export-Package:
 Require-Bundle: 
  org.eclipse.pde.core;bundle-version="[3.13.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.18.0,4.0.0)",
- org.eclipse.osgi.services;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.8.0,2.0.0)",
  org.eclipse.e4.core.services;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)",
@@ -122,7 +121,8 @@ Require-Bundle:
  org.eclipse.equinox.security;bundle-version="[1.2.200,2.0.0)"
 Eclipse-LazyStart: true
 Import-Package: org.eclipse.jdt.debug.ui.console,
- org.eclipse.ui.internal.genericeditor
+ org.eclipse.ui.internal.genericeditor,
+ org.osgi.service.event;version="[1.4,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.pde.ui


### PR DESCRIPTION
OSGi services should really not be imported by requiring a specific provider, replacing the require-bundle with the appropriate import decouples the plugin from a specific implementation detail.