### PR TITLE
Unify Maven build arguments into maven.config and remove unnecessary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,10 @@ jobs:
         mvn
         --batch-mode
         --global-toolchains ${{ github.workspace }}/.github/toolchains.xml
-        -Pbuild-individual-bundles
         -Pbree-libs
         -Papi-check
         -Dmaven.test.failure.ignore=true
-        -Dcompare-version-with-baselines.skip=false
-        -Dproject.build.sourceEncoding=UTF-8
-        -DtrimStackTrace=false
+        -Dmaven.test.error.ignore=true
         clean verify
     - name: Upload Test Results
       uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ Snap.*
 # maven
 /*/*/target/
 .DS_Store
-.polyglot.META-INF
-.polyglot.feature.xml
+.polyglot.*
+pom.tycho

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,4 @@
+-Pbuild-individual-bundles
+-Dcompare-version-with-baselines.skip=false
+-DtrimStackTrace=false
+--fail-at-end

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
 		timestamps()
 	}
 	agent {
-		label "centos-latest"
+		label 'centos-latest'
 	}
 	tools {
 		maven 'apache-maven-latest'
@@ -16,18 +16,19 @@ pipeline {
 		stage('Build') {
 			steps {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh """
-					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						-Pbuild-individual-bundles -Pbree-libs -Papi-check \
-						-Dcompare-version-with-baselines.skip=false \
-						-Dproject.build.sourceEncoding=UTF-8 \
-						-DtrimStackTrace=false
-					"""
+					sh '''
+						mvn clean verify --batch-mode -Dmaven.repo.local=$WORKSPACE/.m2/repository \
+						-Pbree-libs -Papi-check \
+						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
+					'''
 				}
 			}
 			post {
 				always {
-					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
+					archiveArtifacts(allowEmptyArchive: true, artifacts: '*.log, \
+						*/target/work/data/.metadata/*.log, \
+						*/tests/target/work/data/.metadata/*.log, \
+						apiAnalyzer-workspace/.metadata/*.log')
 					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
 					junit '**/target/surefire-reports/*.xml'
 				}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ How to build on the command line
 
 You need Maven 3.3.1 or later installed. Then you can run the build via the following command:
 
-`mvn clean verify -Pbuild-individual-bundles`
+`mvn clean verify`
 
 Contact:
 --------


### PR DESCRIPTION
Add a .mvn/maven.config that contains the maven arguments shared in the Jenkins-CI, GitHub workflow and for a local build. This also enables the 'build-individual-bundles' profile for all of the mentioned scenarios, so that one does not have to specify it manually anymore.

The profile 'bree-libs' is never definied in any pom.xml and therefore removed as CLI argument.
The property 'project.build.sourceEncoding=UTF-8' is already defined in the 'eclipse-platform-parent' pom and is therefore unnecessary.

In the Jenkins build additionally define the
properties'maven.test.error.ignore=true' and
'maven.test.failure.ignore=true' in order to only mark the build as unstable if there are test-failures/errors so that it is simpler to distinguish from other failures in the build.

In Jenkins not specifying '-Dmaven.repo.local=$WORKSPACE/.m2/repository' should the PDE-build use the default Maven-cache of the Jenkins container that is persisted so that dependencies are only downloaded once. Or did I understand this wrong or is there another reason to not use that default maven-cache?