### PR TITLE
toggle framework selection based on project type

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationPage.java
@@ -91,6 +91,12 @@ public class NewProjectCreationPage extends WizardNewProjectCreationPage {
 			fSourceText.setEnabled(enabled);
 			fOutputlabel.setEnabled(enabled);
 			fOutputText.setEnabled(enabled);
+			if (fEclipseButton != null)
+				fEclipseButton.setEnabled(enabled);
+			if (fOSGIButton != null)
+				fOSGIButton.setEnabled(enabled);
+			if (fOSGiCombo != null)
+				fOSGiCombo.setEnabled(enabled);
 			setPageComplete(validatePage());
 		}));
 


### PR DESCRIPTION
In the new pulg-in project wizard (first page),
when the plug-in project is not Java project
it does not make sense to enable the target
framework (OSGi versus Eclipse) to be select-able,
as those types are relevant only for Java projects.

Make the framework selection dependent on project type.

before:
![image](https://user-images.githubusercontent.com/6447530/222880666-c8eb3168-6acb-4c05-a5ee-655979386f67.png)

after:
![image](https://user-images.githubusercontent.com/6447530/222880675-8722e723-bf67-4991-9877-f5adfbc9dd26.png)
