### PR TITLE
Check if the provided baseline actually exits

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnalysisApplication.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnalysisApplication.java
@@ -17,7 +17,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
@@ -253,6 +252,11 @@ public class ApiAnalysisApplication implements IApplication {
 			ApiBaselineManager.getManager().setDefaultApiBaseline(baseline.getName());
 			return baseline;
 		}
+		if (!baselinePath.exists()) {
+			System.err
+					.println(String.format("Specified baseline %s does not denote a file or directory!", baselinePath)); //$NON-NLS-1$
+			return null;
+		}
 		String baselineFileName = baselinePath.getName();
 		if (baselinePath.isFile() && baselineFileName.endsWith(".txt")) { //$NON-NLS-1$
 			try {
@@ -260,11 +264,8 @@ public class ApiAnalysisApplication implements IApplication {
 				ApiBaseline baseline = new ApiBaseline(baselineName);
 				long bundleId = 1;
 				for (String bundleFile : Files.readAllLines(baselinePath.toPath())) {
-					BundleInfo bundleInfo = new BundleInfo(URI.create(bundleFile));
-					if (bundleInfo.getBundleId() != 0) {
-						baseline.addApiComponents(new IApiComponent[] { new BundleComponent(baseline,
-								bundleFile, bundleId++) });
-					}
+					baseline.addApiComponents(
+							new IApiComponent[] { new BundleComponent(baseline, bundleFile, bundleId++) });
 				}
 				ApiBaselineManager.getManager().addApiBaseline(baseline);
 				ApiBaselineManager.getManager().setDefaultApiBaseline(baseline.getName());
@@ -303,7 +304,8 @@ public class ApiAnalysisApplication implements IApplication {
 					"Support for directories not implemented yet, use `default` or a `</path/to/baseline.target>` baseline for currently running application."); //$NON-NLS-1$
 			return null;
 		}
-		return ApiBaselineManager.getManager().getDefaultApiBaseline();
+		System.err.println(String.format("Unsupported file type %s!", baselineFileName)); //$NON-NLS-1$
+		return null;
 	}
 
 	private IProject importProject(File projectPath) throws CoreException, IOException {


### PR DESCRIPTION
Currently there is the case that the provided baseline file does not exits at all, in such a case the default baseline is silently returned what is not what we want here.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/511