### PR TITLE
Fix hasCode / equals to scope will null values in SourceLocationKey

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationKey.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationKey.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
+import java.util.Objects;
 import org.osgi.framework.Version;
 
 /**
@@ -36,25 +37,21 @@ public class SourceLocationKey {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof SourceLocationKey) {
-			SourceLocationKey key = (SourceLocationKey) obj;
-			if (fVersion != null && key.fVersion != null) {
-				return fBundleName.equals(((SourceLocationKey) obj).fBundleName) && fVersion.equals(((SourceLocationKey) obj).fVersion);
-			} else if (fVersion == null && key.fVersion == null) {
-				return fBundleName.equals(((SourceLocationKey) obj).fBundleName);
-			}
+		if (this == obj) {
+			return true;
 		}
-		return false;
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		SourceLocationKey other = (SourceLocationKey) obj;
+		return Objects.equals(fBundleName, other.fBundleName) && Objects.equals(fVersion, other.fVersion);
 	}
 
 	@Override
 	public int hashCode() {
-		if (fVersion == null) {
-			return fBundleName.hashCode();
-		}
-		int result = 1;
-		result = 31 * result + fBundleName.hashCode();
-		result = 31 * result + fVersion.hashCode();
-		return result;
+		return Objects.hash(fBundleName, fVersion);
 	}
 }


### PR DESCRIPTION
Currently the SourceLocationKey will produce a NPE if the bundle symbolic name is null but the constructor never ensures that it is not null.

This replace the hand written hascode / equals with eclipse generated Java 1.7+ variant that can savly accept nulls.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/507