### PR TITLE
Remove unnecessary javax-bundle dependencies in tycho-surefire config

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -43,16 +43,6 @@
               <artifactId>org.eclipse.osgi.compatibility.state</artifactId>
               <version>0.0.0</version>
             </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>javax.xml</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>javax.annotation</artifactId>
-              <version>0.0.0</version>
-            </dependency>
           </dependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
This is necessary to not fail after https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1059.