### PR TITLE
Simplify implementations of IApiTypeContainer.getPackageNames()

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/TypeScope.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/TypeScope.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.pde.api.tools.internal.builder;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -60,22 +59,13 @@ public class TypeScope extends ApiElement implements IApiTypeContainer {
 		fPackageToTypes = new HashMap<>();
 		for (IReferenceTypeDescriptor type : types) {
 			String name = type.getPackage().getName();
-			Set<IReferenceTypeDescriptor> set = fPackageToTypes.get(name);
-			if (set == null) {
-				set = new HashSet<>();
-				fPackageToTypes.put(name, set);
-			}
-			set.add(type);
+			fPackageToTypes.computeIfAbsent(name, n -> new HashSet<>()).add(type);
 		}
 	}
 
 	@Override
 	public String[] getPackageNames() throws CoreException {
-		Set<String> pkgs = fPackageToTypes.keySet();
-		String[] result = new String[pkgs.size()];
-		pkgs.toArray(result);
-		Arrays.sort(result);
-		return result;
+		return fPackageToTypes.keySet().stream().sorted().toArray(String[]::new);
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/AbstractApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/AbstractApiTypeContainer.java
@@ -14,9 +14,10 @@
 package org.eclipse.pde.api.tools.internal.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -159,16 +160,13 @@ public abstract class AbstractApiTypeContainer extends ApiElement implements IAp
 
 	@Override
 	public String[] getPackageNames() throws CoreException {
-		List<String> names = new ArrayList<>();
+		SortedSet<String> names = new TreeSet<>();
 		IApiTypeContainer[] containers = getApiTypeContainers();
 		for (IApiTypeContainer container : containers) {
 			String[] packageNames = container.getPackageNames();
 			Collections.addAll(names, packageNames);
 		}
-		String[] result = new String[names.size()];
-		names.toArray(result);
-		Arrays.sort(result);
-		return result;
+		return names.toArray(String[]::new);
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/DirectoryApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/DirectoryApiTypeContainer.java
@@ -19,7 +19,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -193,11 +192,7 @@ public class DirectoryApiTypeContainer extends ApiElement implements IApiTypeCon
 	public String[] getPackageNames() throws CoreException {
 		init();
 		if (fPackageNames == null) {
-			List<String> names = new ArrayList<>(fPackages.keySet());
-			String[] result = new String[names.size()];
-			names.toArray(result);
-			Arrays.sort(result);
-			fPackageNames = result;
+			fPackageNames = fPackages.keySet().stream().sorted().toArray(String[]::new);
 		}
 		return fPackageNames;
 	}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/StubArchiveApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/StubArchiveApiTypeContainer.java
@@ -16,7 +16,6 @@ package org.eclipse.pde.api.tools.internal.model;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -223,11 +222,7 @@ public class StubArchiveApiTypeContainer extends ApiElement implements IApiTypeC
 		init();
 		synchronized (this) {
 			if (fPackageNames == null) {
-				Set<String> names = fPackages.keySet();
-				String[] result = new String[names.size()];
-				names.toArray(result);
-				Arrays.sort(result);
-				fPackageNames = result;
+				fPackageNames = fPackages.keySet().stream().sorted().toArray(String[]::new);
 			}
 			return fPackageNames;
 		}


### PR DESCRIPTION
and ensure the names are always unique and sorted.