### PR TITLE
Add support for building plugins with using bnd as manifest generator

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ProjectClasspathPreferenceChangeListener.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ProjectClasspathPreferenceChangeListener.java
@@ -63,7 +63,9 @@ public class ProjectClasspathPreferenceChangeListener implements IPreferenceChan
 				IPluginModelBase model = PluginRegistry.findModel(project.getProject());
 				if (model != null) {
 					try {
-						initializer.requestClasspathContainerUpdate(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, project, new RequiredPluginsClasspathContainer(model, ClasspathUtilCore.getBuild(model)));
+						initializer.requestClasspathContainerUpdate(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, project,
+								new RequiredPluginsClasspathContainer(model, ClasspathUtilCore.getBuild(model),
+										project.getProject()));
 					} catch (CoreException e) {
 						Activator.log(e);
 					}

--- a/ui/org.eclipse.pde.core/.project
+++ b/ui/org.eclipse.pde.core/.project
@@ -35,6 +35,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/ui/org.eclipse.pde.core/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/ui/org.eclipse.pde.core/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_3
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -79,7 +79,14 @@ Export-Package:
    org.eclipse.pde.api.tools,
    org.eclipse.pde.unittest.junit",
  org.eclipse.pde.internal.core.variables;x-internal:=true
-Import-Package: aQute.bnd.osgi;version="5.5.0"
+Import-Package: aQute.bnd.build;version="[4.4.0,5.0.0)",
+ aQute.bnd.osgi;version="[5.5.0,6.0.0)",
+ aQute.bnd.osgi.repository;version="[3.0.0,4.0.0)",
+ aQute.bnd.osgi.resource;version="[4.3.0,5.0.0)",
+ aQute.bnd.service;version="[4.7.0,5.0.0)",
+ aQute.bnd.version;version="[2.2.0,3.0.0)",
+ org.osgi.service.repository;version="[1.1.0,2.0.0)",
+ org.osgi.util.promise;version="[1.3.0,2.0.0)"
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.8.0,2.0.0)",
@@ -109,3 +116,4 @@ Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.pde.core
+Service-Component: OSGI-INF/org.eclipse.pde.internal.core.bnd.BndResourceChangeListener.xml

--- a/ui/org.eclipse.pde.core/OSGI-INF/.gitignore
+++ b/ui/org.eclipse.pde.core/OSGI-INF/.gitignore
@@ -1,0 +1,1 @@
+org.eclipse.pde.*.xml

--- a/ui/org.eclipse.pde.core/build.properties
+++ b/ui/org.eclipse.pde.core/build.properties
@@ -21,7 +21,8 @@ bin.includes = plugin.properties,\
                targets/,\
                macosx/,\
                book.css,\
-               schema.css
+               schema.css,\
+               OSGI-INF/org.eclipse.pde.internal.core.bnd.BndResourceChangeListener.xml
 src.includes = about.html,\
                schema/
 output.. = bin/

--- a/ui/org.eclipse.pde.core/plugin.properties
+++ b/ui/org.eclipse.pde.core/plugin.properties
@@ -34,6 +34,7 @@ target_home.description = The location of the target platform
 
 ########## Builders and natures ###################
 natures.pluginNature.name= Plug-in Development
+natures.bndNature.name= Bundle Development
 natures.featureNature.name= Feature Development
 natures.siteNature.name= Update Site Development
 
@@ -41,6 +42,7 @@ builders.manifestBuilder.name = Plug-in Manifest Builder
 builders.marker.label = Plug-in Problem
 builders.schemaBuilder.name = Extension Point Schema Builder
 builders.featureBuilder.name = Feature Manifest Builder
+builders.bndBuilder.name = Bundle Builder
 builders.siteBuilder.name = Update Site Builder
 
 

--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -118,6 +118,16 @@
          </run>
       </runtime>
    </extension>
+   <extension
+         id="org.eclipse.pde.BndNature"
+         name="%natures.bndNature.name"
+         point="org.eclipse.core.resources.natures">
+      <runtime>
+         <run
+               class="org.eclipse.pde.internal.core.natures.BndProject">
+         </run>
+      </runtime>
+   </extension>
 
 <!-- ================================================================================= -->
 <!-- Builders                                                                          -->
@@ -163,6 +173,16 @@
          </run>
       </builder>
    </extension>
+   <extension
+      id="org.eclipse.pde.BndBuilder"
+      name="%builders.bndBuilder.name"
+      point="org.eclipse.core.resources.builders">
+      <builder>
+         <run
+               class="org.eclipse.pde.internal.core.bnd.BndBuilder">
+         </run>
+      </builder>
+	</extension> 
 
 <!-- ================================================================================= -->
 <!-- Markers                                                                           -->
