### PR TITLE
Adapt tests to migration to javax-bundles provided by Jakarta

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -43,6 +43,7 @@ Require-Bundle: org.junit,
  org.eclipse.platform,
  org.eclipse.ui.ide.application
 Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  org.assertj.core.api;version="3.14.0",
  org.assertj.core.presentation;version="3.21.0",
  org.eclipse.pde.internal.build,

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
@@ -51,6 +51,7 @@ import org.eclipse.pde.ui.tests.util.ProjectUtils.CoreConsumer;
 import org.eclipse.pde.ui.tests.util.TargetPlatformUtil;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
+import org.osgi.framework.FrameworkUtil;
 
 public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 
@@ -68,9 +69,9 @@ public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 	@Test
 	public void testGetMergedBundleMap_autostartLevels() throws Throwable {
 		TargetPlatformUtil.setRunningPlatformAsTarget();
-
+		String javaxInjectProvider = FrameworkUtil.getBundle(javax.inject.Inject.class).getSymbolicName();
 		createFeatureProject(FeatureBasedLaunchTest.class.getName() + "-feature", "1.0.0", f -> {
-			addIncludedPlugin(f, "javax.inject", DEFAULT_VERSION);
+			addIncludedPlugin(f, javaxInjectProvider, DEFAULT_VERSION);
 			addIncludedPlugin(f, "org.eclipse.core.runtime", DEFAULT_VERSION);
 			addIncludedPlugin(f, "org.eclipse.ui", DEFAULT_VERSION);
 		});
@@ -84,9 +85,9 @@ public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 		}
 
 		assertThat(byId)//
-		.as("old entry without configuration has defaults").containsEntry("javax.inject", "default:default")
+		.as("old entry without config has defaults").containsEntry(javaxInjectProvider, "default:default")
 		.as("use configured start-levels").containsEntry("org.eclipse.core.runtime", "1:true")
-		.as("ignore configured start-levels of uncheckedplugin")
+		.as("ignore configured start-levels of unchecked plugin")
 		.containsEntry("org.eclipse.ui", "default:default");
 	}
 


### PR DESCRIPTION
As mentioned in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056#issuecomment-1541421660 the test needs adjustments.