### PR TITLE
Remove manual tycho-surefire dependency

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
@@ -47,11 +47,6 @@
       		<dependency-resolution>
          		<extraRequirements>
              <requirement>
-              <type>eclipse-plugin</type>
-              <id>org.eclipse.osgi.compatibility.state</id>
-              <versionRange>0.0.0</versionRange>
-            </requirement> 
-             <requirement>
               <type>eclipse-feature</type>
               <id>org.eclipse.platform</id>
               <versionRange>0.0.0</versionRange>


### PR DESCRIPTION
Bundle o.e.pde.genericeditor.extension.tests no longer requires o.e.osgi.compatibility.state bundles or it was even copy-paste from somewhere.
This reduces possible differences between I-build tests and Maven testing.