### PR TITLE
Move o.e.pde.ui.tests.smartimport to Java 17 BREE

### DIFF
--- a/ui/org.eclipse.pde.ui.tests.smartimport/.classpath
+++ b/ui/org.eclipse.pde.ui.tests.smartimport/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/">
 		<attributes>

--- a/ui/org.eclipse.pde.ui.tests.smartimport/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests.smartimport/.settings/org.eclipse.jdt.core.prefs
@@ -1,13 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16

--- a/ui/org.eclipse.pde.ui.tests.smartimport/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests.smartimport/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Smart Import test for PDE
 Bundle-SymbolicName: org.eclipse.pde.ui.tests.smartimport;singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.ui.tests.smartimport
 Require-Bundle: org.eclipse.core.resources,
@@ -23,5 +23,5 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.pde.ui
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.pde.ui.tests.smartimport

--- a/ui/org.eclipse.pde.ui.tests.smartimport/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests.smartimport/pom.xml
@@ -15,7 +15,7 @@
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.pde.ui.tests.smartimport</artifactId>
-	<version>1.1.100-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>


### PR DESCRIPTION
It uses RedDeer which itself moved to require Java 17. Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/648