### PR TITLE
Fix PluginRegistryTests

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/PluginRegistryTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/PluginRegistryTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,8 +16,12 @@ package org.eclipse.pde.ui.tests.project;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.eclipse.pde.core.plugin.*;
+import org.eclipse.pde.core.plugin.IMatchRules;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.junit.Test;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
 
 /**
  * Tests for plug-in searching
@@ -28,7 +32,9 @@ public class PluginRegistryTests extends PluginRegistryTestsMinimal {
 
 	@Test
 	public void testMatchEquivalent() {
-		IPluginModelBase model = PluginRegistry.findModel("org.eclipse.pde.ui.tests", "3.11.0",
+		Version testsVersion = FrameworkUtil.getBundle(getClass()).getVersion();
+		IPluginModelBase model = PluginRegistry.findModel("org.eclipse.pde.ui.tests",
+				String.format("%s.%s.%s", testsVersion.getMajor(), testsVersion.getMinor(), testsVersion.getMicro()),
 				IMatchRules.EQUIVALENT,
 				null);
 		assertNotNull("NOTE: This test might also fail because the version of the bundle got changed.", model);


### PR DESCRIPTION
Instead of using hardcoded version or the bundle version (which should match the one in OSGi container) fetch the version from OSGi and use that version for quering the plugin registry.