### PR TITLE
Remove compute button and sync checkbox from the feature editor

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeature.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeature.java
@@ -231,8 +231,6 @@ public interface IFeature extends IFeatureObject, IVersionable, IEnvironment {
 	 */
 	public void setURL(IFeatureURL url) throws CoreException;
 
-	public void computeImports() throws CoreException;
-
 	boolean isPrimary();
 
 	public String getLicenseFeatureID();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -862,8 +862,6 @@ public class PDEUIMessages extends NLS {
 
 	public static String FeatureEditor_RequiresSection_title;
 	public static String FeatureEditor_RequiresSection_desc;
-	public static String FeatureEditor_RequiresSection_sync;
-	public static String FeatureEditor_RequiresSection_compute;
 	public static String FeatureEditor_RequiresSection_plugin;
 	public static String FeatureEditor_RequiresSection_feature;
 	public static String FeatureEditor_RequiresSection_sortAlpha;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -242,9 +242,7 @@ Leave blank if the archive does not contain platform-specific code.
 FeatureExportJob_name=Export Features
 
 FeatureEditor_RequiresSection_title = Required Features/Plug-ins
-FeatureEditor_RequiresSection_desc = Compute plug-ins that will need to be present before installing this feature.
-FeatureEditor_RequiresSection_sync = Recompute when feature plug-ins change
-FeatureEditor_RequiresSection_compute = Compute
+FeatureEditor_RequiresSection_desc = List Plug-ins and Features that will need to be present before installing this feature.
 FeatureEditor_RequiresSection_plugin = Add Plug-in...
 FeatureEditor_RequiresSection_feature = Add Feature...
 FeatureEditor_RequiresSection_remove = Remove
@@ -601,7 +599,7 @@ TracingTab_AttributeLabel_TracingOptions=Tracing options
 TracingTab_AttributeLabel_TracingChecked=Tracing select all
 TracingTab_AttributeLabel_TracingNone=Tracing select none
 
-TracingBlock_restore_default=Restore &All to Defaults 
+TracingBlock_restore_default=Restore &All to Defaults
 TracingBlock_restore_default_selected=Restore &Selected to Defaults
 TracingLauncherTab_name = Trac&ing
 TracingLauncherTab_tracing =&Enable tracing
@@ -1147,7 +1145,7 @@ ImageBrowserView_Show=Show:
 ImageBrowserView_Source=Source:
 ImageBrowserView_Width=Width:
 ImportActionGroup_binaryWithLinkedContent=Binary Project with &Linked Content
-ImportActionGroup_cannot_import=The selected plug-ins cannot be imported from a repository. The plug-ins do not have an Eclipse-SourceReferences manifest header that can be processed. 
+ImportActionGroup_cannot_import=The selected plug-ins cannot be imported from a repository. The plug-ins do not have an Eclipse-SourceReferences manifest header that can be processed.
 ImportActionGroup_importContributingPlugin=&Import Contributing Plug-in as
 ImportActionGroup_Repository_project=P&roject from a Repository...
 
@@ -1716,7 +1714,7 @@ RepositorySection_remove=Remove
 RepositorySection_removeAll=Remove All
 
 StatsSection_title=Download Statistics
-StatsSection_description=Specify a URL for the server that tracks download statistics. List the features and plug-ins to be tracked by the server. 
+StatsSection_description=Specify a URL for the server that tracks download statistics. List the features and plug-ins to be tracked by the server.
 StatsSection_url=URL:
 StatsSection_addFeature = Add Feature...
 StatsSection_addBundle = Add Plug-in...
@@ -2575,7 +2573,7 @@ UpdatesSection_EnabledColumn=Enabled
 
 CustomizationPage_title=Customization
 PreferencesSection_title=Default Preferences
-PreferencesSection_description=Use an Eclipse preferences (.epf) file to set the product's default preferences. 
+PreferencesSection_description=Use an Eclipse preferences (.epf) file to set the product's default preferences.
 PreferencesSection_errorReading=Error reading file {0}. Could not generate preferences.
 PreferencesSection_errorNoDefiningPlugin=The product's defining plug-in project could not be found. Cannot generate a plugin_customization.ini file.
 PreferencesSection_errorNoDefiningPluginTitle=Plug-in {0} Not Found
@@ -2665,7 +2663,7 @@ ExtensionAttributeRow_AttrReq={0} (required)
 ExtensionAttributeRow_AttrReqDepr={0} (required) (deprecated)
 ExtensionAttributeRow_AttrFilter=Press {0} within text to filter for this attribute value.
 # In extension page of plug-in editor we list attributes with symbols after to indicate deprecation/required
-ExtensionAttributeRow_AttrLabel={0}: 
+ExtensionAttributeRow_AttrLabel={0}:
 ExtensionAttributeRow_AttrLabelDepr={0}(!):
 ExtensionAttributeRow_AttrLabelReq={0}*:
 ExtensionAttributeRow_AttrLabelReqDepr={0}(!)*:


### PR DESCRIPTION
Two points:

1. `IFeature` has a `computeImports` method, which I didn't touch because that - even if unused in this project - would be a breaking API change.
2. The help content doesn't explain what the _Compute_ button or _Recompute when..._ checkbox do, but the image example is outdated.

Closes: eclipse-pde#37