### PR TITLE
Improve OSGi metadata about dependency to javax.inject/annotations

### DIFF
--- a/ui/org.eclipse.pde.spy.bundle/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.bundle/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.e4.core.di,
  org.eclipse.e4.ui.di
 Bundle-Localization: plugin
-Import-Package: javax.annotation;version="1.3.5",
- javax.inject;version="1.0.0"
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)"
 Bundle-Vendor: %provider-name
 Bundle-ActivationPolicy: lazy

--- a/ui/org.eclipse.pde.spy.context/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.context/META-INF/MANIFEST.MF
@@ -17,8 +17,8 @@ Require-Bundle: org.eclipse.jface;bundle-version="3.9.0",
  org.eclipse.e4.core.services;bundle-version="1.1.0",
  org.eclipse.pde.spy.core;bundle-version="1.0.100"
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.annotation;version="1.2.0",
- javax.inject;version="1.0.0"
+Import-Package: javax.annotation;version="[1.2.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)"
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.spy.context
 

--- a/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
@@ -12,6 +12,6 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench,
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.ui.di,
  org.eclipse.emf.ecore
-Import-Package: javax.inject;version="1.0.0",
+Import-Package: javax.inject;version="[1.0.0,2.0.0)",
  org.eclipse.emf.ecore
 Bundle-Vendor: %provider-name

--- a/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="0.9.1",
  org.eclipse.pde.spy.core;bundle-version="1.0.200"
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.annotation;version="1.2.0",
- javax.inject;version="1.0.0",
+Import-Package: javax.annotation;version="[1.2.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  org.eclipse.e4.core.contexts,
  org.eclipse.e4.core.di.annotations,
  org.eclipse.e4.ui.services,

--- a/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.core.contexts;bundle-version="1.3.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.0.0",
  org.eclipse.e4.core.services;bundle-version="1.1.0",
- javax.inject;bundle-version="1.0.0",
  org.eclipse.core.resources;bundle-version="3.8.100",
  org.eclipse.jdt.core;bundle-version="3.9.0",
  org.eclipse.jdt.ui;bundle-version="3.9.0",
@@ -23,7 +22,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.databinding.property;bundle-version="1.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.annotation;version="1.2.0",
+Import-Package: javax.annotation;version="[1.2.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  org.osgi.service.event;version="[1.4.0,2.0.0)"
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.spy.event

--- a/ui/org.eclipse.pde.spy.model/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.model/META-INF/MANIFEST.MF
@@ -21,6 +21,6 @@ Bundle-Localization: plugin
 Bundle-Vendor: %provider-name
 Service-Component: OSGI-INF/extensionlookup.xml
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.inject;version="1.0.0"
+Import-Package: javax.inject;version="[1.0.0,2.0.0)"
 Export-Package: org.eclipse.pde.spy.model;x-internal:=true
 Automatic-Module-Name: org.eclipse.pde.spy.model

--- a/ui/org.eclipse.pde.spy.preferences/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.preferences/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.runtime,
  org.eclipse.e4.ui.dialogs;bundle-version="1.3.0",
  org.eclipse.jface;bundle-version="3.24.0"
-Import-Package: javax.annotation;version="1.3.5",
- javax.inject;version="1.0.0"
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.jface.databinding;bundle-version="1.9.0",
  org.eclipse.ui;bundle-version="3.109.0"
 Import-Package: org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.osgi.util,
- org.osgi.framework;version="1.10.0"
+ org.osgi.framework;version="[1.10.0,2.0.0)"
 Bundle-Vendor: %provider-name
 Export-Package: org.eclipse.tools.layout.spy.internal.dialogs;x-internal:=true,
  org.eclipse.tools.layout.spy.internal.displayfilter;x-internal:=true,


### PR DESCRIPTION
- Only use Import-Package to for javax.annotation and javax.inject
- Always use closed version ranges [1.X,2) with a minor lower bound

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056