### PR TITLE
[Editor] Consider complete Set of launched Bundles in Product-validation

### DIFF
--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for PDE templates
 Bundle-SymbolicName: org.eclipse.pde.ui.templates.tests
-Bundle-Version: 1.1.200.qualifier
+Bundle-Version: 1.1.300.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: tests.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/ui/org.eclipse.pde.ui.templates.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.templates.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.templates.tests</artifactId>
-  <version>1.1.200-SNAPSHOT</version>
+  <version>1.1.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -23,16 +23,14 @@ import java.util.stream.Collectors;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
-import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.ds.internal.annotations.Messages;
 import org.eclipse.pde.internal.core.ICoreConstants;
-import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.builders.CompilerFlags;
 import org.eclipse.pde.internal.core.builders.PDEMarkerFactory;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
-import org.eclipse.pde.internal.core.iproduct.IProductPlugin;
 import org.eclipse.pde.internal.core.product.WorkspaceProductModel;
 import org.eclipse.pde.internal.launching.launcher.ProductValidationOperation;
+import org.eclipse.pde.internal.ui.launcher.LaunchAction;
 import org.eclipse.pde.internal.ui.wizards.IProjectProvider;
 import org.eclipse.pde.internal.ui.wizards.WizardElement;
 import org.eclipse.pde.internal.ui.wizards.plugin.*;
@@ -175,12 +173,7 @@ public class TestPDETemplates {
 		model.load();
 		IProduct product = model.getProduct();
 
-		Set<IPluginModelBase> launchPlugins = new HashSet<>();
-		for (IProductPlugin plugin : product.getPlugins()) {
-			IPluginModelBase pluginModel = PluginRegistry.findModel(plugin.getId());
-			if (pluginModel != null && TargetPlatformHelper.matchesCurrentEnvironment(pluginModel))
-				launchPlugins.add(pluginModel);
-		}
+		Set<IPluginModelBase> launchPlugins = LaunchAction.getLaunchedBundlesForProduct(product);
 
 		ProductValidationOperation validationOperation = new ProductValidationOperation(launchPlugins);
 		validationOperation.run(new NullProgressMonitor());

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductValidateAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductValidateAction.java
@@ -28,7 +28,7 @@ import org.eclipse.swt.SWT;
 
 public class ProductValidateAction extends Action {
 
-	IProduct fProduct;
+	private final IProduct fProduct;
 
 	public ProductValidateAction(IProduct product) {
 		super(PDEUIMessages.ProductValidateAction_validate, IAction.AS_PUSH_BUTTON);
@@ -38,8 +38,8 @@ public class ProductValidateAction extends Action {
 
 	@Override
 	public void run() {
-		Set<IPluginModelBase> launchPlugins = LaunchAction.getModels(fProduct);
 		try {
+			Set<IPluginModelBase> launchPlugins = LaunchAction.getLaunchedBundlesForProduct(fProduct);
 			LaunchValidationOperation operation = new ProductValidationOperation(launchPlugins);
 			LaunchPluginValidator.runValidationOperation(operation, new NullProgressMonitor());
 			if (!operation.hasErrors()) {


### PR DESCRIPTION
The Validation provided in the Product-Editor only considered the Set of Plug-ins/Bundles directly contained in the product and did not consider transitive dependencies included in launches of the product. With this change this is fixed so that the Validation in the Product-Editor sees the same set of Bundles like the validation when the product is really being launched.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/306
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/343
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/437
Required for https://github.com/eclipse-pde/eclipse.pde/pull/434