### PR TITLE
Dispose baselines more carefully, especially workspace baselines.

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiTestingEnvironment.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiTestingEnvironment.java
@@ -36,8 +36,11 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.tests.builder.TestingEnvironment;
 import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
+import org.eclipse.pde.api.tools.internal.ApiBaselineManager;
 import org.eclipse.pde.api.tools.internal.builder.ApiAnalysisBuilder;
+import org.eclipse.pde.api.tools.internal.model.WorkspaceBaseline;
 import org.eclipse.pde.api.tools.internal.provisional.ApiPlugin;
+import org.eclipse.pde.api.tools.internal.provisional.IApiBaselineManager;
 import org.eclipse.pde.api.tools.internal.provisional.IApiMarkerConstants;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
 import org.eclipse.pde.api.tools.model.tests.TestSuiteHelper;
@@ -505,6 +508,15 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 */
 	protected IApiBaseline getWorkspaceProfile() {
 		return ApiPlugin.getDefault().getApiBaselineManager().getWorkspaceBaseline();
+	}
+
+	public static void dispose(IApiBaseline apiBaseline) {
+		if (apiBaseline instanceof WorkspaceBaseline) {
+			IApiBaselineManager apiBaselineManager = ApiPlugin.getDefault().getApiBaselineManager();
+			((ApiBaselineManager) apiBaselineManager).disposeWorkspaceBaseline();
+		} else if (apiBaseline != null) {
+			apiBaseline.dispose();
+		}
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/OSGiLessAnalysisTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/OSGiLessAnalysisTests.java
@@ -72,7 +72,7 @@ public class OSGiLessAnalysisTests {
 		assertEquals(
 				"Mismatch in problems reported by analyzer.getProblems, returned values:" + Arrays.toString(problems), //$NON-NLS-1$
 				expectedIds, Arrays.stream(problems).map(IApiProblem::getId).collect(Collectors.toSet()));
-		baseline.dispose();
-		current.dispose();
+		ApiTestingEnvironment.dispose(baseline);
+		ApiTestingEnvironment.dispose(current);
 	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleMergeSplitTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleMergeSplitTests.java
@@ -99,11 +99,11 @@ public class BundleMergeSplitTests extends ApiBuilderTest {
 		IApiBaselineManager manager = ApiPlugin.getDefault().getApiBaselineManager();
 		manager.setDefaultApiBaseline(null);
 		manager.removeApiBaseline(API_BASELINE);
-		this.baseline.dispose();
+		ApiTestingEnvironment.dispose(this.baseline);
 		this.baseline = null;
 		IApiBaseline wsbaseline = manager.getWorkspaceBaseline();
 		if (wsbaseline != null) {
-			wsbaseline.dispose();
+			ApiTestingEnvironment.dispose(wsbaseline);
 		}
 		for (IProject project : getEnv().getWorkspace().getRoot().getProjects()) {
 			getEnv().removeProject(project.getFullPath());

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleVersionTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleVersionTests.java
@@ -115,8 +115,8 @@ public class BundleVersionTests extends ApiBuilderTest {
 		IApiBaselineManager manager = ApiPlugin.getDefault().getApiBaselineManager();
 		manager.setDefaultApiBaseline(null);
 		manager.removeApiBaseline(API_BASELINE);
-		this.baseline.dispose();
-		manager.getWorkspaceBaseline().dispose();
+		ApiTestingEnvironment.dispose(this.baseline);
+		ApiTestingEnvironment.dispose(manager.getWorkspaceBaseline());
 		this.baseline = null;
 		for (IProject project : getEnv().getWorkspace().getRoot().getProjects()) {
 			getEnv().removeProject(project.getFullPath());

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/performance/PerformanceTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/performance/PerformanceTest.java
@@ -20,6 +20,7 @@ import java.util.jar.JarFile;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -216,8 +217,10 @@ public abstract class PerformanceTest extends ApiBuilderTest {
 		IEclipsePreferences antuiprefs = InstanceScope.INSTANCE.getNode("org.eclipse.ant.ui"); //$NON-NLS-1$
 		antuiprefs.put("errorDialog", "false"); //$NON-NLS-1$ //$NON-NLS-2$
 
-		workspace.getDescription().setSnapshotInterval(Long.MAX_VALUE);
-		workspace.getDescription().setAutoBuilding(false);
+		IWorkspaceDescription description = workspace.getDescription();
+		description.setSnapshotInterval(Long.MAX_VALUE);
+		description.setAutoBuilding(false);
+		workspace.setDescription(description);
 
 		// Get projects directories
 		long start = System.currentTimeMillis();

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/DependentUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/DependentUsageTests.java
@@ -87,6 +87,7 @@ public class DependentUsageTests extends UsageTest {
 	 * @throws Exception if something bad happens
 	 */
 	protected void deployTest(String test, IPath usepath, IPath refpath, String refname, boolean addtag) throws Exception {
+		boolean autoBuilding = getEnv().getWorkspace().isAutoBuilding();
 		try {
 			getEnv().setAutoBuilding(false);
 			//copy source files and build
@@ -117,7 +118,9 @@ public class DependentUsageTests extends UsageTest {
 			}
 		}
 		finally {
-			getEnv().setAutoBuilding(true);
+			if (autoBuilding) {
+				getEnv().setAutoBuilding(true);
+			}
 		}
 	}
 

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/DeltaTestSetup.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/DeltaTestSetup.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.pde.api.tools.builder.tests.ApiTestingEnvironment;
 import org.eclipse.pde.api.tools.internal.builder.BuilderMessages;
 import org.eclipse.pde.api.tools.internal.provisional.comparator.ApiComparator;
 import org.eclipse.pde.api.tools.internal.provisional.comparator.IDelta;
@@ -214,12 +215,8 @@ public abstract class DeltaTestSetup {
 	@After
 	public void tearDown() throws Exception {
 		//clean up
-		if(this.after != null) {
-			this.after.dispose();
-		}
-		if(this.before != null) {
-			this.before.dispose();
-		}
+		ApiTestingEnvironment.dispose(this.after);
+		ApiTestingEnvironment.dispose(this.before);
 		// remove workspace root
 		assertTrue(TestSuiteHelper.delete(new File(WORKSPACE_ROOT.toOSString())));
 		FreezeMonitor.done();

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/ApiDescriptionTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/ApiDescriptionTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.Signature;
+import org.eclipse.pde.api.tools.builder.tests.ApiTestingEnvironment;
 import org.eclipse.pde.api.tools.internal.ApiDescription;
 import org.eclipse.pde.api.tools.internal.ApiDescriptionProcessor;
 import org.eclipse.pde.api.tools.internal.ApiDescriptionXmlCreator;
@@ -351,7 +352,7 @@ public class ApiDescriptionTests {
 		component.getApiDescription().accept(visitor, null);
 
 		assertTrue("Visit incomplete", visitOrder.isEmpty()); //$NON-NLS-1$
-		baseline.dispose();
+		ApiTestingEnvironment.dispose(baseline);
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/ComponentManifestTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/ComponentManifestTests.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.pde.api.tools.builder.tests.ApiTestingEnvironment;
 import org.eclipse.pde.api.tools.internal.BundleVersionRange;
 import org.eclipse.pde.api.tools.internal.RequiredComponentDescription;
 import org.eclipse.pde.api.tools.internal.model.ApiModelFactory;
@@ -72,7 +73,7 @@ public class ComponentManifestTests {
 				assertEquals("Wrong required component", reqs.get(i), requiredComponents[i]); //$NON-NLS-1$
 			}
 		} finally {
-			baseline.dispose();
+			ApiTestingEnvironment.dispose(baseline);
 		}
 	}
 
@@ -100,7 +101,7 @@ public class ComponentManifestTests {
 			assertTrue("org.eclipse.debug.core should be re-exported", debugCoreExport); //$NON-NLS-1$
 			assertFalse("Other components should not be re-exported", others); //$NON-NLS-1$
 		} finally {
-			baseline.dispose();
+			ApiTestingEnvironment.dispose(baseline);
 		}
 	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/search/tests/SearchTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/search/tests/SearchTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.pde.api.tools.builder.tests.ApiTestingEnvironment;
 import org.eclipse.pde.api.tools.internal.model.ApiModelFactory;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiComponent;
@@ -175,12 +176,8 @@ public abstract class SearchTest {
 
 	@After
 	public void tearDown() throws Exception {
-		if (this.baseline != null) {
-			this.baseline.dispose();
-		}
-		if (this.scope != null) {
-			this.scope.dispose();
-		}
+		ApiTestingEnvironment.dispose(this.baseline);
+		ApiTestingEnvironment.dispose(this.scope);
 		FreezeMonitor.done();
 	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/tests/AbstractApiTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/tests/AbstractApiTest.java
@@ -21,6 +21,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -34,6 +35,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
 import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
 import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.pde.api.tools.builder.tests.ApiTestingEnvironment;
 import org.eclipse.pde.api.tools.internal.provisional.ApiPlugin;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiComponent;
@@ -195,7 +197,7 @@ public class AbstractApiTest {
 		if (name == null) {
 			return;
 		}
-		getWorkspaceBaseline().dispose();
+		ApiTestingEnvironment.dispose(getWorkspaceBaseline());
 		IProject pro = getProject(name);
 		if (pro.exists()) {
 			ResourceEventWaiter waiter = new ResourceEventWaiter(new Path(name), IResourceChangeEvent.POST_CHANGE,
@@ -227,7 +229,13 @@ public class AbstractApiTest {
 	}
 
 	@BeforeClass
-	public static void beforeClass() {
+	public static void beforeClass() throws CoreException {
 		PDECore.getDefault().getPreferencesManager().setValue(ICoreConstants.RUN_API_ANALYSIS_AS_JOB, false);
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		if (workspace.isAutoBuilding()) {
+			IWorkspaceDescription description = workspace.getDescription();
+			description.setAutoBuilding(false);
+			workspace.setDescription(description);
+		}
 	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/ApiBaselineManagerTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/ApiBaselineManagerTests.java
@@ -57,6 +57,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.pde.api.tools.builder.tests.ApiTestingEnvironment;
 import org.eclipse.pde.api.tools.internal.ApiBaselineManager;
 import org.eclipse.pde.api.tools.internal.model.ApiModelFactory;
 import org.eclipse.pde.api.tools.internal.provisional.ApiPlugin;
@@ -895,7 +896,7 @@ public class ApiBaselineManagerTests extends AbstractApiTest {
 	@After
 	public void tearDown() throws Exception {
 		deleteProject(TESTING_PLUGIN_PROJECT_NAME);
-		getWorkspaceBaseline().dispose();
+		ApiTestingEnvironment.dispose(getWorkspaceBaseline());
 		super.tearDown();
 	}
 }

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
@@ -648,7 +648,7 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 	 * Disposes the workspace baseline such that a new one will be created on
 	 * the next request.
 	 */
-	void disposeWorkspaceBaseline() {
+	public void disposeWorkspaceBaseline() {
 		if (workspacebaseline == null) {
 			return;
 		}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/WorkspaceDeltaProcessor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/WorkspaceDeltaProcessor.java
@@ -18,6 +18,8 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.ElementChangedEvent;
@@ -226,6 +228,12 @@ public class WorkspaceDeltaProcessor implements IElementChangedListener, IResour
 						System.out.println("processed PRE_BUILD delta for project: [" + resource.getName() + "]"); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				}
+
+				if (event.getBuildKind() == IncrementalProjectBuilder.AUTO_BUILD
+						&& !ResourcesPlugin.getWorkspace().isAutoBuilding()) {
+					return;
+				}
+
 				IResourceDelta delta = event.getDelta();
 				if (delta != null) {
 					IResourceDelta[] children = delta.getAffectedChildren(IResourceDelta.CHANGED);


### PR DESCRIPTION
Disable auto builds to reduce background activities.