### PR TITLE
Do not explicitly include commons-io in template

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.5/E4Application/$pluginId$.product
@@ -25,7 +25,6 @@
       <plugin id="org.apache.batik.css"/>
       <plugin id="org.apache.batik.i18n"/>
       <plugin id="org.apache.batik.util"/>
-      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
       <plugin id="org.apache.felix.scr"/>


### PR DESCRIPTION
Nothing requires it directly and Maven central and Orbit had different symbolic names so better let the tooling resolve whatever it needs(if at all).