### PR TITLE
Lookup source bundles in the current target platform

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.16.0.qualifier
+Bundle-Version: 3.16.100.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEState.java
@@ -38,6 +38,7 @@ import org.eclipse.pde.internal.core.plugin.ExternalFragmentModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModelBase;
 import org.eclipse.pde.internal.core.util.CoreUtility;
+import org.eclipse.pde.internal.core.util.ManifestUtils;
 import org.osgi.framework.Version;
 
 public class PDEState extends MinimalState {
@@ -165,7 +166,9 @@ public class PDEState extends MinimalState {
 				subMonitor.subTask(file.getName());
 				addBundle(file, -1);
 			} catch (CoreException e) {
-				PDECore.log(e);
+				if (e.getStatus().getCode() != ManifestUtils.STATUS_CODE_NOT_A_BUNDLE_MANIFEST) {
+					PDECore.log(e);
+				}
 			}
 			subMonitor.split(1);
 		}


### PR DESCRIPTION
Currently a "source bundle" is required to have a special header so PDE can discover it, but actually certain location types (e.g. P2 Sites and maven) have other ways to identify/discover the source bundle. Even the Targetplatform model already has the concept of a location that knows about the source for a bundle.

This adds a sourcepath locator that is capable of discovering such native source bundles from the target platform location and implements an ordered lookup that first queries lower complexity locators.