### PR TITLE
Add an action to convert a bundle import into a package import

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -24,6 +24,7 @@ Export-Package:
    org.eclipse.pde.api.tools.tests,
    org.eclipse.pde.unittest.junit",
  org.eclipse.pde.internal.core.annotations;x-friends:="org.eclipse.pde.ui",
+ org.eclipse.pde.internal.core.bnd;x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.internal.core.build;x-friends:="org.eclipse.pde.ui,org.eclipse.pde.ds.ui,org.eclipse.pde.ua.ui",
  org.eclipse.pde.internal.core.builders;x-friends:="org.eclipse.pde.ui,org.eclipse.pde.launching,org.eclipse.pde.ds.core",
  org.eclipse.pde.internal.core.bundle;x-friends:="org.eclipse.pde.ui,org.eclipse.pde.ds.ui",
@@ -78,6 +79,7 @@ Export-Package:
    org.eclipse.pde.api.tools,
    org.eclipse.pde.unittest.junit",
  org.eclipse.pde.internal.core.variables;x-internal:=true
+Import-Package: aQute.bnd.osgi;version="5.5.0"
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.8.0,2.0.0)",

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/FileResource.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/FileResource.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import aQute.bnd.osgi.Resource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.resources.IFile;
+
+/**
+ * Wraps an {@link IFile} to a BND {@link Resource} that can be used to perform
+ * analyzer operations.
+ *
+ * @since 3.17
+ */
+public class FileResource implements Resource {
+
+	private IFile file;
+
+	private String extra;
+
+	public FileResource(IFile file) {
+		this.file = file;
+	}
+
+	@Override
+	public long lastModified() {
+		return file.getLocalTimeStamp();
+	}
+
+	@Override
+	public InputStream openInputStream() throws Exception {
+		return file.getContents(true);
+	}
+
+	@Override
+	public void write(OutputStream out) throws Exception {
+		try (InputStream stream = openInputStream()) {
+			stream.transferTo(out);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+	}
+
+	@Override
+	public void setExtra(String extra) {
+		this.extra = extra;
+	}
+
+	@Override
+	public String getExtra() {
+		return extra;
+	}
+
+	@Override
+	public long size() throws Exception {
+		URI location = file.getLocationURI();
+		if (location != null) {
+			IFileStore store = EFS.getStore(location);
+			if (store != null) {
+				IFileInfo fetchInfo = store.fetchInfo();
+				if (fetchInfo.exists()) {
+					return fetchInfo.getLength();
+				}
+			}
+		}
+		return -1;
+	}
+
+	@Override
+	public synchronized ByteBuffer buffer() throws Exception {
+
+		try (InputStream stream = openInputStream()) {
+			return ByteBuffer.wrap(stream.readAllBytes());
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -117,7 +117,8 @@ Require-Bundle:
  org.eclipse.team.ui;bundle-version="[3.6.100,4.0.0)",
  org.eclipse.help;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)",
- org.eclipse.equinox.security;bundle-version="[1.2.200,2.0.0)"
+ org.eclipse.equinox.security;bundle-version="[1.2.200,2.0.0)",
+ biz.aQute.bndlib;bundle-version="6.3.1"
 Eclipse-LazyStart: true
 Import-Package: org.eclipse.jdt.debug.ui.console,
  org.eclipse.ui.internal.genericeditor,

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3187,6 +3187,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String OrganizeManifestsWizardPage_addDependencies;
 
+	public static String OrganizeManifestsWizardPage_computeImports;
+
 	public static String OrganizeManifestsWizardPage_ProjectsUsingCustomBuildWarning;
 
 	public static String OrganizeManifestsWizardPage_ProjectsUsingCustomBuildWarningPlural;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2391,6 +2391,7 @@ DuplicatePluginResolutionDialog_message=Some of the plug-ins you are importing a
 DuplicatePluginResolutionDialog_selectAll=Select &All
 OrganizeManifestsOperation_additionalDeps=adding required dependencies...{0}
 OrganizeManifestsWizardPage_addDependencies=&Add required dependencies (this may be a long-running operation)
+OrganizeManifestsWizardPage_computeImports=Recompute Import-Package and convert Require-Bundle to package imports
 OrganizeManifestsWizardPage_ProjectsUsingCustomBuildWarning=Projects using a custom build may be missing build.properties entries that are necessary to organize the manifest. Please review any changes closely. The following project has a custom build setup: {0}
 OrganizeManifestsWizardPage_ProjectsUsingCustomBuildWarningPlural=Projects using a custom build may be missing build.properties entries that are necessary to organize the manifest. Please review any changes closely. The following projects have a custom build setup: {0}
 SecondaryBundlesSection_desc=Augment the plug-in development classpath with the following dependencies without adding them to the MANIFEST.MF file.

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/IOrganizeManifestsSettings.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/IOrganizeManifestsSettings.java
@@ -25,6 +25,7 @@ public interface IOrganizeManifestsSettings {
 	public static final String PROP_RESOLVE_IMP_MARK_OPT = "OrganizeManifests.RequireImport.resolve:markOptional"; //$NON-NLS-1$
 	public static final String PROP_UNUSED_DEPENDENCIES = "OrganizeManifests.RequireImport.findRemoveUnused"; //$NON-NLS-1$
 	public static final String PROP_ADD_DEPENDENCIES = "OrganizeManifests.AddDependencies"; //$NON-NLS-1$
+	public static final String PROP_COMPUTE_IMPORTS = "OrganizeManifests.ComputeImports"; //$NON-NLS-1$
 	public static final String PROP_REMOVE_LAZY = "OrganizeManifests.General.cleanup"; //$NON-NLS-1$
 	public static final String PROP_REMOVE_USELESSFILES = "OrganizeManifests.General.cleanup.removeUselessFiles"; //$NON-NLS-1$
 	public static final String PROP_NLS_PATH = "OrganizeManifests.Translation.nls"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifestsProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifestsProcessor.java
@@ -65,6 +65,7 @@ public class OrganizeManifestsProcessor extends RefactoringProcessor implements 
 
 	List<IProject> fProjectList;
 	private IProject fCurrentProject;
+	private boolean fComputeImports;
 
 	public OrganizeManifestsProcessor(List<IProject> projects) {
 		fProjectList = projects;
@@ -134,7 +135,7 @@ public class OrganizeManifestsProcessor extends RefactoringProcessor implements 
 	}
 
 	private void runCleanup(IProgressMonitor monitor, IBundlePluginModelBase modelBase, Change[] result)
-			throws InvocationTargetException, InterruptedException {
+			throws InvocationTargetException, InterruptedException, CoreException {
 
 		IBundle currentBundle = modelBase.getBundleModel().getBundle();
 		ISharedExtensionsModel sharedExtensionsModel = modelBase.getExtensionsModel();
@@ -235,6 +236,9 @@ public class OrganizeManifestsProcessor extends RefactoringProcessor implements 
 			}
 			subMonitor.worked(1);
 		}
+		if (fComputeImports) {
+			OrganizeManifest.computeImportPackages(modelBase, fCurrentProject, subMonitor.split(1));
+		}
 		subMonitor.setWorkRemaining(0);
 	}
 
@@ -314,5 +318,9 @@ public class OrganizeManifestsProcessor extends RefactoringProcessor implements 
 
 	public void setAddDependencies(boolean addDependencies) {
 		fAddDependencies = addDependencies;
+	}
+
+	public void setComputeImports(boolean computeImports) {
+		this.fComputeImports = computeImports;
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifestsWizardPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifestsWizardPage.java
@@ -48,6 +48,7 @@ public class OrganizeManifestsWizardPage extends UserInputWizardPage implements 
 	private Button fModifyDependencies;
 	private Button fUnusedDependencies;
 	private Button fAdditonalDependencies;
+	private Button fComputeImportPackages;
 	private Button fFixIconNLSPaths;
 	private Button fRemovedUnusedKeys;
 	private Button fRemoveLazy;
@@ -180,6 +181,9 @@ public class OrganizeManifestsWizardPage extends UserInputWizardPage implements 
 
 		fAdditonalDependencies = new Button(group, SWT.CHECK);
 		fAdditonalDependencies.setText(PDEUIMessages.OrganizeManifestsWizardPage_addDependencies);
+
+		fComputeImportPackages = new Button(group, SWT.CHECK);
+		fComputeImportPackages.setText(PDEUIMessages.OrganizeManifestsWizardPage_computeImports);
 	}
 
 	private void createGeneralGroup(Composite container) {
@@ -245,6 +249,10 @@ public class OrganizeManifestsWizardPage extends UserInputWizardPage implements 
 		fAdditonalDependencies.setSelection(selection);
 		fProcessor.setAddDependencies(selection);
 
+		selection = settings.getBoolean(PROP_COMPUTE_IMPORTS);
+		fComputeImportPackages.setSelection(selection);
+		fProcessor.setComputeImports(selection);
+
 		selection = !settings.getBoolean(PROP_REMOVE_LAZY);
 		fRemoveLazy.setSelection(selection);
 		fProcessor.setRemoveLazy(selection);
@@ -278,6 +286,7 @@ public class OrganizeManifestsWizardPage extends UserInputWizardPage implements 
 		settings.put(PROP_RESOLVE_IMP_MARK_OPT, fOptionalImport.getSelection());
 		settings.put(PROP_UNUSED_DEPENDENCIES, fUnusedDependencies.getSelection());
 		settings.put(PROP_ADD_DEPENDENCIES, fAdditonalDependencies.getSelection());
+		settings.put(PROP_COMPUTE_IMPORTS, fComputeImportPackages.getSelection());
 
 		settings.put(PROP_REMOVE_LAZY, !fRemoveLazy.getSelection());
 		settings.put(PROP_REMOVE_USELESSFILES, !fRemoveUselessFiles.getSelection());
@@ -298,7 +307,9 @@ public class OrganizeManifestsWizardPage extends UserInputWizardPage implements 
 	}
 
 	private void setButtonArrays() {
-		fTopLevelButtons = new Button[] {fRemoveUnresolved, fAddMissing, fModifyDependencies, fMarkInternal, fUnusedDependencies, fAdditonalDependencies, fFixIconNLSPaths, fRemovedUnusedKeys, fRemoveLazy, fRemoveUselessFiles, fCalculateUses};
+		fTopLevelButtons = new Button[] { fRemoveUnresolved, fAddMissing, fModifyDependencies, fMarkInternal,
+				fUnusedDependencies, fAdditonalDependencies, fComputeImportPackages, fFixIconNLSPaths,
+				fRemovedUnusedKeys, fRemoveLazy, fRemoveUselessFiles, fCalculateUses };
 	}
 
 	private void setPageComplete() {
@@ -349,6 +360,8 @@ public class OrganizeManifestsWizardPage extends UserInputWizardPage implements 
 			fProcessor.setUnusedDependencies(fUnusedDependencies.getSelection());
 		else if (fAdditonalDependencies.equals(source))
 			fProcessor.setAddDependencies(fAdditonalDependencies.getSelection());
+		else if (fComputeImportPackages.equals(source))
+			fProcessor.setAddDependencies(fComputeImportPackages.getSelection());
 		else if (fRemoveLazy.equals(source))
 			fProcessor.setRemoveLazy(fRemoveLazy.getSelection());
 		else if (fRemoveUselessFiles.equals(source))


### PR DESCRIPTION
Currently there is no convient way to convert a bundle from using Require-Bundle to Import-Package (what is recommended to use).

This adds a new option in the OrganizeManifest action to do this conversion automatically in the follwoing way:

- Automatic Managed Dependencies are set to using Import-Package
- Current Require-Bundles are converted to Automatic Managed Dependencies
- the package imports are recalculated and updated

Fix https://github.com/eclipse-pde/eclipse.pde/issues/362