### PR TITLE
make export dialog add button follow list selection

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ConditionalListSelectionDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ConditionalListSelectionDialog.java
@@ -67,6 +67,15 @@ public class ConditionalListSelectionDialog extends ElementListSelectionDialog {
 		super.setElements(elements);
 		fElements = elements;
 	}
+	
+	@Override
+	protected void updateOkState() {
+		super.updateOkState();
+		Button ok = getOkButton();
+		if (ok != null && !ok.isEnabled()) {
+			ok.setEnabled(fElements.length != 0);
+		}
+	}
 
 	public void setConditionalElements(Object[] elements) {
 		fConditionalElements = elements;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ConditionalListSelectionDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ConditionalListSelectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2015 IBM Corporation and others.
+ *  Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -72,7 +72,7 @@ public class ConditionalListSelectionDialog extends ElementListSelectionDialog {
 	protected void updateOkState() {
 		super.updateOkState();
 		Button ok = getOkButton();
-		if (ok != null && !ok.isEnabled()) {
+		if (ok != null && !ok.isEnabled() && fElements != null) {
 			ok.setEnabled(fElements.length != 0);
 		}
 	}


### PR DESCRIPTION
There are potential race conditions that are happening between the dialog creation with empty list and the thread that populates the list and fires selection change events.

An easy hack is to make sure the button is enabled whenever there are items in the list. This always
works, as the default behavior of list makes sure
that there is at least one item selected in a
non-empty list.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/534