### PR TITLE
migrate to Java 17 switch semantics: extras

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/filter/SizeFilter.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/filter/SizeFilter.java
@@ -38,10 +38,10 @@ public class SizeFilter implements IFilter {
 	public boolean accept(final ImageElement element) {
 		
 
-		boolean accept = true & switch (mWidthType) {
-			case TYPE_EXACT -> (element.getImageData().width == mWidth);
-			case TYPE_BIGGER_EQUALS -> (element.getImageData().width >= mWidth);
-			case TYPE_SMALLER_EQUALS -> (element.getImageData().width <= mWidth);
+		boolean accept = switch (mWidthType) {
+			case TYPE_EXACT -> element.getImageData().width == mWidth;
+			case TYPE_BIGGER_EQUALS -> element.getImageData().width >= mWidth;
+			case TYPE_SMALLER_EQUALS -> element.getImageData().width <= mWidth;
 			default -> true;
 		};
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/templates/PreprocessorParser.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/templates/PreprocessorParser.java
@@ -213,7 +213,7 @@ public class PreprocessorParser {
 			}
 
 			int opcode = switch (token) {
-				case T_AND -> opcode = OP_AND;
+				case T_AND -> OP_AND;
 				case T_OR -> OP_OR;
 				case T_EQ -> OP_EQ;
 				case T_NEQ -> OP_NEQ;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/templates/PreprocessorParser.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/templates/PreprocessorParser.java
@@ -212,14 +212,12 @@ public class PreprocessorParser {
 				continue;
 			}
 
-			int opcode = 0;
-
-			opcode = switch (token) {
+			int opcode = switch (token) {
 				case T_AND -> opcode = OP_AND;
 				case T_OR -> OP_OR;
 				case T_EQ -> OP_EQ;
 				case T_NEQ -> OP_NEQ;
-				default -> opcode;
+				default -> 0;
 			};
 			if (opcode != 0) {
 				pushNode(opcode);


### PR DESCRIPTION
replace legacy switch block with java 17 semantics:
1. short-circuit initialization in the switch expression
2. default case match with the original initialization
3. reduce complex boolean expression to an elegant form

Refs: https://github.com/eclipse-pde/eclipse.pde/pull/570#pullrequestreview-1379419914

/cc @HannesWell 