### PR TITLE
Add missing shortcuts for the project explorer

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -118,7 +118,8 @@ Require-Bundle:
  org.eclipse.help;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)",
  org.eclipse.equinox.security;bundle-version="[1.2.200,2.0.0)",
- biz.aQute.bndlib;bundle-version="6.3.1"
+ biz.aQute.bndlib;bundle-version="6.3.1",
+ org.eclipse.ui.navigator
 Eclipse-LazyStart: true
 Import-Package: org.eclipse.jdt.debug.ui.console,
  org.eclipse.ui.internal.genericeditor,

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -2388,4 +2388,47 @@
          </managedMarker>
       </compilationParticipant>
    </extension>
+      <extension
+            point="org.eclipse.ui.navigator.navigatorContent">
+         <commonWizard
+               menuGroupId="org.eclipse.pde.PDE"
+               type="new"
+               wizardId="org.eclipse.pde.ui.NewProjectWizard">
+		    <enablement>
+				<with variable="activeWorkbenchWindow.activePerspective">
+					<equals value="org.eclipse.pde.ui.PDEPerspective"/>
+				</with>
+			</enablement>
+         </commonWizard>
+         <commonWizard
+               menuGroupId="org.eclipse.pde.PDE"
+               type="new"
+               wizardId="org.eclipse.pde.ui.NewFeatureProjectWizard">
+		    <enablement>
+				<with variable="activeWorkbenchWindow.activePerspective">
+					<equals value="org.eclipse.pde.ui.PDEPerspective"/>
+				</with>
+			</enablement>
+         </commonWizard>
+         <commonWizard
+               menuGroupId="org.eclipse.pde.PDE"
+               type="new"
+               wizardId="org.eclipse.pde.ui.NewProductConfigurationWizard">
+		    <enablement>
+				<with variable="activeWorkbenchWindow.activePerspective">
+					<equals value="org.eclipse.pde.ui.PDEPerspective"/>
+				</with>
+			</enablement>
+         </commonWizard>
+         <commonWizard
+               menuGroupId="org.eclipse.pde.PDE"
+               type="new"
+               wizardId="org.eclipse.pde.ui.NewProfileWizard">
+		    <enablement>
+				<with variable="activeWorkbenchWindow.activePerspective">
+					<equals value="org.eclipse.pde.ui.PDEPerspective"/>
+				</with>
+			</enablement>
+         </commonWizard>
+      </extension>
 </plugin>


### PR DESCRIPTION
Currently only items are shown in the package-explorer or in the file menu but not in project explorer:

## File Menu
![menu](https://user-images.githubusercontent.com/1331477/229289042-67d1cc11-ec6e-47c7-8f05-8efce4c7864a.png)

## Package Explorer
![package_explorer](https://user-images.githubusercontent.com/1331477/229289064-292a1e65-16fa-4345-9570-5de4f173f972.png)

## Project Explorer
![project_explorer](https://user-images.githubusercontent.com/1331477/229289087-35141008-fdee-49b7-848b-b5fb341a7c29.png)

This adds the missing items to the project explorer as well.