### PR TITLE
Synchronize values changed in the Overview with the instructions file

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
@@ -66,18 +66,20 @@ public class BndProjectManager {
 
 	private static void setupProject(Project bnd, IProject project) throws CoreException {
 		IPath base = project.getFullPath();
-		IJavaProject javaProject = JavaCore.create(project);
-		IClasspathEntry[] classpath = javaProject.getRawClasspath();
-		List<String> src = new ArrayList<>(1);
-		for (IClasspathEntry cpe : classpath) {
-			if (cpe.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
-				src.add(cpe.getPath().makeRelativeTo(base).toString());
+		if (project.hasNature(JavaCore.NATURE_ID)) {
+			IJavaProject javaProject = JavaCore.create(project);
+			IClasspathEntry[] classpath = javaProject.getRawClasspath();
+			List<String> src = new ArrayList<>(1);
+			for (IClasspathEntry cpe : classpath) {
+				if (cpe.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+					src.add(cpe.getPath().makeRelativeTo(base).toString());
+				}
 			}
+			String outputLocation = javaProject.getOutputLocation().makeRelativeTo(base).toString();
+			bnd.setProperty(Constants.DEFAULT_PROP_SRC_DIR, src.stream().collect(Collectors.joining(DELIMITER)));
+			bnd.setProperty(Constants.DEFAULT_PROP_BIN_DIR, outputLocation);
+			bnd.setProperty(Constants.DEFAULT_PROP_TARGET_DIR, outputLocation);
 		}
-		String outputLocation = javaProject.getOutputLocation().makeRelativeTo(base).toString();
-		bnd.setProperty(Constants.DEFAULT_PROP_SRC_DIR, src.stream().collect(Collectors.joining(DELIMITER)));
-		bnd.setProperty(Constants.DEFAULT_PROP_BIN_DIR, outputLocation);
-		bnd.setProperty(Constants.DEFAULT_PROP_TARGET_DIR, outputLocation);
 		String buildPath = bnd.getProperty(Constants.BUILDPATH);
 		Stream<String> enhnacedBuildPath = OSGiAnnotationsClasspathContributor.annotations()
 				.map(p -> p.getPluginBase().getId());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/natures/BndProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/natures/BndProject.java
@@ -15,7 +15,6 @@ package org.eclipse.pde.internal.core.natures;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.pde.internal.core.bnd.BndBuilder;
 
 public class BndProject extends BaseProject {
@@ -45,7 +44,7 @@ public class BndProject extends BaseProject {
 
 	private static boolean hasRequiredNatures(IProject project) {
 		try {
-			return project.hasNature(BndProject.NATURE_ID) && project.hasNature(JavaCore.NATURE_ID);
+			return project.hasNature(BndProject.NATURE_ID);
 		} catch (CoreException e) {
 			return false;
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
@@ -26,7 +26,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ICoreConstants;
@@ -67,15 +66,17 @@ public class PDEProject {
 			}
 		}
 		if (BndProject.isBndProject(project)) {
-			IJavaProject javaProject = JavaCore.create(project);
-			IPath outputLocation;
+
 			try {
-				outputLocation = javaProject.getOutputLocation();
-				IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
-				IFolder outputFolder = workspaceRoot.getFolder(outputLocation);
-				return outputFolder;
-			} catch (JavaModelException e) {
-				// can't get output folder... fall through as last resort.
+				if (project.hasNature(JavaCore.NATURE_ID)) {
+					IJavaProject javaProject = JavaCore.create(project);
+					IPath outputLocation = javaProject.getOutputLocation();
+					IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
+					return workspaceRoot.getFolder(outputLocation);
+				}
+			} catch (CoreException e) {
+				// can't determine the bundle root then from java settings!
+				// fall through as last resort
 			}
 		}
 		return project;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/dialogs/PluginSelectionDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/dialogs/PluginSelectionDialog.java
@@ -156,6 +156,9 @@ public class PluginSelectionDialog extends FilteredItemsSelectionDialog {
 	}
 
 	private static void addSelfAndDirectImports(HashSet<String> set, IPluginModelBase model) {
+		if (model == null) {
+			return;
+		}
 		set.add(model.getPluginBase().getId());
 		IPluginImport[] imports = model.getPluginBase().getImports();
 		for (IPluginImport pImport : imports) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormEditor.java
@@ -888,7 +888,7 @@ public abstract class PDEFormEditor extends FormEditor implements IInputContextL
 
 	@Override
 	protected final void addPages() {
-		fError = getAggregateModel() == null;
+		fError = hasMissingResources();
 		if (fError) {
 			try {
 				addPage(new MissingResourcePage(this));
@@ -897,6 +897,10 @@ public abstract class PDEFormEditor extends FormEditor implements IInputContextL
 			}
 		} else
 			addEditorPages();
+	}
+
+	protected boolean hasMissingResources() {
+		return getAggregateModel() == null;
 	}
 
 	protected abstract void addEditorPages();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndBadLocationException.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndBadLocationException.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.bnd;
+
+import org.eclipse.jface.text.BadLocationException;
+
+/**
+ * this wraps the jface-text BadLocationException into a bnd-document one
+ */
+final class BndBadLocationException extends aQute.bnd.properties.BadLocationException {
+
+	private static final long serialVersionUID = 1L;
+
+	public BndBadLocationException(BadLocationException wrapped) {
+		super(wrapped.getMessage());
+		initCause(wrapped);
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndDocument.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndDocument.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.bnd;
+
+import aQute.bnd.properties.IRegion;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+
+/**
+ * This class wraps from JFace text framework to bnd-document
+ */
+final class BndDocument implements aQute.bnd.properties.IDocument {
+
+	private final IDocument document;
+
+	public BndDocument(IDocument document) {
+		this.document = document;
+	}
+
+	@Override
+	public int getNumberOfLines() {
+		return document.getNumberOfLines();
+	}
+
+	@Override
+	public IRegion getLineInformation(int lineNum) throws BndBadLocationException {
+		try {
+			return new BndRegion(document.getLineInformation(lineNum));
+		} catch (BadLocationException e) {
+			throw new BndBadLocationException(e);
+		}
+	}
+
+	@Override
+	public String get() {
+		return document.get();
+	}
+
+	@Override
+	public String get(int offset, int length) throws BndBadLocationException {
+		try {
+			return document.get(offset, length);
+		} catch (BadLocationException e) {
+			throw new BndBadLocationException(e);
+		}
+	}
+
+	@Override
+	public String getLineDelimiter(int line) throws BndBadLocationException {
+		try {
+			return document.getLineDelimiter(line);
+		} catch (BadLocationException e) {
+			throw new BndBadLocationException(e);
+		}
+	}
+
+	@Override
+	public int getLength() {
+		return document.getLength();
+	}
+
+	@Override
+	public void replace(int offset, int length, String data) throws BndBadLocationException {
+		try {
+			document.replace(offset, length, data);
+		} catch (BadLocationException e) {
+			throw new BndBadLocationException(e);
+		}
+	}
+
+	@Override
+	public char getChar(int offset) throws BndBadLocationException {
+		try {
+			return document.getChar(offset);
+		} catch (BadLocationException e) {
+			throw new BndBadLocationException(e);
+		}
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndModel.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndModel.java
@@ -13,20 +13,48 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.bnd;
 
-import org.eclipse.pde.core.IBaseModel;
+import aQute.bnd.build.model.BndEditModel;
+import java.io.IOException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.pde.core.*;
 
-public class BndModel implements IBaseModel {
+/**
+ * Extension to a bnd edit model that implements the base model methods and
+ * maintain the document to load/store changes
+ */
+public class BndModel extends BndEditModel implements IBaseModel, IModelChangeProvider {
 
+	private BndDocument bndDocument;
+	private volatile boolean valid;
 	private volatile boolean disposed;
 
-	@Override
-	public <T> T getAdapter(Class<T> adapter) {
-		return null;
+	public BndModel(IDocument document) {
+		bndDocument = new BndDocument(document);
 	}
 
 	@Override
-	public void dispose() {
-		disposed = true;
+	public void load() {
+		try {
+			loadFrom(bndDocument);
+			valid = true;
+		} catch (IOException e) {
+			valid = false;
+		}
+	}
+
+	@Override
+	public void saveChanges() throws IOException {
+		super.saveChangesTo(bndDocument);
+	}
+
+	@Override
+	public boolean isEditable() {
+		return true;
+	}
+
+	@Override
+	public boolean isValid() {
+		return valid;
 	}
 
 	@Override
@@ -35,13 +63,36 @@ public class BndModel implements IBaseModel {
 	}
 
 	@Override
-	public boolean isEditable() {
-		return false;
+	public void dispose() {
+		disposed = true;
 	}
 
 	@Override
-	public boolean isValid() {
-		return true;
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == aQute.bnd.properties.IDocument.class) {
+			return adapter.cast(bndDocument);
+		}
+		return null;
+	}
+
+	@Override
+	public void addModelChangedListener(IModelChangedListener listener) {
+
+	}
+
+	@Override
+	public void fireModelChanged(IModelChangedEvent event) {
+
+	}
+
+	@Override
+	public void fireModelObjectChanged(Object object, String property, Object oldValue, Object newValue) {
+
+	}
+
+	@Override
+	public void removeModelChangedListener(IModelChangedListener listener) {
+
 	}
 
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndRegion.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndRegion.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.bnd;
+
+import org.eclipse.jface.text.IRegion;
+
+/**
+ * Wraps a JFace-text region as a bnd-document-region
+ */
+final class BndRegion implements aQute.bnd.properties.IRegion {
+
+	private final IRegion textRegion;
+
+	public BndRegion(IRegion region) {
+		this.textRegion = region;
+	}
+
+	@Override
+	public int getLength() {
+		return textRegion.getLength();
+	}
+
+	@Override
+	public int getOffset() {
+		return textRegion.getOffset();
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/BundleInputContext.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/BundleInputContext.java
@@ -81,6 +81,11 @@ public class BundleInputContext extends UTF8InputContext {
 	}
 
 	@Override
+	public BundleModel getModel() {
+		return (BundleModel) super.getModel();
+	}
+
+	@Override
 	public String getId() {
 		return CONTEXT_ID;
 	}
@@ -178,7 +183,7 @@ public class BundleInputContext extends UTF8InputContext {
 	public void doRevert() {
 		fEditOperations.clear();
 		fOperationTable.clear();
-		AbstractEditingModel model = (AbstractEditingModel) getModel();
+		AbstractEditingModel model = getModel();
 		model.reconciled(model.getDocument());
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependenciesPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependenciesPage.java
@@ -14,6 +14,7 @@
 package org.eclipse.pde.internal.ui.editor.plugin;
 
 import java.util.ArrayList;
+import org.eclipse.pde.core.IBaseModel;
 import org.eclipse.pde.internal.ui.*;
 import org.eclipse.pde.internal.ui.editor.FormLayoutFactory;
 import org.eclipse.pde.internal.ui.editor.PDEFormPage;
@@ -66,7 +67,8 @@ public class DependenciesPage extends PDEFormPage {
 			ImportPackageSection importPackageSection = new ImportPackageSection(this, right);
 			importPackageSection.getSection().descriptionVerticalSpacing = requiresSection.getSection().getTextClientHeightDifference();
 			managedForm.addPart(importPackageSection);
-			if (getModel().isEditable())
+			IBaseModel model = getModel();
+			if (model != null && model.isEditable())
 				managedForm.addPart(new DependencyManagementSection(this, left));
 			else
 				gd.horizontalSpan = 2;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyAnalysisSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyAnalysisSection.java
@@ -40,8 +40,13 @@ public class DependencyAnalysisSection extends PDESection {
 	}
 
 	private String getFormText() {
-		boolean editable = getPage().getModel().isEditable();
-		if (getPage().getModel() instanceof IPluginModel) {
+		IBaseModel model = getPage().getModel();
+		if (model == null) {
+			return ""; // we don't know the type so we can't give //$NON-NLS-1$
+						// a suitable hint (at the momment)
+		}
+		boolean editable = model.isEditable();
+		if (model instanceof IPluginModel) {
 			if (editable)
 				return PDEUIMessages.DependencyAnalysisSection_plugin_editable;
 			return PDEUIMessages.DependencyAnalysisSection_plugin_notEditable;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/GeneralInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/GeneralInfoSection.java
@@ -99,7 +99,10 @@ public abstract class GeneralInfoSection extends PDESection {
 
 	protected IPluginBase getPluginBase() {
 		IBaseModel model = getPage().getPDEEditor().getAggregateModel();
-		return ((IPluginModelBase) model).getPluginBase();
+		if (model instanceof IPluginModelBase base) {
+			return base.getPluginBase();
+		}
+		return null;
 	}
 
 	/**
@@ -128,7 +131,7 @@ public abstract class GeneralInfoSection extends PDESection {
 	protected IBundle getBundle() {
 		BundleInputContext context = getBundleContext();
 		if (context != null) {
-			IBundleModel model = (IBundleModel) context.getModel();
+			IBundleModel model = context.getModel();
 			return model.getBundle();
 		}
 		return null;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/LibrarySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/LibrarySection.java
@@ -198,7 +198,8 @@ public class LibrarySection extends TableSection implements IBuildPropertiesCons
 	@Override
 	protected void selectionChanged(IStructuredSelection selection) {
 		getPage().getPDEEditor().setSelection(selection);
-		if (getPage().getModel().isEditable())
+		IBaseModel model = getPage().getModel();
+		if (model != null && model.isEditable())
 			updateButtons();
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/LibraryVisibilitySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/LibraryVisibilitySection.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.ui.*;
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.jface.window.Window;
+import org.eclipse.pde.core.IBaseModel;
 import org.eclipse.pde.core.IModelChangedEvent;
 import org.eclipse.pde.core.plugin.IPluginLibrary;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -115,8 +116,9 @@ public class LibraryVisibilitySection extends TableSection implements IPartSelec
 		update(null);
 		makeActions();
 
-		IPluginModelBase model = (IPluginModelBase) getPage().getModel();
-		model.addModelChangedListener(this);
+		if (getPage().getModel() instanceof IPluginModelBase model) {
+			model.addModelChangedListener(this);
+		}
 
 		section.setLayout(FormLayoutFactory.createClearGridLayout(false, 1));
 		section.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -152,7 +154,8 @@ public class LibraryVisibilitySection extends TableSection implements IPartSelec
 		fPackageExportContainer.setLayoutData(new GridData(GridData.FILL_BOTH));
 
 		EditableTablePart tablePart = getTablePart();
-		tablePart.setEditable(getPage().getModel().isEditable());
+		IBaseModel model = getPage().getModel();
+		tablePart.setEditable(model != null && model.isEditable());
 		createViewerPartControl(fPackageExportContainer, SWT.FULL_SELECTION, 2, toolkit);
 		fPackageExportViewer = tablePart.getTableViewer();
 		fPackageExportViewer.setContentProvider(new TableContentProvider());


### PR DESCRIPTION
Currently one can edit the instructions file and after safe the manifest is updated (and thus also the editor), but the other way does not work, if one for example edit the name in the overview page the changes are just overwritten on the next compile.

This installs listeners and implements a very basic model for the instructions so changes are mirrored to the instructions file as it already happens for the MANIFEST.MF source tab.

