### PR TITLE
Honor multiple versions of same bundle in launch config

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -45,7 +45,8 @@ Require-Bundle: org.junit,
  org.eclipse.ui.ide.application
 Import-Package: org.assertj.core.api;version="3.14.0",
  org.assertj.core.presentation;version="3.21.0",
- org.junit.jupiter.api.function;version="5.8.1"
+ org.junit.jupiter.api.function;version="5.8.1",
+ org.eclipse.pde.internal.build
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Eclipse-BundleShape: dir


### PR DESCRIPTION
Do not consider only bundle id when generating the runtime metadata, resolving to actually configured bundle as soon as possible.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/433