### PR TITLE
Use p2.inf to pull in depedency to org.eclipse.jdt.launching.macosx

### DIFF
--- a/ui/org.eclipse.pde.ui.tests.smartimport/META-INF/p2.inf
+++ b/ui/org.eclipse.pde.ui.tests.smartimport/META-INF/p2.inf
@@ -1,0 +1,3 @@
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.jdt.launching.macosx
+requires.0.filter = (osgi.os=macosx)


### PR DESCRIPTION
jdt.launcher requires special treatment to find jvms on MacOS that is handeled with an additional bundle and the pde.smartimport test depend on the launching framework.

This adds a p2.inf that pulls in this additional depenedency using a p2.inf for the test framework resoloution.