### PR TITLE
Simplify usage of java.nio.file.Path

### DIFF
--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/tests/PDETestCase.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/tests/PDETestCase.java
@@ -24,7 +24,7 @@ import java.io.FileReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -177,7 +177,7 @@ public abstract class PDETestCase {
 			AntRunner runner = new AntRunner();
 			runner.run(args);
 		} catch (InvocationTargetException e) {
-			java.nio.file.Path logPath = Paths.get(antHome, "log.log");
+			Path logPath = Path.of(antHome, "log.log");
 			String logContent = Files.readString(logPath);
 			System.err.println("### Ant log file content from " + logPath + ":");
 			System.err.println(logContent);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/ExternalPluginModelBase.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/ExternalPluginModelBase.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import org.eclipse.core.runtime.IPath;
@@ -92,7 +93,7 @@ public abstract class ExternalPluginModelBase extends AbstractPluginModelBase {
 
 	@Override
 	protected Long getResourceTimeStamp() {
-		java.nio.file.Path installFile = java.nio.file.Path.of(getInstallLocation());
+		Path installFile = Path.of(getInstallLocation());
 		BasicFileAttributes installFileAttribute;
 		try {
 			installFileAttribute = Files.readAttributes(installFile, BasicFileAttributes.class);
@@ -103,8 +104,7 @@ public abstract class ExternalPluginModelBase extends AbstractPluginModelBase {
 			return installFileAttribute.lastModifiedTime().toMillis();
 		}
 		try {
-			java.nio.file.Path manifestFile = java.nio.file.Path.of(getInstallLocation(),
-					ICoreConstants.BUNDLE_FILENAME_DESCRIPTOR);
+			Path manifestFile = Path.of(getInstallLocation(), ICoreConstants.BUNDLE_FILENAME_DESCRIPTOR);
 			return Files.getLastModifiedTime(manifestFile).toMillis();
 		} catch (IOException e) {
 			try {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/WorkspaceModelManagerTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/WorkspaceModelManagerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -301,9 +302,9 @@ public class WorkspaceModelManagerTest {
 
 	private void copyFile(IFile source, IFile target, UnaryOperator<String> modifications)
 			throws IOException, CoreException {
-		try (Stream<String> lines = Files.lines(java.nio.file.Path.of(source.getLocationURI()))) {
+		try (Stream<String> lines = Files.lines(Path.of(source.getLocationURI()))) {
 			Iterable<String> bs = lines.map(modifications)::iterator;
-			java.nio.file.Path targetPath = java.nio.file.Path.of(target.getLocationURI());
+			Path targetPath = Path.of(target.getLocationURI());
 			Files.createDirectories(targetPath.getParent());
 			Files.write(targetPath, bs);
 			target.refreshLocal(IResource.DEPTH_INFINITE, null);


### PR DESCRIPTION
Now that PDE does not use `o.e.core.runtime.Path` anymore, the usage of `java.nio.file.Path` can be simplfied.