### PR TITLE
Auto-complete for build.properties: Image Icons

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPluginImages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPluginImages.java
@@ -110,6 +110,8 @@ public class PDEPluginImages {
 	public static final ImageDescriptor DESC_PROCESSING_INST_OBJ = create(PATH_OBJ, "processinginst.png"); //$NON-NLS-1$
 	public static final ImageDescriptor DESC_XML_ELEMENT_OBJ = create(PATH_OBJ, "element.png"); //$NON-NLS-1$
 	public static final ImageDescriptor DESC_XML_ELEMENT_REF_OBJ = create(PATH_OBJ, "elref_sc_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_FOLDER_OBJ = create(PATH_OBJ, "fldr_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_DEFAULT_OBJ = create(PATH_OBJ, "build_var_obj.png"); //$NON-NLS-1$
 
 	public static final ImageDescriptor DESC_SIMPLECS_OBJ = create(PATH_OBJ, "cheatsheet_simple_obj.png"); //$NON-NLS-1$
 	public static final ImageDescriptor DESC_COMPCS_OBJ = create(PATH_OBJ, "cheatsheet_composite_obj.png"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/BuildPropertiesContentAssistProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/BuildPropertiesContentAssistProcessor.java
@@ -14,14 +14,18 @@ package org.eclipse.pde.internal.ui.editor.contentassist;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.text.*;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.pde.internal.build.IBuildPropertiesConstants;
+import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.editor.PDESourcePage;
+import org.eclipse.swt.graphics.Image;
 
 public class BuildPropertiesContentAssistProcessor extends TypePackageCompletionProcessor {
 
 	protected PDESourcePage fSourcePage;
+
 	public BuildPropertiesContentAssistProcessor(PDESourcePage sourcePage) {
 		fSourcePage = sourcePage;
 	}
@@ -44,7 +48,8 @@ public class BuildPropertiesContentAssistProcessor extends TypePackageCompletion
 					continue;
 				}
 				if (element.regionMatches(true, 0, value, 0, value.length())) {
-					TypeCompletionProposal proposal = new TypeCompletionProposal(element, null, element, lineStart,
+					Image img = getImage(element);
+					TypeCompletionProposal proposal = new TypeCompletionProposal(element, img, element, lineStart,
 							value.length());
 					completions.add(proposal);
 				}
@@ -53,5 +58,25 @@ public class BuildPropertiesContentAssistProcessor extends TypePackageCompletion
 		} catch (BadLocationException e) {
 		}
 		return null;
+	}
+
+	@SuppressWarnings("nls")
+	public Image getImage(String element) {
+		ImageDescriptor desc = switch (element)
+			{
+			case "src.includes", "src.excludes", "src.additionalRoots", "permissions", "root.", // linebreak
+					"root", ".permissions.", ".link", "folder.", ".folder.", "link", // linebreak
+					"source.", "sourceFileExtensions", "bin.includes", "bin.excludes", "javacCustomEncodings.", // linebreak
+					"javacDefaultEncoding." -> PDEPluginImages.DESC_CATEGORY_OBJ;
+			case ".jar", "jars.compile.order", "jars.extra.classpath" -> PDEPluginImages.DESC_JAR_LIB_OBJ;
+			case "javacProjectSettings" -> PDEPluginImages.DESC_SETTINGS_OBJ;
+			case "javacErrors." -> PDEPluginImages.DESC_ERROR_ST_OBJ;
+			case "significantVersionDigits", "generatedVersionLength" -> PDEPluginImages.DESC_INFO_ST_OBJ;
+			case "javacWarnings." -> PDEPluginImages.DESC_ALERT_OBJ;
+			case "jre.compilation.profile" -> PDEPluginImages.DESC_TARGET_ENVIRONMENT;
+			case "manifest." -> PDEPluginImages.DESC_FOLDER_OBJ;
+			default -> PDEPluginImages.DESC_DEFAULT_OBJ;
+			};
+		return desc != null ? desc.createImage() : null;
 	}
 }


### PR DESCRIPTION
Refs: https://github.com/eclipse-pde/eclipse.pde/pull/508
 
This PR addresses one of the pending items in the referenced PR. The auto-complete feature attaches most relevant image icons to the properties listing, so that the user is able to associate meaning of the property intuitively. 

The work is incomplete. I have taken some assumptions here, and would like to get some reviews before proceeding further. 

- Classified the headers of the build.properties specification
- Identified and attached the most meaningful existing images
- Provided a generic image for the default case(when the work completes I expect only very few items under this category.)

Please let me know what you think of the general approach.
