### PR TITLE
Deprecate ApiFileGenerationApplication

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiFileGenerationApplication.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiFileGenerationApplication.java
@@ -17,10 +17,17 @@ import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.eclipse.pde.api.tools.internal.provisional.ApiPlugin;
 
+/**
+ * Prefer using the tycho-apitools-plugin to generate the api description file
+ *
+ */
+@Deprecated
 public class ApiFileGenerationApplication implements IApplication {
 
+	private static String DEPRECATION_WARNING = "DEPRECATED, PLEASE MOVE TO THE tycho-apitools-plugin TO GENERATE THE API DESCRIPTION FILE"; //$NON-NLS-1$
 	@Override
 	public Object start(IApplicationContext context) throws Exception {
+		ApiPlugin.logErrorMessage(DEPRECATION_WARNING);
 		APIFileGenerator generator = new APIFileGenerator();
 		String[] args = (String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS);
 		generator.projectName = find("projectName", args); //$NON-NLS-1$


### PR DESCRIPTION
Eclipse platform migrated to Tycho for generating the API baseline. Yon also also add the generation to your Tycho build. Also platform is not using this application anymore it is now deprecated and may be deleted in the future-

 </plugin>
			<plugin>
	            <groupId>org.eclipse.tycho</groupId>
				<artifactId>tycho-apitools-plugin</artifactId>
	            <version>${tycho.version}</version>
				<executions>
					<execution>
						<id>generate</id>
						<goals>
							<goal>generate</goal>
						</goals>
						<configuration>
                  			<skip>${skipAPIDescription}</skip>
                  			<projectName>${project.artifactId}_${qualifiedVersion}</projectName>
laeubi marked this conversation as resolved.
						</configuration>
					</execution>
				</executions>
			</plugin>