### PR TITLE
complete the help text content of the browser plugin template

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/plugin.properties
+++ b/ui/org.eclipse.pde.ui.templates/plugin.properties
@@ -280,6 +280,9 @@ creating a category. The view can be opened by selecting \
 <b>Window</b>, <b>Show View</b> and then <b>Other...</b> \
 on the menu bar. The template demonstrates how data can be exchanged \
 between Java and JavaScript in the browser.
+<p><b>Extension Used</b></p>\
+<li>org.eclipse.ui.views</li>
+<li>org.eclipse.ui.perspectiveExtensions</li>
 
 template.multiPageEditor.name = Multi-page Editor
 template.multiPageEditor.desc = This template creates a \

--- a/ui/org.eclipse.pde.ui.templates/plugin.properties
+++ b/ui/org.eclipse.pde.ui.templates/plugin.properties
@@ -68,7 +68,10 @@ pluginContent.browserview.name = View using browser technology
 pluginContent.browserview.description=\
 <p>This wizard creates a standard plug-in directory structure and \
 adds the following:</p>\
-<li><b>Browser view</b>. %template.browserview.desc%</li>
+<li><b>Browser view</b>. %template.browserview.desc%</li>\
+<p><b>Extensions Used</b></p>\
+<li>org.eclipse.ui.views</li>\
+<li>org.eclipse.ui.perspectiveExtensions</li>
 
 pluginContent.view.name = View contribution using 3.x API
 pluginContent.view.description=\
@@ -279,10 +282,7 @@ The view is contributed to the workbench by \
 creating a category. The view can be opened by selecting \
 <b>Window</b>, <b>Show View</b> and then <b>Other...</b> \
 on the menu bar. The template demonstrates how data can be exchanged \
-between Java and JavaScript in the browser.\
-<p><b>Extensions Used</b></p>\
-<li>org.eclipse.ui.views</li>\
-<li>org.eclipse.ui.perspectiveExtensions</li>
+between Java and JavaScript in the browser.
 
 template.multiPageEditor.name = Multi-page Editor
 template.multiPageEditor.desc = This template creates a \

--- a/ui/org.eclipse.pde.ui.templates/plugin.properties
+++ b/ui/org.eclipse.pde.ui.templates/plugin.properties
@@ -279,9 +279,9 @@ The view is contributed to the workbench by \
 creating a category. The view can be opened by selecting \
 <b>Window</b>, <b>Show View</b> and then <b>Other...</b> \
 on the menu bar. The template demonstrates how data can be exchanged \
-between Java and JavaScript in the browser.
-<p><b>Extension Used</b></p>\
-<li>org.eclipse.ui.views</li>
+between Java and JavaScript in the browser.\
+<p><b>Extensions Used</b></p>\
+<li>org.eclipse.ui.views</li>\
 <li>org.eclipse.ui.perspectiveExtensions</li>
 
 template.multiPageEditor.name = Multi-page Editor


### PR DESCRIPTION
the information on the actual extensions used in the browser plugin template was missed out in the help text associated with the plugin template selection view, for some reason. incorporate that info, so that the help page reflects the actuals.

**generated plugin.xml:**

![image](https://user-images.githubusercontent.com/6447530/214764991-84b34d42-405d-431a-af9b-51a88cb59ee7.png)

**template wizard help text:**

<img width="582" alt="Screenshot 2023-01-26 at 11 00 30 AM" src="https://user-images.githubusercontent.com/6447530/214765114-83839f7f-4921-4d68-8603-e7a51d7ed3d9.png">

