### PR TITLE
Add complexity attribute for source locators

### DIFF
--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -403,7 +403,11 @@
     </extension>
         <extension
           point="org.eclipse.pde.core.dynamicSource">
-          <locator class="org.eclipse.pde.internal.core.EclipsePluginSourcePathLocator" />
-          <locator class="org.eclipse.pde.internal.core.LocalMavenPluginSourcePathLocator" />
+          <locator
+                class="org.eclipse.pde.internal.core.EclipsePluginSourcePathLocator"
+                complexity="low"/>
+          <locator
+                class="org.eclipse.pde.internal.core.LocalMavenPluginSourcePathLocator"
+                complexity="low"/>
     </extension> 
 </plugin>

--- a/ui/org.eclipse.pde.core/schema/dynamicSource.exsd
+++ b/ui/org.eclipse.pde.core/schema/dynamicSource.exsd
@@ -20,7 +20,13 @@
          <choice minOccurs="1" maxOccurs="unbounded">
             <element ref="locator"/>
          </choice>
-         <attribute name="point" type="string" use="required"/>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -35,6 +41,27 @@
                   <meta.attribute kind="java" basedOn=":org.eclipse.pde.core.IPluginSourcePathLocator"/>
                </appInfo>
             </annotation>
+         </attribute>
+         <attribute name="complexity" use="required">
+            <annotation>
+               <documentation>
+                  Gives a hint to the framework about how complex it is to compute if sources can be found.
+
+low: computation includes just trivial steps, e.g. check if a file exits in the local file system.
+medium: computation includes some more steps e.g iterate over some kind of objects store in linear time or look into the content of local files.
+high: computation includes steps that can potentially reach out to remote systems to find a suitable source item
+               </documentation>
+            </annotation>
+            <simpleType>
+               <restriction base="string">
+                  <enumeration value="low">
+                  </enumeration>
+                  <enumeration value="medium">
+                  </enumeration>
+                  <enumeration value="high">
+                  </enumeration>
+               </restriction>
+            </simpleType>
          </attribute>
       </complexType>
    </element>


### PR DESCRIPTION
This enables dynamic source providers to state how complex there computation is so the using code can decide to query faster ones first, or even decide if showing some progress or scheduling jobs is suitable.

@vik-chand I'd like to get approval for this to be included in RC2 because of the following reasons:

1. The extension point was only added in this release (and relative late) so there are no consumers we can break or where there are issues
2. this intentionally do not contain any code changes (what could be done in 2023-03 release) but possible implements should be forced to define this property from day-1 so we have the information available.