### PR TITLE
autocomplete for build.properties: follow-up

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildSourceViewerConfiguration.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildSourceViewerConfiguration.java
@@ -43,7 +43,6 @@ public class BuildSourceViewerConfiguration extends ChangeAwareSourceViewerConfi
 	private BasePDEScanner fPropertyValueScanner;
 
 	private ContentAssistant fContentAssistant;
-	private BuildPropertiesContentAssistProcessor fContentAssistantProcessor;
 
 	private abstract class AbstractJavaScanner extends BasePDEScanner {
 
@@ -241,6 +240,7 @@ public class BuildSourceViewerConfiguration extends ChangeAwareSourceViewerConfi
 
 	@Override
 	public IContentAssistant getContentAssistant(ISourceViewer sourceViewer) {
+		BuildPropertiesContentAssistProcessor fContentAssistantProcessor;
 		if (fSourcePage != null && fSourcePage.isEditable()) {
 			if (fContentAssistant == null) {
 				// Initialize in SWT thread before using in background thread:
@@ -250,7 +250,6 @@ public class BuildSourceViewerConfiguration extends ChangeAwareSourceViewerConfi
 				fContentAssistantProcessor = new BuildPropertiesContentAssistProcessor(fSourcePage);
 				fContentAssistant.setContentAssistProcessor(fContentAssistantProcessor, IDocument.DEFAULT_CONTENT_TYPE);
 				fContentAssistant.setContentAssistProcessor(fContentAssistantProcessor, PROPERTY_VALUE);
-				fContentAssistant.addCompletionListener(fContentAssistantProcessor);
 				fContentAssistant.enableAutoInsert(true);
 				fContentAssistant.setInformationControlCreator(parent -> new DefaultInformationControl(parent, false));
 				fContentAssistant.setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_ABOVE);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/BuildPropertiesContentAssistProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/BuildPropertiesContentAssistProcessor.java
@@ -15,34 +15,15 @@ package org.eclipse.pde.internal.ui.editor.contentassist;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import org.eclipse.jface.text.*;
-import org.eclipse.jface.text.contentassist.*;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.pde.internal.build.IBuildPropertiesConstants;
 import org.eclipse.pde.internal.ui.editor.PDESourcePage;
 
-public class BuildPropertiesContentAssistProcessor extends TypePackageCompletionProcessor
-		implements ICompletionListener {
+public class BuildPropertiesContentAssistProcessor extends TypePackageCompletionProcessor {
 
 	protected PDESourcePage fSourcePage;
 	public BuildPropertiesContentAssistProcessor(PDESourcePage sourcePage) {
 		fSourcePage = sourcePage;
-	}
-
-	@Override
-	public void assistSessionStarted(ContentAssistEvent event) {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public void assistSessionEnded(ContentAssistEvent event) {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public void selectionChanged(ICompletionProposal proposal, boolean smartToggle) {
-		// TODO Auto-generated method stub
-
 	}
 
 	@Override
@@ -56,7 +37,7 @@ public class BuildPropertiesContentAssistProcessor extends TypePackageCompletion
 			Field[] properties = IBuildPropertiesConstants.class.getFields();
 			for (Field f : properties) {
 				String key = f.getName();
-				String element = "";
+				String element;
 				try {
 					element = (String) f.get(key);
 				} catch (IllegalAccessException e) {
@@ -68,7 +49,7 @@ public class BuildPropertiesContentAssistProcessor extends TypePackageCompletion
 					completions.add(proposal);
 				}
 			}
-			return completions.toArray(new ICompletionProposal[completions.size()]);
+			return completions.toArray(ICompletionProposal[]::new);
 		} catch (BadLocationException e) {
 		}
 		return null;


### PR DESCRIPTION
a few review comments are included in this follow-up PR:
 - removed inheriting from ICompletionListener
 - hence removed completion listener registration (ICompletionListener.addCompletionListener)
 - usage of array creation shortcut
 - better string initialization
 - localization of fContentAssistantProcessor variable

Refs: https://github.com/eclipse-pde/eclipse.pde/pull/508

/cc @HannesWell 