### PR TITLE
Do not require org.eclipse.osgi.services

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Require-Bundle: org.junit,
  org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
- org.eclipse.osgi.services,
  org.eclipse.e4.core.contexts,
  org.eclipse.e4.core.services,
  org.eclipse.jdt.core,
@@ -45,8 +44,9 @@ Require-Bundle: org.junit,
  org.eclipse.ui.ide.application
 Import-Package: org.assertj.core.api;version="3.14.0",
  org.assertj.core.presentation;version="3.21.0",
+ org.eclipse.pde.internal.build,
  org.junit.jupiter.api.function;version="5.8.1",
- org.eclipse.pde.internal.build
+ org.osgi.service.event;version="[1.3.0,2.0.0)"
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir


### PR DESCRIPTION
Requiring org.eclipse.osgi.services bundle is bad as it actually is only meant to export some osgi packages that can came from everywhere, therefore a bundle should instead import the package of the desired service and not bound to one specific provider (that is planned to be deprecated).

@vik-chand @akurtakov as only test code is affected, maybe something we can still merge as "configuration change" to get down dependency count on  `org.eclipse.osgi.services`?