### PR TITLE
Move PDE spies to dedicated new Feature 'o.e.pde.spies'

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde"
       label="%featureName"
-      version="3.14.1600.qualifier"
+      version="3.15.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -24,7 +24,7 @@
       <import plugin="org.osgi.annotation.versioning"/>
       <import plugin="org.osgi.annotation.bundle"/>
       <import plugin="org.osgi.service.component.annotations"/>
-      <import plugin="org.osgi.service.metatype.annotations" />
+      <import plugin="org.osgi.service.metatype.annotations"/>
    </requires>
 
    <plugin
@@ -154,62 +154,6 @@
 
    <plugin
          id="org.eclipse.pde.genericeditor.extension"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.tools.layout.spy"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.model"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.css"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.preferences"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.context"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.bundle"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.spy.event"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.eclipse.pde.spies-feature/.project
+++ b/features/org.eclipse.pde.spies-feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.pde.spies-feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.pde.spies-feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.pde.spies-feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.pde.spies-feature/.settings/org.eclipse.core.runtime.prefs
+++ b/features/org.eclipse.pde.spies-feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/features/org.eclipse.pde.spies-feature/build.properties
+++ b/features/org.eclipse.pde.spies-feature/build.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2023, 2023 Hannes Wellmann and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Hannes Wellmann - initial API and implementation
+###############################################################################
+bin.includes = feature.xml,\
+               feature.properties

--- a/features/org.eclipse.pde.spies-feature/feature.properties
+++ b/features/org.eclipse.pde.spies-feature/feature.properties
@@ -18,17 +18,17 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=Eclipse Plug-in Development Environment
+featureName=Eclipse Plug-in Development Environment Spies
 
 # "providerName" property - name of the company that provides the feature
 providerName=Eclipse.org
 
 # "description" property - description of the feature
-description=Eclipse plug-in development environment.
+description=Eclipse plug-in development environment spies.
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\
-Copyright (c) 2000, 2023 IBM Corporation and others.\n\
+Copyright (c) 2016, 2023 IBM Corporation and others.\n\
 \n\
 This program and the accompanying materials\n\
 are made available under the terms of the Eclipse Public License 2.0\n\
@@ -38,5 +38,11 @@ https://www.eclipse.org/legal/epl-2.0/\n\
 SPDX-License-Identifier: EPL-2.0\n\
 \n\
 Contributors:\n\
-    IBM Corporation - initial API and implementation\n
+    Olivier Prouvost (OPCoach) - create PDE Bundle, Context, Core spies\n
+    Brian de Alwis (Manumitting Technologies, Inc) - Create PDE CSS spy\n
+    Stefan Xenos (Google) - Create SWT Layout spy\n
+    IBM Corporation - Create PDE Event Spy\n
+    Tom Schindl (BestSolution.at) - Create PDE Model spy\n
+    Simon Scholz (Vogella GmbH) - Create PDE Preferences spy\n
+    Hannes Wellmann (IILS mbH) - Create dedicated o.e.pde.spies Feature\n
 ################ end of copyright property ####################################

--- a/features/org.eclipse.pde.spies-feature/feature.xml
+++ b/features/org.eclipse.pde.spies-feature/feature.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.pde.spies"
+      label="%featureName"
+      version="1.0.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <plugin
+         id="org.eclipse.tools.layout.spy"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.model"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.css"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.preferences"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.context"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.bundle"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.event"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/472

When this is merged we have to make sure that the new feature ends up in the Eclipse-SDK repo.
Can someone tell me where to do this?
The SimRel contribution has to be adjusted too in https://git.eclipse.org/c/simrel/org.eclipse.simrel.build.git/tree/ep.aggrcon

Alternatively we could simply add it to the org.eclipse.sdk feature. Then it should end in both of the mentioned repos automatically. But I'm not sure if this is the right place.

@akurtakov should we consider this for RC1? Or better wait for 4.28?