@@ -409,5 +429,5 @@
           <locator
                 class="org.eclipse.pde.internal.core.LocalMavenPluginSourcePathLocator"
                 complexity="low"/>
-    </extension> 
+    </extension>
 </plugin>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
@@ -316,6 +316,8 @@ public class PDECoreMessages extends NLS {
 
 	public static String PluginModelManager_1;
 
+	public static String BundleBuilder_building;
+
 	public static String PluginModelManager_CurrentTargetPlatformContainsErrors;
 
 	public static String PluginModelManager_InitializingPluginModels;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
@@ -329,7 +329,7 @@ public class PluginModelManager implements IModelProviderListener {
 				IProject project = model.getUnderlyingResource().getProject();
 				try {
 					if (project.hasNature(JavaCore.NATURE_ID)) {
-						map.put(JavaCore.create(project), new RequiredPluginsClasspathContainer(model));
+						map.put(JavaCore.create(project), new RequiredPluginsClasspathContainer(model, project));
 					}
 				} catch (CoreException e) {
 				}
@@ -347,7 +347,7 @@ public class PluginModelManager implements IModelProviderListener {
 						if (project.hasNature(JavaCore.NATURE_ID)) {
 							IJavaProject jProject = JavaCore.create(project);
 							if (!map.containsKey(jProject)) {
-								map.put(jProject, new RequiredPluginsClasspathContainer(model));
+								map.put(jProject, new RequiredPluginsClasspathContainer(model, project));
 							}
 						}
 					}
@@ -368,7 +368,7 @@ public class PluginModelManager implements IModelProviderListener {
 					}
 					IBuild build = ClasspathUtilCore.getBuild(model);
 					if (build != null && build.getEntry(IBuildEntry.SECONDARY_DEPENDENCIES) != null) {
-						map.put(jProject, new RequiredPluginsClasspathContainer(model, build));
+						map.put(jProject, new RequiredPluginsClasspathContainer(model, build, project));
 					}
 				} catch (CoreException e) {
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -48,7 +48,8 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 		}
 		if (project.exists() && project.isOpen()) {
 			IPluginModelBase model = manager.findModel(project);
-			JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, new IJavaProject[] {javaProject}, new IClasspathContainer[] {new RequiredPluginsClasspathContainer(model)}, null);
+			JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, new IJavaProject[] { javaProject },
+					new IClasspathContainer[] { new RequiredPluginsClasspathContainer(model, project) }, null);
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IAccessRule;
 import org.eclipse.jdt.core.IClasspathAttribute;
@@ -47,13 +48,24 @@ public class OSGiAnnotationsClasspathContributor implements IClasspathContributo
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
 		IPluginModelBase model = PluginRegistry.findModel(project);
 		if (model != null) {
-			return OSGI_ANNOTATIONS.stream().map(PluginRegistry::findModel).filter(Objects::nonNull)
-					.filter(IPluginModelBase::isEnabled).map(IPluginModelBase::getInstallLocation)
-					.filter(Objects::nonNull).map(Path::new).map(path -> JavaCore.newLibraryEntry(path, path, Path.ROOT,
-							new IAccessRule[0], new IClasspathAttribute[0], false))
-					.collect(Collectors.toList());
+			return entries().collect(Collectors.toList());
 		}
 		return Collections.emptyList();
