### PR TITLE
Display generated manifest and bnd instructions in manifest editor

### DIFF
--- a/ui/org.eclipse.pde.core/plugin.properties
+++ b/ui/org.eclipse.pde.core/plugin.properties
@@ -60,6 +60,7 @@ siteManifestName = Update Site Manifest File
 pluginPropertiesName = Plug-in Properties File
 productConfiguration = Product Configuration File
 buildPropertiesName = Build Properties File
+bndInstructionsName = BND Instructions File
 schemaFile = Extension Point Schema File
 bundleManifest = Bundle Manifest File
 target.profile.content = Target Profile File

--- a/ui/org.eclipse.pde.core/plugin.xml
+++ b/ui/org.eclipse.pde.core/plugin.xml
@@ -338,6 +338,13 @@
             priority="high"
             file-names="plugin.properties"/>
       <content-type
+            base-type="org.eclipse.jdt.core.javaProperties"
+            default-charset="UTF-8"
+            file-names="bnd.bnd,pde.bnd"
+            id="org.eclipse.pde.bndInstructions"
+            name="%bndInstructionsName"
+            priority="high"/>
+      <content-type
             id="org.eclipse.pde.buildProperties"
             name="%buildPropertiesName"
             base-type="org.eclipse.jdt.core.javaProperties"

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/FileAdapter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/FileAdapter.java
@@ -16,6 +16,7 @@ package org.eclipse.pde.internal.core;
 import java.io.File;
 import java.util.Locale;
 import org.eclipse.core.runtime.PlatformObject;
