### PR TITLE
synchronise both the views with the template selector

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/FormBrowser.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/FormBrowser.java
@@ -24,6 +24,7 @@ public class FormBrowser {
 	FormToolkit toolkit;
 	Composite container;
 	ScrolledFormText formText;
+	FormText ftext;
 	String text;
 	int style;
 
@@ -44,7 +45,7 @@ public class FormBrowser {
 			formText.setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TREE_BORDER);
 			toolkit.paintBordersFor(container);
 		}
-		FormText ftext = toolkit.createFormText(formText, false);
+		ftext = toolkit.createFormText(formText, false);
 		formText.setFormText(ftext);
 		formText.setExpandHorizontal(true);
 		formText.setExpandVertical(true);
@@ -71,5 +72,12 @@ public class FormBrowser {
 		this.text = text;
 		if (formText != null)
 			formText.setText(text);
+	}
+
+	public void setEnabled(boolean enabled) {
+		if (formText != null)
+			formText.setEnabled(enabled);
+		if (ftext != null)
+			ftext.setEnabled(enabled);
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/BaseWizardSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/BaseWizardSelectionPage.java
@@ -58,5 +58,6 @@ public abstract class BaseWizardSelectionPage extends WizardSelectionPage implem
 		Control dcontrol = descriptionBrowser.getControl();
 		if (dcontrol != null)
 			dcontrol.setEnabled(enabled);
+		descriptionBrowser.setEnabled(enabled);
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
@@ -121,6 +121,7 @@ public class TemplateListSelectionPage extends WizardListSelectionPage {
 		wizardSelectionViewer.addFilter(new WizardFilter());
 		if (getInitialTemplateId() != null)
 			selectInitialTemplate();
+		setDescriptionEnabled(false);
 	}
 
 	private void selectInitialTemplate() {


### PR DESCRIPTION
The plug-in template selector has two components - template list, and the help text (FormBrowser). While the first widget follows the toggle button properly, the formbrowser does not. Fix that by toggling between enabled and disabled states following the template selector button.

Before the change: when the template selector is off, the template list is disabled, but the form browser is not.

![image](https://user-images.githubusercontent.com/6447530/216649203-b78b6d1e-a117-4427-8f31-a3b2972f1bdc.png)

After the change: both the template list as well as the form browser is disabled.
![image](https://user-images.githubusercontent.com/6447530/216649601-662318cb-f7ea-4a3f-ae24-8ec9c1cc87d0.png)

![image](https://user-images.githubusercontent.com/6447530/216649909-9bad137c-320d-4d23-ab7b-1f8af0aee11a.png)
