### PR TITLE
Standardize name of the compiler in different property sheets

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.properties
+++ b/ui/org.eclipse.pde.ui/plugin.properties
@@ -143,7 +143,7 @@ differentiate between binary and source projects.
 
 PropertyPage.pluginDevelopment = Plug-in Development
 PropertyPage.selfHosting = Runtime Classpath
-PropertyPage.compilers = Compiler
+PropertyPage.compilers = Compilers
 Plugin.dependencies.container = Plug-in Dependencies
 
 Plugin.WorkingSet = Plug-ins and Fragments

--- a/ui/org.eclipse.pde.ui/plugin.properties
+++ b/ui/org.eclipse.pde.ui/plugin.properties
@@ -143,7 +143,7 @@ differentiate between binary and source projects.
 
 PropertyPage.pluginDevelopment = Plug-in Development
 PropertyPage.selfHosting = Runtime Classpath
-PropertyPage.compilers = Plug-in Manifest Compiler
+PropertyPage.compilers = Compiler
 Plugin.dependencies.container = Plug-in Dependencies
 
 Plugin.WorkingSet = Plug-ins and Fragments


### PR DESCRIPTION
The name of the compiler under the plug-in development property page is appearing differently in different contexts. Since we are already under the plugin development tab, just the name `Compiler` should suffice.

Eclipse preference property page:
![image](https://user-images.githubusercontent.com/122432113/216255034-f59437c5-24c8-4953-b53c-27878347e1fa.png)

Quick-fix property page:
![image](https://user-images.githubusercontent.com/122432113/216255194-c188c211-5c20-42f5-915e-2c401543290e.png)


