### PR TITLE
Align e4 template for toolbar naming with menu contribution

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/plugin.properties
+++ b/ui/org.eclipse.pde.ui.templates/plugin.properties
@@ -388,19 +388,19 @@ pluginContent.e4Handler.description=\
 <li>a menu contribution to the main menu</li>\
 <li>a menu contribution to any popup</li>\
 <p>It uses the standard xpath:/ notation to add these contributions to any application model.</p>\
-<p>The generated plug-in is also compliant with an Eclipse 3 application running with the compatibility layer.</p>\
+<p>The generated plug-in is also compliant with an Eclipse 3 application running on a 4.x platform.</p>\
 <p>The handler can be triggered by selecting <b>E4 Menu > Hello world</b> in the main menu or in any view popup menu</p>\
 <p><b>Extensions Used</b></p>\
 <li>org.eclipse.e4.workbench.model</li>
 
-pluginContent.e4ToolbarContribution.name = Toolbar contribution using e4 API
+pluginContent.e4ToolbarContribution.name = Toolbar contribution using 4.x API
 pluginContent.e4ToolbarContribution.description=\
 <p>This template creates an Eclipse 4 plugin with a model application fragment containing :</p>\
 <li>a 'Hello world' command</li>\
 <li>a 'Hello world' handler</li>\
 <li>a trim contribution to the main toolbar</li>\
 <p>It uses the standard xpath:/ notation to add these contributions to any application model.</p>\
-<p>The generated plugin is also compliant with an Eclipse 3 application running with the compatibility layer.</p>\
+<p>The generated plugin is also compliant with an Eclipse 3 application running on a 4.x platform</p>\
 <p>The handler can be triggered by pressing the <b>Hello world</b> button in the main toolbar.</p>\
 <p><b>Extensions Used</b></p>\
 <li>org.eclipse.e4.workbench.model</li>


### PR DESCRIPTION
Currently the PDE wizard show a mix of 3.x and e4 namings, that is inconsistent and should be align.
Also make it clear that this work on any platform using 4.x API.