### PR TITLE
Bump PDE Spy version to fix baseline-issues due to their interim removal

### DIFF
--- a/ui/org.eclipse.pde.spy.bundle/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.bundle/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.bundle;singleton:=true
-Bundle-Version: 0.12.300.qualifier
+Bundle-Version: 0.12.400.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.pde.spy.bundle
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",

--- a/ui/org.eclipse.pde.spy.context/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.context/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.context;singleton:=true
-Bundle-Version: 1.0.500.qualifier
+Bundle-Version: 1.0.600.qualifier
 Bundle-Vendor: %provider-name
 Automatic-Module-Name: org.eclipse.pde.spy.context
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.core;singleton:=true
-Bundle-Version: 1.0.300.qualifier
+Bundle-Version: 1.0.400.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.core
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.css;singleton:=true
-Bundle-Version: 0.12.400.qualifier
+Bundle-Version: 0.12.500.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.css
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",

--- a/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.event;singleton:=true
-Bundle-Version: 1.0.200.qualifier
+Bundle-Version: 1.0.300.qualifier
 Bundle-Vendor: Eclipse Foundation
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/ui/org.eclipse.pde.spy.model/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.model;singleton:=true
-Bundle-Version: 0.12.500.qualifier
+Bundle-Version: 0.12.600.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.e4.ui.services;bundle-version="0.9.1",
  org.eclipse.e4.tools.emf.ui;bundle-version="4.7.0",

--- a/ui/org.eclipse.pde.spy.preferences/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.preferences;singleton:=true
-Bundle-Version: 0.12.400.qualifier
+Bundle-Version: 0.12.500.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.preferences
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %provider-name


### PR DESCRIPTION
When the PDE spies were moved into their own feature they have not been included into the I-builds repo in time and where temporarily removed. Therefore there is now a baseline discrepancy which is fixed by bumping their version.

See for example https://github.com/eclipse-pde/eclipse.pde/pull/497#issuecomment-1467730236