### PR TITLE
Delete the temporary file after being parsed

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
@@ -484,6 +484,7 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 							fVMBinding = iVMInstall;
 							ExecutionEnvironmentDescription ee = new ExecutionEnvironmentDescription(file);
 							initialize(ee);
+							file.delete();
 						} catch (CoreException | IOException e) {
 							error = Status.error(CoreMessages.ApiBaseline_2, e);
 						}


### PR DESCRIPTION
Currently one gets a lots of lingering files named:

```
/tmp/eed17021414477589663537.ee
/tmp/eed15599516348791254164.ee
/tmp/eed10981864096532456217.ee
/tmp/eed9998009589164187122.ee
/tmp/eed2679993409650199583.ee
```

in the temp directory of the system even though after the file is read it is never used anywhere.