### PR TITLE
Enable publication of Jenkins build code metrics as Github checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,9 @@ pipeline {
 						*/target/work/data/.metadata/*.log, \
 						*/tests/target/work/data/.metadata/*.log, \
 						apiAnalyzer-workspace/.metadata/*.log')
-					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
 					junit '**/target/surefire-reports/*.xml'
+					discoverGitReferenceBuild referenceJob: 'eclipse.pde/master'
+					recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
 				}
 			}
 		}


### PR DESCRIPTION
The required Github apps have been requested and installed in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2920.