### PR TITLE
Add pde.build readme

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,11 @@
+#PDE buld is in deep maintenance mode
+
+## Compatibility with newer Eclipse versions functionality
+Enhancements to make use of new functionality implemented in latest versions of other components are most likely not implemented in pde.build.
+
+## Bugs 
+Bugs affecting in IDE Export functionality may still be worked on (until replacement functionality is provided) although with low priority. If you experience issues with headless builds it is highly likely that you would have to investigate and provide a patch fixing it.
+
+## Alternative headless/standalone builds recommendation
+[Tycho project](https://github.com/eclipse-tycho/tycho) is the most common and active project for building Eclipse RCP apps and thus is recommended as a replacement for pde.build.
+


### PR DESCRIPTION
Recommending Tycho as a standalone build and giving clear message about state of this part of the code.
This should have been done in 2016 as per March 29, 2016 [PMC discussion](https://wiki.eclipse.org/Eclipse/PMC/Minutes_2016 ) .
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/469