+import org.eclipse.pde.internal.core.natures.BndProject;
 
 public class FileAdapter extends PlatformObject {
 	private final File fFile;
@@ -35,7 +36,10 @@ public class FileAdapter extends PlatformObject {
 
 	public boolean isManifest() {
 		String fileName = fFile.getName();
-		return (fileName.equals(ICoreConstants.PLUGIN_FILENAME_DESCRIPTOR) || fileName.equals(ICoreConstants.FRAGMENT_FILENAME_DESCRIPTOR) || fileName.equalsIgnoreCase(ICoreConstants.MANIFEST_FILENAME));
+		return (fileName.equals(ICoreConstants.PLUGIN_FILENAME_DESCRIPTOR)
+				|| fileName.equals(ICoreConstants.FRAGMENT_FILENAME_DESCRIPTOR)
+				|| fileName.equalsIgnoreCase(ICoreConstants.MANIFEST_FILENAME))
+				|| fileName.equalsIgnoreCase(BndProject.INSTRUCTIONS_FILE);
 	}
 
 	public boolean isSchema() {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
@@ -128,7 +128,7 @@ public class BndBuilder extends IncrementalProjectBuilder {
 					if (resource instanceof IFile) {
 						IFile file = (IFile) resource;
 						String name = file.getName();
-						if (name.endsWith(CLASS_EXTENSION) || file.getName().equals(Project.BNDFILE)) {
+						if (name.endsWith(CLASS_EXTENSION) || file.getName().equals(BndProject.INSTRUCTIONS_FILE)) {
 							result.set(true);
 							return false;
 						}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
@@ -53,7 +53,8 @@ public class BndProjectManager {
 			if (projectPath != null) {
 				File projectFolder = projectPath.toFile();
 				if (projectFolder != null) {
-					Project bnd = new Project(getWorkspace(), projectFolder);
+					Project bnd = new Project(getWorkspace(), projectFolder,
+							new File(projectFolder, BndProject.INSTRUCTIONS_FILE));
 					bnd.setBase(projectFolder);
 					setupProject(bnd, project);
 					return Optional.of(bnd);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.bnd;
 
-import aQute.bnd.build.Project;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -51,7 +50,8 @@ public class BndResourceChangeListener implements IResourceChangeListener {
 						IResource resource = delta.getResource();
 						if (resource instanceof IFile) {
 							IFile file = (IFile) resource;
-							if (Project.BNDFILE.equals(file.getName()) && BndProject.isBndProject(file.getProject())) {
+							if (BndProject.INSTRUCTIONS_FILE.equals(file.getName())
+									&& BndProject.isBndProject(file.getProject())) {
 								updateProjects.add(file.getProject());
 							}
 						}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/natures/BndProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/natures/BndProject.java
@@ -22,6 +22,10 @@ public class BndProject extends BaseProject {
 
 	public static final String NATURE_ID = "org.eclipse.pde.BndNature"; //$NON-NLS-1$
 
+	public static final String INSTRUCTIONS_FILE_EXTENSION = ".bnd"; //$NON-NLS-1$
+
+	public static final String INSTRUCTIONS_FILE = "pde" + INSTRUCTIONS_FILE_EXTENSION; //$NON-NLS-1$
+
 	@Override
 	public void configure() throws CoreException {
 		addToBuildSpec(BndBuilder.BUILDER_ID);

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -343,7 +343,8 @@
             id="org.eclipse.pde.ui.manifestEditor">
             <contentTypeBinding contentTypeId="org.eclipse.pde.pluginManifest"/>
             <contentTypeBinding contentTypeId="org.eclipse.pde.fragmentManifest"/>
-            <contentTypeBinding contentTypeId="org.eclipse.pde.bundleManifest"/>            
+            <contentTypeBinding contentTypeId="org.eclipse.pde.bundleManifest"/>
+            <contentTypeBinding contentTypeId="org.eclipse.pde.bndInstructions"/>
       </editor>
       <editor
             default="true"

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndInputContext.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndInputContext.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.bnd;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.pde.core.IBaseModel;
+import org.eclipse.pde.core.IModelChangedEvent;
+import org.eclipse.pde.internal.ui.editor.PDEFormEditor;
+import org.eclipse.pde.internal.ui.editor.context.InputContext;
+import org.eclipse.text.edits.TextEdit;
+import org.eclipse.ui.IEditorInput;
+
+public class BndInputContext extends InputContext {
+	public static final String CONTEXT_ID = "bnd-context"; //$NON-NLS-1$
+
+	public BndInputContext(PDEFormEditor editor, IEditorInput input, boolean primary) {
+		super(editor, input, primary);
+		create();
+	}
+
+	@Override
+	protected Charset getDefaultCharset() {
+		return StandardCharsets.UTF_8;
+	}
+
+	@Override
+	protected IBaseModel createModel(IEditorInput input) throws CoreException {
+		return new BndModel();
+	}
+
+	@Override
+	public String getId() {
+		return CONTEXT_ID;
+	}
+
+	@Override
+	protected void addTextEditOperation(ArrayList<TextEdit> ops, IModelChangedEvent event) {
+	}
+
+	@Override
+	public void doRevert() {
+	}
+
+	@Override
+	protected String getPartitionName() {
+		return "___bnd_partition"; //$NON-NLS-1$
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndModel.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndModel.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.bnd;
+
+import org.eclipse.pde.core.IBaseModel;
+
+public class BndModel implements IBaseModel {
+
+	private volatile boolean disposed;
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	@Override
+	public void dispose() {
+		disposed = true;
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return disposed;
+	}
+
+	@Override
+	public boolean isEditable() {
+		return false;
+	}
+
+	@Override
+	public boolean isValid() {
+		return true;
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ExecutionEnvironmentSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ExecutionEnvironmentSection.java
@@ -416,8 +416,10 @@ public class ExecutionEnvironmentSection extends TableSection {
 
 	protected boolean isFragment() {
 		InputContextManager manager = getPage().getPDEEditor().getContextManager();
-		IPluginModelBase model = (IPluginModelBase) manager.getAggregateModel();
-		return model.isFragmentModel();
+		if (manager.getAggregateModel() instanceof IPluginModelBase model) {
+			return model.isFragmentModel();
+		}
+		return false;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ExportPackageSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ExportPackageSection.java
@@ -88,8 +88,10 @@ public class ExportPackageSection extends TableSection {
 	}
 
 	private boolean isFragment() {
-		IPluginModelBase model = (IPluginModelBase) getPage().getPDEEditor().getAggregateModel();
-		return model != null && model.isFragmentModel();
+		if (getPage().getPDEEditor().getAggregateModel() instanceof IPluginModelBase model) {
+			return model.isFragmentModel();
+		}
+		return false;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ImportPackageSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ImportPackageSection.java
@@ -171,8 +171,10 @@ public class ImportPackageSection extends TableSection {
 	}
 
 	private boolean isFragment() {
-		IPluginModelBase model = (IPluginModelBase) getPage().getPDEEditor().getAggregateModel();
-		return model != null && model.isFragmentModel();
+		if (getPage().getPDEEditor().getAggregateModel() instanceof IPluginModelBase model) {
+			return model.isFragmentModel();
+		}
+		return false;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/LibrarySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/LibrarySection.java
@@ -108,9 +108,11 @@ public class LibrarySection extends TableSection implements IBuildPropertiesCons
 	private String getSectionDescription() {
 		IPluginModelBase model = getModel();
 		if (isBundle()) {
-			return (model.isFragmentModel()) ? PDEUIMessages.ClasspathSection_fragment : PDEUIMessages.ClasspathSection_plugin;
+			return (model != null && model.isFragmentModel()) ? PDEUIMessages.ClasspathSection_fragment
+					: PDEUIMessages.ClasspathSection_plugin;
 		}
-		return (model.isFragmentModel()) ? PDEUIMessages.ManifestEditor_LibrarySection_fdesc : PDEUIMessages.ManifestEditor_LibrarySection_desc;
+		return (model != null && model.isFragmentModel()) ? PDEUIMessages.ManifestEditor_LibrarySection_fdesc
+				: PDEUIMessages.ManifestEditor_LibrarySection_desc;
 	}
 
 	protected boolean isBundle() {
@@ -144,8 +146,10 @@ public class LibrarySection extends TableSection implements IBuildPropertiesCons
 		section.setClient(container);
 
 		IPluginModelBase model = getModel();
-		fLibraryTable.setInput(model.getPluginBase());
-		model.addModelChangedListener(this);
+		if (model != null) {
+			fLibraryTable.setInput(model.getPluginBase());
+			model.addModelChangedListener(this);
+		}
 	}
 
 	private void updateButtons() {
@@ -696,7 +700,10 @@ public class LibrarySection extends TableSection implements IBuildPropertiesCons
 	}
 
 	private IPluginModelBase getModel() {
-		return (IPluginModelBase) getPage().getModel();
+		if (getPage().getModel() instanceof IPluginModelBase base) {
+			return base;
+		}
+		return null;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestOutlinePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestOutlinePage.java
@@ -31,17 +31,18 @@ public class ManifestOutlinePage extends FormOutlinePage {
 	protected Object[] getChildren(Object parent) {
 		if (parent instanceof PDEFormPage) {
 			PDEFormPage page = (PDEFormPage) parent;
-			IPluginModelBase model = (IPluginModelBase) page.getModel();
-			if (model != null && model.isValid()) {
-				IPluginBase pluginBase = model.getPluginBase();
-				if (page.getId().equals(DependenciesPage.PAGE_ID))
-					return pluginBase.getImports();
-				if (page.getId().equals(RuntimePage.PAGE_ID))
-					return pluginBase.getLibraries();
-				if (page.getId().equals(ExtensionsPage.PAGE_ID))
-					return pluginBase.getExtensions();
-				if (page.getId().equals(ExtensionPointsPage.PAGE_ID))
-					return pluginBase.getExtensionPoints();
+			if (page.getModel() instanceof IPluginModelBase model) {
+				if (model.isValid()) {
+					IPluginBase pluginBase = model.getPluginBase();
+					if (page.getId().equals(DependenciesPage.PAGE_ID))
+						return pluginBase.getImports();
+					if (page.getId().equals(RuntimePage.PAGE_ID))
+						return pluginBase.getLibraries();
+					if (page.getId().equals(ExtensionsPage.PAGE_ID))
+						return pluginBase.getExtensions();
+					if (page.getId().equals(ExtensionPointsPage.PAGE_ID))
+						return pluginBase.getExtensionPoints();
+				}
 			}
 		}
 		return new Object[0];

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/OverviewPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/OverviewPage.java
@@ -32,6 +32,7 @@ import org.eclipse.pde.internal.ui.editor.*;
 import org.eclipse.pde.internal.ui.editor.build.BuildInputContext;
 import org.eclipse.pde.internal.ui.editor.build.BuildPage;
 import org.eclipse.pde.internal.ui.editor.context.InputContext;
+import org.eclipse.pde.internal.ui.editor.context.InputContextManager;
 import org.eclipse.pde.internal.ui.nls.GetNonExternalizedStringsAction;
 import org.eclipse.pde.internal.ui.util.SharedLabelProvider;
 import org.eclipse.pde.internal.ui.wizards.tools.OrganizeManifestsAction;
@@ -198,11 +199,14 @@ public class OverviewPage extends LaunchShortcutOverviewPage {
 	}
 
 	private boolean isFragment() {
-		if (getPDEEditor().getContextManager() == null) {
+		InputContextManager contextManager = getPDEEditor().getContextManager();
+		if (contextManager == null) {
 			return false;
 		}
-		IPluginModelBase model = (IPluginModelBase) getPDEEditor().getContextManager().getAggregateModel();
-		return model.isFragmentModel();
+		if (contextManager.getAggregateModel() instanceof IPluginModelBase model) {
+			return model.isFragmentModel();
+		}
+		return false;
 	}
 
 	private boolean isBundle() {
@@ -210,8 +214,14 @@ public class OverviewPage extends LaunchShortcutOverviewPage {
 	}
 
 	private boolean isEditable() {
-		IPluginModelBase model = (IPluginModelBase) getPDEEditor().getContextManager().getAggregateModel();
-		return model.isEditable();
+		InputContextManager contextManager = getPDEEditor().getContextManager();
+		if (contextManager == null) {
+			return false;
+		}
+		if (contextManager.getAggregateModel() instanceof IPluginModelBase model) {
+			return model.isEditable();
+		}
+		return false;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/PluginGeneralInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/PluginGeneralInfoSection.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.plugin;
 
-import org.eclipse.pde.internal.core.ibundle.IManifestHeader;
-
 import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
 import java.util.ArrayList;
@@ -178,22 +176,21 @@ public class PluginGeneralInfoSection extends GeneralInfoSection {
 	public void refresh() {
 		if (fBlockListener)
 			return;
-		IPluginModelBase model = (IPluginModelBase) getPage().getModel();
 		// if we are refactoring, the Manifest moves before the editor closes.  This could cause the model to be null on a refresh()
-		if (model == null)
-			return;
-		IPlugin plugin = (IPlugin) model.getPluginBase();
-		// Only update this field if it already has not been modified
-		// This will prevent the cursor from being set to position 0 after
-		// accepting a field assist proposal using \r
-		if (fClassEntry.isDirty() == false) {
-			fClassEntry.setValue(plugin.getClassName(), true);
+		if (getPage().getModel() instanceof IPluginModelBase model) {
+			IPlugin plugin = (IPlugin) model.getPluginBase();
+			// Only update this field if it already has not been modified
+			// This will prevent the cursor from being set to position 0 after
+			// accepting a field assist proposal using \r
+			if (fClassEntry.isDirty() == false) {
+				fClassEntry.setValue(plugin.getClassName(), true);
+			}
+			if (fLazyStart != null) {
+				IManifestHeader header = getLazyStartHeader();
+				fLazyStart.setSelection(header instanceof LazyStartHeader && ((LazyStartHeader) header).isLazyStart());
+			}
+			super.refresh();
 		}
-		if (fLazyStart != null) {
-			IManifestHeader header = getLazyStartHeader();
-			fLazyStart.setSelection(header instanceof LazyStartHeader && ((LazyStartHeader) header).isLazyStart());
-		}
-		super.refresh();
 	}
 
 	private LazyStartHeader[] getLazyStartHeaders() {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/RequiresSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/RequiresSection.java
@@ -84,13 +84,20 @@ public class RequiresSection extends TableSection implements IPluginModelListene
 	public RequiresSection(DependenciesPage page, Composite parent, String[] labels) {
 		super(page, parent, Section.DESCRIPTION, labels);
 		getSection().setText(PDEUIMessages.RequiresSection_title);
-		boolean fragment = ((IPluginModelBase) getPage().getModel()).isFragmentModel();
+		boolean fragment = isFragment();
 		if (fragment)
 			getSection().setDescription(PDEUIMessages.RequiresSection_fDesc);
 		else
 			getSection().setDescription(PDEUIMessages.RequiresSection_desc);
 		getTablePart().setEditable(false);
 		resetImportInsertIndex();
+	}
+
+	private boolean isFragment() {
+		if (getPage().getModel() instanceof IPluginModelBase plugin) {
+			return plugin.isFragmentModel();
+		}
+		return false;
 	}
 
 	@Override
@@ -211,9 +218,9 @@ public class RequiresSection extends TableSection implements IPluginModelListene
 
 	@Override
 	public void dispose() {
-		IPluginModelBase model = (IPluginModelBase) getPage().getModel();
-		if (model != null)
+		if (getPage().getModel() instanceof IPluginModelBase model) {
 			model.removeModelChangedListener(this);
+		}
 		PDECore.getDefault().getModelManager().removePluginModelListener(this);
 		super.dispose();
 	}
@@ -490,15 +497,14 @@ public class RequiresSection extends TableSection implements IPluginModelListene
 	}
 
 	public void initialize() {
-		IPluginModelBase model = (IPluginModelBase) getPage().getModel();
-		if (model == null)
-			return;
-		fImportViewer.setInput(model.getPluginBase());
-		updateButtons();
-		model.addModelChangedListener(this);
 		PDECore.getDefault().getModelManager().addPluginModelListener(this);
-		fAddAction.setEnabled(model.isEditable());
-		fRemoveAction.setEnabled(model.isEditable());
+		if (getPage().getModel() instanceof IPluginModelBase model) {
+			fImportViewer.setInput(model.getPluginBase());
+			updateButtons();
+			model.addModelChangedListener(this);
+			fAddAction.setEnabled(model.isEditable());
+			fRemoveAction.setEnabled(model.isEditable());
+		}
 	}
 
 	private void makeActions() {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/RuntimePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/RuntimePage.java
@@ -31,12 +31,10 @@ public class RuntimePage extends PDEFormPage {
 
 	@Override
 	protected String getHelpResource() {
-		IPluginModelBase base = (IPluginModelBase) getPDEEditor().getAggregateModel();
-		if (base == null) {
-			return null;
+		if (getPDEEditor().getAggregateModel() instanceof IPluginModelBase base) {
+			if (base.isFragmentModel())
+				return IHelpContextIds.MANIFEST_FRAGMENT_RUNTIME;
 		}
-		if (base.isFragmentModel())
-			return IHelpContextIds.MANIFEST_FRAGMENT_RUNTIME;
 		return IHelpContextIds.MANIFEST_PLUGIN_RUNTIME;
 	}
 
@@ -61,14 +59,14 @@ public class RuntimePage extends PDEFormPage {
 			mform.addPart(new LibraryVisibilitySection(this, form.getBody()));
 		}
 
-		IPluginModelBase base = (IPluginModelBase) getPDEEditor().getAggregateModel();
-		if (base == null) {
-			return;
+		if (getPDEEditor().getAggregateModel() instanceof IPluginModelBase base) {
+			if (base.isFragmentModel())
+				PlatformUI.getWorkbench().getHelpSystem().setHelp(form.getBody(),
+						IHelpContextIds.MANIFEST_FRAGMENT_RUNTIME);
+			else
+				PlatformUI.getWorkbench().getHelpSystem().setHelp(form.getBody(),
+						IHelpContextIds.MANIFEST_PLUGIN_RUNTIME);
 		}
-		if (base.isFragmentModel())
-			PlatformUI.getWorkbench().getHelpSystem().setHelp(form.getBody(), IHelpContextIds.MANIFEST_FRAGMENT_RUNTIME);
-		else
-			PlatformUI.getWorkbench().getHelpSystem().setHelp(form.getBody(), IHelpContextIds.MANIFEST_PLUGIN_RUNTIME);
 	}
 
 	private boolean isBundle() {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationOperation.java
@@ -18,7 +18,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.wizards.plugin;
 
-import aQute.bnd.build.Project;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.properties.Document;
 import java.io.IOException;
@@ -414,7 +413,7 @@ public class NewProjectCreationOperation extends WorkspaceModifyOperation {
 			fModel.save();
 			openFile((IFile) fModel.getUnderlyingResource());
 		} else {
-			IFile file = project.getFile(Project.BNDFILE);
+			IFile file = project.getFile(BndProject.INSTRUCTIONS_FILE);
 			if (file.exists()) {
 				openFile(file);
 			}
@@ -438,7 +437,7 @@ public class NewProjectCreationOperation extends WorkspaceModifyOperation {
 		model.setBundleName(fData.getName());
 		model.setBundleVendor(fData.getProvider());
 		model.setBundleVersion(fData.getVersion());
-		IFile file = project.getFile(Project.BNDFILE);
+		IFile file = project.getFile(BndProject.INSTRUCTIONS_FILE);
 		try {
 			file.create(model.toAsciiStream(document), true, monitor);
 		} catch (IOException e) {


### PR DESCRIPTION
Currently the bnd instructions file is only displayed in a raw text editor, but this is very inconvenient as the user is not able to inspect the final results.

This connects the bnd instruction file with the usual manifest editor to edit the file and inspect the results in a way PDE users are familiar with.

### BND instructions source tab:
![grafik](https://user-images.githubusercontent.com/1331477/229351323-114e2947-66b7-4456-ad7e-61f79375571f.png)

### Generated Manifest source view
![grafik](https://user-images.githubusercontent.com/1331477/229351401-16f8060b-66c6-4aea-be2c-bbab520d7fa4.png)

### Overview page
![grafik](https://user-images.githubusercontent.com/1331477/229351482-de8e0551-6322-4784-bec5-d78ce8c8e8e2.png)
