### PR TITLE
remove RunAPIAnalysisBuilderAsJob option from perferences UI

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PreferenceInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PreferenceInitializer.java
@@ -75,7 +75,6 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		PDEPreferencesManager corePrefs = PDECore.getDefault().getPreferencesManager();
 		corePrefs.setDefault(ICoreConstants.WORKSPACE_PLUGINS_OVERRIDE_TARGET, true);
 		corePrefs.setDefault(ICoreConstants.DISABLE_API_ANALYSIS_BUILDER, false);
-		corePrefs.setDefault(ICoreConstants.RUN_API_ANALYSIS_AS_JOB, true);
 		corePrefs.setDefault(ICoreConstants.ADD_SWT_NON_DISPOSAL_REPORTING, true);
 		corePrefs.setDefault(ICoreConstants.TEST_PLUGIN_PATTERN, ICoreConstants.TEST_PLUGIN_PATTERN_DEFAULTVALUE);
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -373,7 +373,6 @@ MainPreferencePage_ShowTargetStatus=S&how current target platform in status bar
 MainPreferencePage_updateStale=&Update stale manifest files prior to launching
 MainPreferencePage_WorkspacePluginsOverrideTarget=Workspace p&lug-ins override target platform plug-ins with the same id
 MainPreferencePage_DisableAPIAnalysisBuilder=&Disable API analysis builder
-MainPreferencePage_RunAPIAnalysisBuilderAsJob=&Run API analysis parallel to the build job
 MainPreferencePage_WorkspacePluginsOverrideTargetTooltip=When disabled, all plug-in versions from workspace and target platform are being used.
 MainPreferencePage_test_plugin_pattern_group=Test plug-in detection:
 MainPreferencePage_test_plugin_pattern_description=Source folders in test plug-ins are marked to contain test sources.

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/MainPreferencePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/MainPreferencePage.java
@@ -158,7 +158,6 @@ public class MainPreferencePage extends PreferencePage implements IWorkbenchPref
 	private Button fShowTargetStatus;
 	private Button fAlwaysPreferWorkspace;
 	private Button fDisableAPIAnalysisBuilder;
-	private Button fRunAPIAnalysisBuilderAsJob;
 	private Button fAddSwtNonDisposalReporting;
 
 	private Text fRuntimeWorkspaceLocation;
@@ -221,15 +220,6 @@ public class MainPreferencePage extends PreferencePage implements IWorkbenchPref
 		fDisableAPIAnalysisBuilder = new Button(optionComp, SWT.CHECK);
 		fDisableAPIAnalysisBuilder.setText(PDEUIMessages.MainPreferencePage_DisableAPIAnalysisBuilder);
 		fDisableAPIAnalysisBuilder.setSelection(store.getBoolean(IPreferenceConstants.DISABLE_API_ANALYSIS_BUILDER));
-
-		fRunAPIAnalysisBuilderAsJob = new Button(optionComp, SWT.CHECK);
-		fRunAPIAnalysisBuilderAsJob.setText(PDEUIMessages.MainPreferencePage_RunAPIAnalysisBuilderAsJob);
-		fRunAPIAnalysisBuilderAsJob.setSelection(
-				PDECore.getDefault().getPreferencesManager().getBoolean(ICoreConstants.RUN_API_ANALYSIS_AS_JOB));
-
-		fDisableAPIAnalysisBuilder.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
-			fRunAPIAnalysisBuilderAsJob.setEnabled(!fDisableAPIAnalysisBuilder.getSelection());
-		}));
 
 		fAddSwtNonDisposalReporting = new Button(optionComp, SWT.CHECK);
 		fAddSwtNonDisposalReporting.setText(PDEUIMessages.MainPreferencePage_AddSwtNonDisposedToVMArguments);
@@ -448,13 +438,6 @@ public class MainPreferencePage extends PreferencePage implements IWorkbenchPref
 
 		}
 
-		boolean runAPIAnalysisAsJob = fRunAPIAnalysisBuilderAsJob.getSelection();
-		if (PDECore.getDefault().getPreferencesManager()
-				.getBoolean(ICoreConstants.RUN_API_ANALYSIS_AS_JOB) != runAPIAnalysisAsJob) {
-			PDEPreferencesManager prefs = PDECore.getDefault().getPreferencesManager();
-			prefs.setValue(ICoreConstants.RUN_API_ANALYSIS_AS_JOB, runAPIAnalysisAsJob);
-		}
-
 		boolean addSwtNonDisposalReporting = fAddSwtNonDisposalReporting.getSelection();
 		if (store.getBoolean(IPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING) != addSwtNonDisposalReporting) {
 			store.setValue(IPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING, addSwtNonDisposalReporting);
@@ -502,9 +485,6 @@ public class MainPreferencePage extends PreferencePage implements IWorkbenchPref
 		fShowTargetStatus.setSelection(store.getDefaultBoolean(IPreferenceConstants.SHOW_TARGET_STATUS));
 		fAlwaysPreferWorkspace
 				.setSelection(store.getDefaultBoolean(IPreferenceConstants.WORKSPACE_PLUGINS_OVERRIDE_TARGET));
-		fRunAPIAnalysisBuilderAsJob.setEnabled(true);
-		fRunAPIAnalysisBuilderAsJob.setSelection(
-				PDECore.getDefault().getPreferencesManager().getDefaultBoolean(ICoreConstants.RUN_API_ANALYSIS_AS_JOB));
 		fDisableAPIAnalysisBuilder
 				.setSelection(store.getDefaultBoolean(IPreferenceConstants.DISABLE_API_ANALYSIS_BUILDER));
 		fAddSwtNonDisposalReporting


### PR DESCRIPTION
Remove all references to the UI preference for running API analysis in parallel to the builder, as a scheduled job, While retaining the underlying boolean ICoreConstants.RUN_API_ANALYSIS_AS_JOB so that the tests that depend on it are unaffected, though it is false always.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/307