### PR TITLE
Automatic flag in TemplateListSelectionPage must check if OSGi is active

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
@@ -46,7 +46,7 @@ public class TemplateListSelectionPage extends WizardListSelectionPage {
 			boolean ui = data.isUIPlugin();
 			boolean rcp = data.isRCPApplicationPlugin();
 			boolean osgi = data.getOSGiFramework() != null;
-			boolean automatic = data.isAutomaticMetadataGeneration();
+			boolean automatic = osgi && data.isAutomaticMetadataGeneration();
 			WizardElement welement = (WizardElement) element;
 			boolean active = TemplateWizardHelper.isActive(welement);
 			boolean uiFlag = TemplateWizardHelper.getFlag(welement, TemplateWizardHelper.FLAG_UI, true);


### PR DESCRIPTION
The "automatic" flag is actually bound to the enablement of an OSGi Framework project type, so we need to disable it when OSGI is not selected.

@HannesWell @vik-chand this should be easy enough to be included in current M1?

Fix https://github.com/eclipse-pde/eclipse.pde/issues/566