+	}
+
+	static Stream<IClasspathEntry> entries() {
+		return annotations().map(IPluginModelBase::getInstallLocation)
+				.filter(Objects::nonNull).map(Path::new).map(path -> JavaCore.newLibraryEntry(path, path, Path.ROOT,
+						new IAccessRule[0], new IClasspathAttribute[0], false));
+	}
+
+	/**
+	 * @return s stream of all current aviable annotations in the current plugin
+	 *         registry
+	 */
+	public static Stream<IPluginModelBase> annotations() {
+		return OSGI_ANNOTATIONS.stream().map(PluginRegistry::findModel).filter(Objects::nonNull)
+				.filter(IPluginModelBase::isEnabled);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.ProjectBuilder;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.PDECoreMessages;
+import org.eclipse.pde.internal.core.natures.BndProject;
+
+public class BndBuilder extends IncrementalProjectBuilder {
+
+	private static final String CLASS_EXTENSION = ".class"; //$NON-NLS-1$
+
+	private static final Predicate<IResource> classFilter = resource -> {
+		if (resource instanceof IFile) {
+			return resource.getName().endsWith(CLASS_EXTENSION);
+		}
+		return true;
+	};
+
+	private Map<IProject, Job> buildJobMap = new ConcurrentHashMap<>();
+
+	public static final String BUILDER_ID = "org.eclipse.pde.BndBuilder";//$NON-NLS-1$
+
+	@Override
+	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
+		IProject project = getProject();
+		if (BndProject.isBndProject(project) && hasRelevantDelta(getDelta(project))) {
+			Job buildJob = buildJobMap.compute(project, (p, oldJob) -> {
+				Job job = Job.create(NLS.bind(PDECoreMessages.BundleBuilder_building, project.getName()),
+						new BndBuild(p, oldJob));
+				job.addJobChangeListener(new JobChangeAdapter() {
+					@Override
+					public void done(IJobChangeEvent event) {
+						buildJobMap.remove(p, job);
+					}
+				});
+				return job;
+			});
+			buildJob.schedule();
+		}
+		return new IProject[] { project };
+	}
+
+	private static final class BndBuild implements ICoreRunnable {
+
+		private IProject project;
+		private Job oldJob;
+
+		public BndBuild(IProject project, Job oldJob) {
+			this.project = project;
+			this.oldJob = oldJob;
+		}
+
+		@Override
+		public void run(IProgressMonitor monitor) {
+
+			if (oldJob != null) {
+				oldJob.cancel();
+				try {
+					oldJob.join();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					return;
+				}
+			}
+			try {
+				Optional<Project> bndProject = BndProjectManager.getBndProject(project);
+				if (bndProject.isEmpty()) {
+					return;
+				}
+				if (monitor.isCanceled()) {
+					return;
+				}
+				try (Project bnd = bndProject.get(); ProjectBuilder builder = new ProjectBuilder(bnd)) {
+					builder.setBase(bnd.getBase());
+					ProjectJar jar = new ProjectJar(project, classFilter);
+					builder.setJar(jar);
+					builder.build();
+				}
+				if (monitor.isCanceled()) {
+					return;
+				}
+			} catch (Exception e) {
+				PDECore.log(e);
+			}
+		}
+	}
+
+	private static boolean hasRelevantDelta(IResourceDelta delta) throws CoreException {
+		if (delta != null) {
+			AtomicBoolean result = new AtomicBoolean();
+			delta.accept(new IResourceDeltaVisitor() {
+
+				@Override
+				public boolean visit(IResourceDelta delta) throws CoreException {
+					IResource resource = delta.getResource();
+					if (resource instanceof IFile) {
+						IFile file = (IFile) resource;
+						String name = file.getName();
+						if (name.endsWith(CLASS_EXTENSION) || file.getName().equals(Project.BNDFILE)) {
+							result.set(true);
+							return false;
+						}
+					}
+					return true;
+				}
+			});
+			return result.get();
+		}
+		return true;
+	}
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import aQute.bnd.build.Container;
+import aQute.bnd.build.Container.TYPE;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Processor;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IAccessRule;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.annotations.OSGiAnnotationsClasspathContributor;
+import org.eclipse.pde.internal.core.natures.BndProject;
+
+public class BndProjectManager {
+
+	private static final String DELIMITER = ","; //$NON-NLS-1$
+	private static final String TRUE = "true"; //$NON-NLS-1$
+	private static Workspace workspace;
+
+	public static Optional<Project> getBndProject(IProject project) throws Exception {
+		if (BndProject.isBndProject(project)) {
+			IPath projectPath = project.getLocation();
+			if (projectPath != null) {
+				File projectFolder = projectPath.toFile();
+				if (projectFolder != null) {
+					Project bnd = new Project(getWorkspace(), projectFolder);
+					bnd.setBase(projectFolder);
+					setupProject(bnd, project);
+					return Optional.of(bnd);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	private static void setupProject(Project bnd, IProject project) throws CoreException {
+		IPath base = project.getFullPath();
+		IJavaProject javaProject = JavaCore.create(project);
+		IClasspathEntry[] classpath = javaProject.getRawClasspath();
+		List<String> src = new ArrayList<>(1);
+		for (IClasspathEntry cpe : classpath) {
+			if (cpe.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+				src.add(cpe.getPath().makeRelativeTo(base).toString());
+			}
+		}
+		String outputLocation = javaProject.getOutputLocation().makeRelativeTo(base).toString();
+		bnd.setProperty(Constants.DEFAULT_PROP_SRC_DIR, src.stream().collect(Collectors.joining(DELIMITER)));
+		bnd.setProperty(Constants.DEFAULT_PROP_BIN_DIR, outputLocation);
+		String buildPath = bnd.getProperty(Constants.BUILDPATH);
+		Stream<String> enhnacedBuildPath = OSGiAnnotationsClasspathContributor.annotations()
+				.map(p -> p.getPluginBase().getId());
+		if (buildPath != null) {
+			enhnacedBuildPath = Stream.concat(Stream.of(buildPath), enhnacedBuildPath);
+		}
+		bnd.setProperty(Constants.BUILDPATH, enhnacedBuildPath.collect(Collectors.joining(DELIMITER)));
+	}
+
+	static synchronized Workspace getWorkspace() throws Exception {
+		Processor run = new Processor();
+		run.setProperty(Constants.STANDALONE, TRUE);
+		IPath path = PDECore.getDefault().getStateLocation().append(Project.BNDCNF);
+		if (workspace == null) {
+			workspace = Workspace.createStandaloneWorkspace(run, path.toFile().toURI());
+			workspace.addBasicPlugin(TargetRepository.getTargetRepository());
+			workspace.refresh();
+		}
+		return workspace;
+	}
+
+	static void publishContainerEntries(List<IClasspathEntry> entries, Collection<Container> containers,
+			boolean isTest) {
+		for (Container container : containers) {
+			TYPE type = container.getType();
+			if (type == TYPE.PROJECT) {
+				continue;
+			}
+			File file = container.getFile();
+			if (file.exists()) {
+				Path path = new Path(file.getAbsolutePath());
+				IClasspathAttribute[] attributes;
+				if (isTest) {
+					attributes = new IClasspathAttribute[] {
+							JavaCore.newClasspathAttribute(IClasspathAttribute.TEST, TRUE) };
+				} else {
+					attributes = new IClasspathAttribute[0];
+				}
+				entries.add(JavaCore.newLibraryEntry(path, null, Path.ROOT, new IAccessRule[0], attributes, false));
+			}
+		}
+	}
+
+	public static List<IClasspathEntry> getClasspathEntries(Project project, IWorkspaceRoot root) throws Exception {
+		List<IClasspathEntry> entries = new ArrayList<>();
+		for (Project dep : project.getBuildDependencies()) {
+			File base = dep.getBase();
+			@SuppressWarnings("deprecation")
+			IContainer[] containers = root.findContainersForLocation(new Path(base.getAbsolutePath()));
+			for (IContainer container : containers) {
+				if (container instanceof IProject) {
+					IProject p = (IProject) container;
+					entries.add(JavaCore.newProjectEntry(p.getFullPath()));
+				}
+			}
+		}
+		publishContainerEntries(entries, project.getBootclasspath(), false);
+		publishContainerEntries(entries, project.getBuildpath(), false);
+		publishContainerEntries(entries, project.getClasspath(), false);
+		publishContainerEntries(entries, project.getTestpath(), true);
+		return entries;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import aQute.bnd.build.Project;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.ClasspathContainerInitializer;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.PDECoreMessages;
+import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer;
+import org.eclipse.pde.internal.core.natures.BndProject;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = {})
+public class BndResourceChangeListener implements IResourceChangeListener {
+
+	@Reference
+	private IWorkspace workspace;
+
+	@Activate
+	void start() {
+		workspace.addResourceChangeListener(this);
+	}
+
+	@Deactivate
+	void stop() {
+		workspace.removeResourceChangeListener(this);
+	}
+
+	@Override
+	public void resourceChanged(IResourceChangeEvent event) {
+		IResourceDelta delta = event.getDelta();
+		if (delta != null) {
+			Set<IProject> updateProjects = new HashSet<>();
+			try {
+				delta.accept(new IResourceDeltaVisitor() {
+
+					@Override
+					public boolean visit(IResourceDelta delta) throws CoreException {
+						IResource resource = delta.getResource();
+						if (resource instanceof IFile) {
+							IFile file = (IFile) resource;
+							if (Project.BNDFILE.equals(file.getName()) && BndProject.isBndProject(file.getProject())) {
+								updateProjects.add(file.getProject());
+							}
+						}
+						return true;
+					}
+				});
+				if (updateProjects.size() > 0) {
+					performClasspathUpdate(updateProjects);
+				}
+			} catch (CoreException e) {
+				// can't do anything then...
+			}
+		}
+	}
+
+	private static void performClasspathUpdate(Collection<IProject> updateProjects) {
+		Job.create(PDECoreMessages.PluginModelManager_1, new ICoreRunnable() {
+
+			@Override
+			public void run(IProgressMonitor monitor) throws CoreException {
+				ClasspathContainerInitializer initializer = JavaCore
+						.getClasspathContainerInitializer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH.segment(0));
+				if (initializer == null) {
+					return;
+				}
+				for (IProject project : updateProjects) {
+					IJavaProject javaProject = JavaCore.create(project);
+					if (initializer.canUpdateClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, javaProject)) {
+							initializer.requestClasspathContainerUpdate(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH,
+								javaProject, new RequiredPluginsClasspathContainer(null, null, project));
+					}
+				}
+
+			}
+		}).schedule();
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/FileResource.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/FileResource.java
@@ -13,16 +13,22 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.bnd;
 
+import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.function.Predicate;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 
 /**
  * Wraps an {@link IFile} to a BND {@link Resource} that can be used to perform
@@ -91,6 +97,33 @@ public class FileResource implements Resource {
 
 		try (InputStream stream = openInputStream()) {
 			return ByteBuffer.wrap(stream.readAllBytes());
+		}
+	}
+
+	public static void addResources(Jar jar, IContainer container, Predicate<IResource> filter) throws CoreException {
+		addResources(jar, container, container.getProjectRelativePath().toString(), filter);
+	}
+
+	private static void addResources(Jar jar, IContainer container, String prefix, Predicate<IResource> filter)
+			throws CoreException {
+		if (container == null || !container.exists()) {
+			return;
+		}
+		for (IResource resource : container.members()) {
+			if (filter == null || filter.test(container)) {
+				if (resource instanceof IFile) {
+					IPath projectRelativePath = resource.getProjectRelativePath();
+					String relativePath = projectRelativePath.toString();
+					String base = relativePath.substring(prefix.length());
+					if (base.startsWith("/")) { //$NON-NLS-1$
+						base = base.substring(1);
+					}
+					jar.putResource(base, new FileResource((IFile) resource));
+				}
+				if (resource instanceof IContainer) {
+					addResources(jar, (IContainer) resource, prefix, filter);
+				}
+			}
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/ProjectJar.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/ProjectJar.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
+import java.io.InputStream;
+import java.util.function.Predicate;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+
+public class ProjectJar extends Jar {
+
+	private IFolder outputFolder;
+
+	public ProjectJar(IProject project, Predicate<IResource> filter) throws CoreException {
+		super(project.getName());
+		if (project.hasNature(JavaCore.NATURE_ID)) {
+			IJavaProject javaProject = JavaCore.create(project);
+			IPath outputLocation = javaProject.getOutputLocation();
+			IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
+			outputFolder = workspaceRoot.getFolder(outputLocation);
+			FileResource.addResources(this, outputFolder, filter);
+			IClasspathEntry[] classpath = javaProject.getResolvedClasspath(true);
+			for (IClasspathEntry cp : classpath) {
+				if (cp.getEntryKind() == IClasspathEntry.CPE_SOURCE && !cp.isTest()) {
+					IPath location = cp.getOutputLocation();
+					if (location != null) {
+						IFolder otherOutputFolder = workspaceRoot.getFolder(location);
+						FileResource.addResources(this, otherOutputFolder, filter);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean putResource(String path, Resource resource, boolean overwrite) {
+		if (resource instanceof FileResource) {
+			return super.putResource(path, resource, overwrite);
+		}
+		IFile file = outputFolder.getFile(path);
+		try {
+			if (file.exists()) {
+				if (overwrite) {
+					try (InputStream stream = resource.openInputStream()) {
+						file.setContents(stream, true, false, null);
+					}
+				}
+			} else {
+				mkdirs(file);
+				try (InputStream stream = resource.openInputStream()) {
+					file.create(stream, true, null);
+				}
+			}
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		return super.putResource(path, new FileResource(file), overwrite);
+	}
+
+	private void mkdirs(IResource resource) throws CoreException {
+		if (resource == null) {
+			return;
+		}
+		mkdirs(resource.getParent());
+		if (resource instanceof IFolder folder) {
+			if (!folder.exists()) {
+				folder.create(true, true, null);
+			}
+		}
+	}
+
+	public IFolder getOutputFolder() {
+		return outputFolder;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/TargetRepository.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/TargetRepository.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import aQute.bnd.osgi.Instruction;
+import aQute.bnd.osgi.repository.BaseRepository;
+import aQute.bnd.osgi.resource.ResourceUtils;
+import aQute.bnd.service.RepositoryPlugin;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.jar.Attributes;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.pde.core.plugin.IPluginLibrary;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.core.ClasspathUtilCore;
+import org.eclipse.pde.internal.core.PDECore;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+
+public class TargetRepository extends BaseRepository implements RepositoryPlugin {
+
+	private static final TargetRepository instance = new TargetRepository();
+
+	private TargetRepository() {
+	}
+
+	@Override
+	public File get(String bsn, aQute.bnd.version.Version version, Map<String, String> properties,
+			DownloadListener... listeners) throws Exception {
+		Optional<BundleDescription> description = getTargetPlatformState()
+				.map(state -> state.getBundle(bsn, convert(version)));
+		if (description.isEmpty()) {
+			// not found!
+			return null;
+		}
+		Optional<File> bundle = description.map(BundleDescription::getLocation).map(location -> new File(location))
+				.filter(File::isFile).or(() -> {
+					IPluginModelBase model = PluginRegistry.findModel(description.get());
+					if (model != null) {
+						IPluginLibrary[] libraries = model.getPluginBase().getLibraries();
+						String installLocation = model.getInstallLocation();
+						if (libraries.length == 0) {
+							return Optional.of(new File(installLocation));
+						}
+						for (IPluginLibrary library : libraries) {
+							if (IPluginLibrary.RESOURCE.equals(library.getType())) {
+								continue;
+							}
+							String name = library.getName();
+							String expandedName = ClasspathUtilCore.expandLibraryName(name);
+							return Optional.of(new File(installLocation, expandedName));
+						}
+					}
+					return Optional.empty();
+				});
+		if (bundle.isPresent()) {
+			File file = bundle.get();
+			for (DownloadListener l : listeners) {
+				try {
+					l.success(file);
+				} catch (Exception e) {
+				}
+			}
+			return file;
+		}
+		return null;
+	}
+
+	@Override
+	public boolean canWrite() {
+		return true;
+	}
+
+	@Override
+	public PutResult put(InputStream stream, PutOptions options) throws Exception {
+		State state = getTargetPlatformState().get();
+		Dictionary<String, String> headers = new Hashtable<>();
+		try (JarInputStream jar = new JarInputStream(stream)) {
+			Manifest manifest = jar.getManifest();
+			Attributes attributes = manifest.getMainAttributes();
+			attributes.entrySet().forEach(e -> headers.put(e.getKey().toString(), e.getValue().toString()));
+		}
+		BundleDescription description = state.getFactory().createBundleDescription(state, headers, null,
+				state.getHighestBundleId() + 1);
+		PutResult result = new PutResult();
+		result.alreadyReleased = state.updateBundle(description);
+		if (!result.alreadyReleased) {
+			state.addBundle(description);
+		}
+		result.digest = options.digest;
+		return result;
+	}
+
+	@Override
+	public List<String> list(String glob) throws Exception {
+
+		Stream<String> stream = bundles(null).map(BundleDescription::getSymbolicName).distinct();
+		if (glob != null) {
+			Instruction pattern = new Instruction(glob);
+			stream = stream.filter(bsn -> pattern.matches(bsn));
+		}
+		return stream.collect(Collectors.toList());
+	}
+
+	@Override
+	public SortedSet<aQute.bnd.version.Version> versions(String bsn) throws Exception {
+		return bundles(bsn).filter(bd -> bd.getLocation() != null).map(bundle -> bundle.getVersion())
+				.map(v -> convert(v)).collect(Collectors.toCollection(TreeSet::new));
+	}
+
+	@Override
+	public String getName() {
+		return "PDE Target Platform State"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String getLocation() {
+		return "pde-target-state"; //$NON-NLS-1$
+	}
+
+	@Override
+	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
+		return ResourceUtils.findProviders(requirements, this::findProvider);
+	}
+
+	public List<Capability> findProvider(Requirement requirement) {
+		String namespace = requirement.getNamespace();
+		return bundles(null).flatMap(resource -> ResourceUtils.capabilityStream(resource, namespace))
+				.filter(ResourceUtils.matcher(requirement, ResourceUtils::filterPredicate))
+				.collect(ResourceUtils.toCapabilities());
+	}
+
+	/**
+	 * Aquires a stream of bundles from the current state
+	 *
+	 * @param bsn
+	 *            the bsn to find (exact match) or <code>null</code> to return
+	 *            all aviable bundles
+	 * @return A stream of bundles from the current PDE state that match the
+	 *         given bsn
+	 */
+	private static Stream<BundleDescription> bundles(String bsn) {
+		Optional<State> state = getTargetPlatformState();
+		if (state.isEmpty()) {
+			return Stream.empty();
+		}
+		BundleDescription[] bundles;
+		if (bsn == null) {
+			bundles = state.get().getBundles();
+		} else {
+			bundles = state.get().getBundles(bsn);
+		}
+		return Arrays.stream(bundles);
+	}
+
+	/**
+	 * Aquires the current PDE target platform state
+	 *
+	 * @return an {@link Optional} describing the current PDE target platform
+	 *         state or an empty optional if no state is currently aviable
+	 */
+	private static Optional<State> getTargetPlatformState() {
+		PDECore pde = PDECore.getDefault();
+		if (pde == null) {
+			// This seems to be called outside of PDE running, so simply assume
+			// there is no state..
+			return Optional.empty();
+		}
+		try {
+			return Optional.of(pde.getModelManager().getState().getState());
+		} catch (RuntimeException e) {
+			// PDE is active but there is still a small chance that something
+			// still goes wrong, so in this case we return an empty optional,
+			// later calls to this method still might succeed then.
+			return Optional.empty();
+		}
+	}
+
+	private static org.osgi.framework.Version convert(aQute.bnd.version.Version version) {
+		return new org.osgi.framework.Version(version.getMajor(), version.getMinor(), version.getMicro(),
+				version.getQualifier());
+	}
+
+	private static aQute.bnd.version.Version convert(org.osgi.framework.Version v) {
+		return new aQute.bnd.version.Version(v.getMajor(), v.getMinor(), v.getMicro(), v.getQualifier());
+	}
+
+	public static TargetRepository getTargetRepository() {
+		return instance;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/natures/BndProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/natures/BndProject.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.natures;
+
+import aQute.bnd.build.Project;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.pde.internal.core.bnd.BndBuilder;
+
+public class BndProject extends BaseProject {
+
+	public static final String NATURE_ID = "org.eclipse.pde.BndNature"; //$NON-NLS-1$
+
+	@Override
+	public void configure() throws CoreException {
+		addToBuildSpec(BndBuilder.BUILDER_ID);
+	}
+
+	@Override
+	public void deconfigure() throws CoreException {
+		removeFromBuildSpec(BndBuilder.BUILDER_ID);
+	}
+
+	public static boolean isBndProject(IProject project) {
+		if (project.isOpen() && hasRequiredNatures(project)) {
+			IFile buildFile = project.getFile(Project.BNDFILE);
+			return buildFile.exists();
+		}
+		return false;
+	}
+
+	private static boolean hasRequiredNatures(IProject project) {
+		try {
+			return project.hasNature(BndProject.NATURE_ID) && project.hasNature(JavaCore.NATURE_ID);
+		} catch (CoreException e) {
+			return false;
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
@@ -245,6 +245,8 @@ PluginModelManager_InitializingPluginModels=Initializing plug-in models
 PluginModelManager_PlatformAdminMissingErrorMessage=The Plug-in Development Environment requires the PlatformAdmin service to operate. Please install the compatibility fragment 'org.eclipse.osgi.compatibility.state'.
 PluginModelManager_TargetInitCancelledLog=Target platform initialization cancelled. To reload, open Window > Preferences > Plug-in Development > Target Platform, select the current target platform and press Reload.
 
+BundleBuilder_building=Build Bundle {0}...
+
 # {0} will be a product id, this string will be the name of a p2 repository 
 ProductExportOperation_0={0} Repository
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
@@ -17,17 +17,22 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEManager;
+import org.eclipse.pde.internal.core.natures.BndProject;
 import org.osgi.service.prefs.BackingStoreException;
 
 /**
@@ -59,6 +64,18 @@ public class PDEProject {
 			if (string != null) {
 				IPath path = Path.fromPortableString(string);
 				return project.getFolder(path);
+			}
+		}
+		if (BndProject.isBndProject(project)) {
+			IJavaProject javaProject = JavaCore.create(project);
+			IPath outputLocation;
+			try {
+				outputLocation = javaProject.getOutputLocation();
+				IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
+				IFolder outputFolder = workspaceRoot.getFolder(outputLocation);
+				return outputFolder;
+			} catch (JavaModelException e) {
+				// can't get output folder... fall through as last resort.
 			}
 		}
 		return project;

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
@@ -52,7 +52,7 @@ public class ClasspathResolutionTest {
 		project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
 		IJavaProject javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
 		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
-				PDECore.getDefault().getModelManager().findModel(project));
+				PDECore.getDefault().getModelManager().findModel(project), project);
 		for (IClasspathEntry entry : container.getClasspathEntries()) {
 			if (entry.getPath().lastSegment().contains("org.w3c.dom.events")) {
 				fail(entry.getPath() + " erronesously present in container");
@@ -81,7 +81,7 @@ public class ClasspathResolutionTest {
 		// In Java 11, javax.annotation is not present, so the bundle *must* be
 		// part of classpath
 		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
-				PDECore.getDefault().getModelManager().findModel(project));
+				PDECore.getDefault().getModelManager().findModel(project), project);
 		assertTrue("javax.annotation is missing from required bundle",
 				Arrays.stream(container.getClasspathEntries()).map(IClasspathEntry::getPath).map(IPath::lastSegment)
 				.anyMatch(fileName -> fileName.contains("javax.annotation")));
@@ -99,7 +99,7 @@ public class ClasspathResolutionTest {
 		// In Java 11, javax.annotation is not present, so the bundle *must* be
 		// part of classpath, even if no BREE is specified
 		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
-				PDECore.getDefault().getModelManager().findModel(project));
+				PDECore.getDefault().getModelManager().findModel(project), project);
 		assertTrue("javax.annotation is missing from required bundle",
 				Arrays.stream(container.getClasspathEntries()).map(IClasspathEntry::getPath).map(IPath::lastSegment)
 				.anyMatch(fileName -> fileName.contains("javax.annotation")));
@@ -113,7 +113,7 @@ public class ClasspathResolutionTest {
 		// In Java 8, javax.annotation is present, so the bundle must *NOT* be
 		// part of classpath
 		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
-				PDECore.getDefault().getModelManager().findModel(project));
+				PDECore.getDefault().getModelManager().findModel(project), project);
 		assertTrue("javax.annotations shouldn't be present in required bundles",
 				Arrays.stream(container.getClasspathEntries()).map(IClasspathEntry::getPath).map(IPath::lastSegment)
 				.noneMatch(fileName -> fileName.contains("javax.annotation")));
@@ -128,7 +128,7 @@ public class ClasspathResolutionTest {
 		// Require-Capability
 		// --> javax.annotation bundle must not be on the classpath
 		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
-				PDECore.getDefault().getModelManager().findModel(project));
+				PDECore.getDefault().getModelManager().findModel(project), project);
 		assertTrue("javax.annotations shouldn't be present in required bundles",
 				Arrays.stream(container.getClasspathEntries()).map(IClasspathEntry::getPath).map(IPath::lastSegment)
 				.noneMatch(fileName -> fileName.contains("javax.annotation")));

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/RequiredPluginsContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/RequiredPluginsContainerPage.java
@@ -186,7 +186,7 @@ public class RequiredPluginsContainerPage extends WizardPage implements IClasspa
 			entry = ClasspathComputer.createContainerEntry();
 			IPluginModelBase model = PluginRegistry.findModel(javaProject.getProject());
 			if (model != null) {
-				IClasspathContainer container = new RequiredPluginsClasspathContainer(model);
+				IClasspathContainer container = new RequiredPluginsClasspathContainer(model, javaProject.getProject());
 				realEntries = container.getClasspathEntries();
 			}
 		} else {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifest.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifest.java
@@ -220,7 +220,7 @@ public class OrganizeManifest implements IOrganizeManifestsSettings {
 		try (Jar jar = new Jar(project.getProject().getName()); Analyzer analyzer = new Analyzer(jar)) {
 			analyzer.setImportPackage("*"); //$NON-NLS-1$
 			IFolder folder = workspaceRoot.getFolder(outputLocation);
-			addResources(jar, folder, folder.getProjectRelativePath().toString());
+			FileResource.addResources(jar, folder, null);
 			for (IClasspathEntry cp : classpath) {
 				if (cp.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
 					File file = cp.getPath().toFile();
@@ -232,7 +232,7 @@ public class OrganizeManifest implements IOrganizeManifestsSettings {
 					IPath location = cp.getOutputLocation();
 					if (location != null) {
 						IFolder folder2 = workspaceRoot.getFolder(location);
-						addResources(jar, folder2, folder2.getProjectRelativePath().toString());
+						FileResource.addResources(jar, folder2, null);
 					}
 
 				}
@@ -261,26 +261,6 @@ public class OrganizeManifest implements IOrganizeManifestsSettings {
 
 		} catch (Exception e) {
 			throw new CoreException(Status.error("Error generating manifest!", e)); //$NON-NLS-1$
-		}
-	}
-
-	private static void addResources(Jar jar, IContainer container, String prefix) throws CoreException {
-		if (container == null || !container.exists()) {
-			return;
-		}
-		for (IResource resource : container.members()) {
-			if (resource instanceof IFile) {
-				IPath projectRelativePath = resource.getProjectRelativePath();
-				String relativePath = projectRelativePath.toString();
-				String base = relativePath.substring(prefix.length());
-				if (base.startsWith("/")) { //$NON-NLS-1$
-					base = base.substring(1);
-				}
-				jar.putResource(base, new FileResource((IFile) resource));
-			}
-			if (resource instanceof IContainer) {
-				addResources(jar, (IContainer) resource, prefix);
-			}
 		}
 	}
 


### PR DESCRIPTION
Currently PDE only supports a "Manifest-First" approach whne building plugins, but actually most of the data in a manifest can be derived from the compiled class files and sources.

This adds a very basic aproach to support "Code-First" but still retain the basic concepts of PDE like a target platform and the integration with the existing PDE ecosystem.

# How to try this out

1. create a new java project
2. create a file `bnd.bnd` in the root of the project (see below for an example)
3. add the nature `org.eclipse.pde.BndNature` (this should automatically add the
```
<buildCommand>
	<name>org.eclipse.pde.BndBuilder</name>
</buildCommand> 
```

You can now configure the project in the BND file, for example similar to this:
```
Bundle-SymbolicName: my.first.bnd.test
Bundle-Name: This is a test showing the new auto-generated Manifest feature
Bundle-Version: 1.0.0.qualifier

-buildpath: org.eclipse.osgi,\
     ... other bundle names you want on the classpath ...
```

Whats not included but can be added later on based on this:

- auto completion / basic syntax highlight
- quickfixes to add missing `buildpath` entries like for a Manifest-First-Plugin
- conversion / configuration of existing project
- enhancing of the new project wizard to support the new type
- open the manifest editor and show a new tab when double-click on a `bnd.bnd` file
- ...