### PR TITLE
Unify and clean-up Product Editor's PluginSection and FeatureSection

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2171,14 +2171,11 @@ public class PDEUIMessages extends NLS {
 	public static String ProductJRESection_browseEEs;
 	public static String ProdctJRESection_bundleJRE;
 
-	public static String Product_FeatureSection_remove;
-	public static String Product_FeatureSection_open;
 	public static String Product_FeatureSection_up;
 	public static String Product_FeatureSection_down;
 	public static String Product_FeatureSection_sortAlpha;
 	public static String FeatureSection_addRequired;
 	public static String FeatureSection_toggleRoot;
-	public static String FeatureSection_removeAll;
 
 	public static String ImportPackageSection_desc;
 	public static String ImportPackageSection_descFragment;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/AbstractProductContentSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/AbstractProductContentSection.java
@@ -1,0 +1,347 @@
+/*******************************************************************************
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Unify and clean-up Product Editor's PluginSection and FeatureSection
+ *******************************************************************************/
+
+package org.eclipse.pde.internal.ui.editor.product;
+
+import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
+
+import java.lang.reflect.Array;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.pde.core.IModelChangedEvent;
+import org.eclipse.pde.internal.core.iproduct.IProduct;
+import org.eclipse.pde.internal.core.iproduct.IProductModel;
+import org.eclipse.pde.internal.ui.PDEPlugin;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.eclipse.pde.internal.ui.editor.FormLayoutFactory;
+import org.eclipse.pde.internal.ui.editor.PDEFormPage;
+import org.eclipse.pde.internal.ui.editor.TableSection;
+import org.eclipse.pde.internal.ui.parts.TablePart;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.ui.actions.ActionFactory;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.eclipse.ui.forms.widgets.Section;
+
+public abstract class AbstractProductContentSection<S extends AbstractProductContentSection<S>> extends TableSection {
+
+	private final Predicate<Object> elementFilter;
+	private final List<Consumer<S>> buttonHandlers;
+
+	protected AbstractProductContentSection(PDEFormPage formPage, Composite parent, List<String> buttonLabels,
+			List<Consumer<S>> buttonHandlers, Predicate<Object> elementFilter) {
+		super(formPage, parent, Section.DESCRIPTION, buttonLabels.toArray(String[]::new));
+		this.elementFilter = elementFilter;
+		this.buttonHandlers = buttonHandlers;
+	}
+
+	TableViewer getTableViewer() {
+		return getTablePart().getTableViewer();
+	}
+
+	Table getTable() {
+		return getTableViewer().getTable();
+	}
+
+	IStructuredSelection getTableSelection() {
+		return getTableViewer().getStructuredSelection();
+	}
+
+	IProductModel getModel() {
+		return (IProductModel) getPage().getPDEEditor().getAggregateModel();
+	}
+
+	IProduct getProduct() {
+		return getModel().getProduct();
+	}
+
+	@Override
+	protected void createClient(Section section, FormToolkit toolkit) {
+
+		section.setLayout(FormLayoutFactory.createClearGridLayout(false, 1));
+		GridData sectionData = new GridData(GridData.FILL_BOTH);
+		sectionData.verticalSpan = 2;
+		section.setLayoutData(sectionData);
+
+		Composite container = createClientContainer(section, 2, toolkit);
+		createViewerPartControl(container, SWT.MULTI, 2, toolkit);
+		container.setLayoutData(new GridData(GridData.FILL_BOTH));
+		getTableViewer().setLabelProvider(PDEPlugin.getDefault().getLabelProvider());
+		GridData data = (GridData) getTablePart().getControl().getLayoutData();
+		data.minimumWidth = 200;
+
+		populateSection(section, container, toolkit);
+
+		toolkit.paintBordersFor(container);
+		section.setClient(container);
+
+		getModel().addModelChangedListener(this);
+		createSectionToolbar(section);
+	}
+
+	abstract void populateSection(Section section, Composite container, FormToolkit toolkit);
+
+	void createAutoIncludeRequirementsButton(Composite container, String buttonLabel) {
+		Button autoInclude = new Button(container, SWT.CHECK);
+		autoInclude.setText(buttonLabel);
+		autoInclude.setSelection(getProduct().includeRequirementsAutomatically());
+		if (isEditable()) {
+			autoInclude.addSelectionListener(widgetSelectedAdapter(
+					e -> getProduct().setIncludeRequirementsAutomatically(autoInclude.getSelection())));
+		} else {
+			autoInclude.setEnabled(false); // default is true
+		}
+	}
+
+	<T> void configureTable(Function<IProduct, T[]> provider, ViewerComparator comparator) {
+		TableViewer fTable = getTableViewer();
+		fTable.setContentProvider((IStructuredContentProvider) p -> provider.apply((IProduct) p));
+		fTable.setComparator(comparator);
+		fTable.setInput(getProduct());
+	}
+
+	void enableTableButtons(int... buttonIndices) {
+		TablePart tablePart = getTablePart();
+		for (int button : buttonIndices) {
+			tablePart.setButtonEnabled(button, isEditable());
+		}
+	}
+
+	private void createSectionToolbar(Section section) {
+		ToolBarManager toolBarManager = new ToolBarManager(SWT.FLAT);
+		ToolBar toolbar = toolBarManager.createControl(section);
+		toolbar.setCursor(Display.getCurrent().getSystemCursor(SWT.CURSOR_HAND));
+		getToolbarActions().forEach(toolBarManager::add);
+		toolBarManager.update(true);
+		section.setTextClient(toolbar);
+	}
+
+	abstract List<Action> getToolbarActions();
+
+	@Override
+	protected void fillContextMenu(IMenuManager manager) {
+		IStructuredSelection ssel = getTableSelection();
+		if (ssel == null) {
+			return;
+		}
+		Action openAction = createAction(PDEUIMessages.PluginSection_open,
+				() -> handleDoubleClick(getTableSelection()));
+		openAction.setEnabled(isEditable() && ssel.size() == 1);
+		manager.add(openAction);
+
+		manager.add(new Separator());
+
+		Action removeAction = createAction(PDEUIMessages.PluginSection_remove, this::handleRemove);
+		removeAction.setEnabled(isEditable() && !ssel.isEmpty());
+		manager.add(removeAction);
+
+		Action removeAll = createAction(PDEUIMessages.PluginSection_removeAll, this::handleRemoveAll);
+		removeAll.setEnabled(isEditable());
+		manager.add(removeAll);
+
+		manager.add(new Separator());
+
+		getPage().getPDEEditor().getContributor().contextMenuAboutToShow(manager);
+	}
+
+	@Override
+	protected boolean createCount() {
+		return true;
+	}
+
+	@Override
+	public void dispose() {
+		IProductModel model = getModel();
+		if (model != null) {
+			model.removeModelChangedListener(this);
+		}
+		super.dispose();
+	}
+
+	@Override
+	public boolean setFormInput(Object input) {
+		if (elementFilter.test(input)) {
+			getTableViewer().setSelection(new StructuredSelection(input), true);
+			return true;
+		}
+		return super.setFormInput(input);
+	}
+
+	@Override
+	public boolean doGlobalAction(String actionId) {
+		if (actionId.equals(ActionFactory.DELETE.getId())) {
+			handleRemove();
+			return true;
+		}
+		if (actionId.equals(ActionFactory.CUT.getId())) {
+			handleRemove();
+			return false;
+		}
+		if (actionId.equals(ActionFactory.PASTE.getId())) {
+			doPaste();
+			return true;
+		}
+		return super.doGlobalAction(actionId);
+	}
+
+	@Override
+	protected boolean canPaste(Object target, Object[] objects) {
+		return Stream.of(objects).anyMatch(elementFilter);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void buttonSelected(int index) {
+		if (index < buttonHandlers.size()) {
+			buttonHandlers.get(index).accept((S) this);
+		}
+	}
+
+	void handleRemove() {
+		IStructuredSelection ssel = getTableSelection();
+		if (!ssel.isEmpty()) {
+			removeElements(getProduct(), ssel.toList());
+			updateButtons(true, true);
+		}
+	}
+
+	abstract void removeElements(IProduct product, List<Object> elements);
+
+	abstract void handleRemoveAll();
+
+	@Override
+	public void refresh() {
+		getTableViewer().refresh();
+		updateButtons(true, true);
+		super.refresh();
+	}
+
+	@Override
+	protected void selectionChanged(IStructuredSelection selection) {
+		getPage().getPDEEditor().setSelection(selection);
+		updateButtons(true, false);
+	}
+
+	@Override
+	public void modelChanged(IModelChangedEvent e) {
+		// No need to call super, handling world changed event here
+		if (e.getChangeType() == IModelChangedEvent.WORLD_CHANGED) {
+			handleModelEventWorldChanged();
+			return;
+		}
+		TableViewer tableViewer = getTableViewer();
+		if (e.getChangeType() == IModelChangedEvent.INSERT) {
+			Stream.of(e.getChangedObjects()).filter(elementFilter).forEach(tableViewer::add);
+
+		} else if (e.getChangeType() == IModelChangedEvent.REMOVE) {
+			Stream.of(e.getChangedObjects()).filter(elementFilter).forEach(tableViewer::remove);
+
+			// Update Selection
+			Table table = getTable();
+			int count = table.getItemCount();
+			if (count != 0) {
+				int index = table.getSelectionIndex();
+				table.setSelection(Math.min(index, count - 1));
+			} // else, nothing to select
+
+		} else if (e.getChangeType() == IModelChangedEvent.CHANGE) {
+			tableViewer.refresh();
+		}
+		updateButtons(false, true);
+	}
+
+	private void handleModelEventWorldChanged() {
+		// This section can get disposed if the configuration is changed from
+		// plugins to features or vice versa. Subsequently, the configuration
+		// page is removed and readded. In this circumstance, abort the refresh
+		if (getTable().isDisposed()) {
+			return;
+		}
+		// Reload the input
+		getTableViewer().setInput(getProduct());
+		// Perform the refresh
+		refresh();
+	}
+
+	abstract void updateButtons(boolean updateRemove, boolean updateRemoveAll);
+
+	void updateRemoveButtons(int btnRemove, int btnRemoveAll) {
+		TablePart tablePart = getTablePart();
+		if (btnRemove > -1) {
+			ISelection selection = getViewerSelection();
+			tablePart.setButtonEnabled(btnRemove,
+					isEditable() && !selection.isEmpty()
+							&& selection instanceof IStructuredSelection structuredSelection
+							&& elementFilter.test(structuredSelection.getFirstElement()));
+		}
+		if (btnRemoveAll > -1) {
+			tablePart.setButtonEnabled(btnRemoveAll,
+					isEditable() && tablePart.getTableViewer().getTable().getItemCount() > 0);
+		}
+	}
+
+	// --- utility methods ---
+
+	static Action createPushAction(String text, ImageDescriptor image, Runnable runAction) {
+		Action action = createAction(text, IAction.AS_PUSH_BUTTON, runAction);
+		action.setImageDescriptor(image);
+		return action;
+	}
+
+	static Action createAction(String text, Runnable action) {
+		return createAction(text, 0, action);
+	}
+
+	static <S> int addButton(String label, Consumer<S> handler, List<String> labels, List<Consumer<S>> handlers) {
+		labels.add(label);
+		handlers.add(handler);
+		return labels.size() - 1;
+	}
+
+	private static Action createAction(String text, int style, Runnable action) {
+		return new Action(text, style) {
+			@Override
+			public void run() {
+				action.run();
+			}
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T> T[] filterToArray(Stream<Object> stream, Class<T> type) {
+		return stream.filter(type::isInstance).map(type::cast).toArray(l -> (T[]) Array.newInstance(type, l));
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PluginSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PluginSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2022 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,17 +16,18 @@
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 487988
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 351356
  *     Hannes Wellmann - Bug 570760 - Option to automatically add requirements to product-launch
+ *     Hannes Wellmann - Unify and clean-up Product Editor's PluginSection and FeatureSection
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
 import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -35,33 +36,20 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.action.Action;
-import org.eclipse.jface.action.IAction;
-import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.jface.action.Separator;
-import org.eclipse.jface.action.ToolBarManager;
-import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.jface.viewers.TableViewer;
-import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.eclipse.pde.core.IModelChangedEvent;
 import org.eclipse.pde.core.plugin.IMatchRules;
-import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.DependencyManager.Options;
 import org.eclipse.pde.internal.core.ICoreConstants;
-import org.eclipse.pde.internal.core.IPluginModelListener;
-import org.eclipse.pde.internal.core.PluginModelDelta;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
-import org.eclipse.pde.internal.core.iproduct.IProductModel;
 import org.eclipse.pde.internal.core.iproduct.IProductModelFactory;
 import org.eclipse.pde.internal.core.iproduct.IProductPlugin;
 import org.eclipse.pde.internal.core.util.VersionUtil;
@@ -70,9 +58,7 @@ import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.dialogs.PluginSelectionDialog;
-import org.eclipse.pde.internal.ui.editor.FormLayoutFactory;
 import org.eclipse.pde.internal.ui.editor.PDEFormPage;
-import org.eclipse.pde.internal.ui.editor.TableSection;
 import org.eclipse.pde.internal.ui.editor.plugin.ManifestEditor;
 import org.eclipse.pde.internal.ui.parts.TablePart;
 import org.eclipse.pde.internal.ui.util.PersistablePluginObject;
@@ -80,155 +66,78 @@ import org.eclipse.pde.internal.ui.util.SWTUtil;
 import org.eclipse.pde.internal.ui.wizards.plugin.NewFragmentProjectWizard;
 import org.eclipse.pde.internal.ui.wizards.plugin.NewPluginProjectWizard;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Cursor;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableItem;
-import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.dialogs.IWorkingSetSelectionDialog;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
 
-public class PluginSection extends TableSection implements IPluginModelListener {
+/**
+ * Section of the product editor on the {@code Contents} page that lists all
+ * required Plug-ins of this Plug-in-based product.
+ */
+public class PluginSection extends AbstractProductContentSection<PluginSection> {
 
-	class ContentProvider implements IStructuredContentProvider {
-		@Override
-		public Object[] getElements(Object parent) {
-			return getProduct().getPlugins();
-		}
+	private static final List<String> BUTTON_LABELS;
+	private static final List<Consumer<PluginSection>> BUTTON_HANDLERS;
+
+	private static final int BTN_ADD;
+	private static final int BTN_ADD_WORKING_SET;
+	private static final int BTN_ADD_REQUIRED;
+	private static final int BTN_REMOVE;
+	private static final int BTN_REMOVE_ALL;
+	private static final int BTN_PROPS;
+
+	static {
+		List<String> labels = new ArrayList<>();
+		List<Consumer<PluginSection>> handlers = new ArrayList<>();
+
+		BTN_ADD = addButton(PDEUIMessages.Product_PluginSection_add, PluginSection::handleAdd, labels, handlers);
+		BTN_ADD_WORKING_SET = addButton(PDEUIMessages.Product_PluginSection_working, PluginSection::handleAddWorkingSet,
+				labels, handlers);
+		BTN_ADD_REQUIRED = addButton(PDEUIMessages.Product_PluginSection_required,
+				s -> handleAddRequired(s.getProduct().getPlugins(), s.fIncludeOptionalButton.getSelection()), labels,
+				handlers);
+		BTN_REMOVE = addButton(PDEUIMessages.PluginSection_remove, PluginSection::handleRemove, labels, handlers);
+		BTN_REMOVE_ALL = addButton(PDEUIMessages.Product_PluginSection_removeAll, PluginSection::handleRemoveAll,
+				labels, handlers);
+		BTN_PROPS = addButton(PDEUIMessages.Product_FeatureSection_properties, PluginSection::handleProperties, labels,
+				handlers);
+
+		BUTTON_LABELS = List.copyOf(labels);
+		BUTTON_HANDLERS = List.copyOf(handlers);
 	}
 
-	private TableViewer fPluginTable;
 	private Button fIncludeOptionalButton;
-	private Action fNewPluginAction;
-	private Action fNewFragmentAction;
-	public static final QualifiedName OPTIONAL_PROPERTY = new QualifiedName(IPDEUIConstants.PLUGIN_ID, "product.includeOptional"); //$NON-NLS-1$
-
-	class NewPluginAction extends Action {
-
-		public NewPluginAction() {
-			super(PDEUIMessages.Product_PluginSection_newPlugin, IAction.AS_PUSH_BUTTON);
-			setImageDescriptor(PDEPluginImages.DESC_NEWPPRJ_TOOL);
-		}
-
-		@Override
-		public void run() {
-			handleNewPlugin();
-		}
-	}
-
-	class NewFragmentAction extends Action {
-
-		public NewFragmentAction() {
-			super(PDEUIMessages.Product_PluginSection_newFragment, IAction.AS_PUSH_BUTTON);
-			setImageDescriptor(PDEPluginImages.DESC_NEWFRAGPRJ_TOOL);
-		}
-
-		@Override
-		public void run() {
-			handleNewFragment();
-		}
-	}
+	private static final QualifiedName OPTIONAL_PROPERTY = new QualifiedName(IPDEUIConstants.PLUGIN_ID,
+			"product.includeOptional"); //$NON-NLS-1$
 
 	public PluginSection(PDEFormPage formPage, Composite parent) {
-		super(formPage, parent, Section.DESCRIPTION, getButtonLabels());
-	}
-
-	private static String[] getButtonLabels() {
-		String[] labels = new String[6];
-		labels[0] = PDEUIMessages.Product_PluginSection_add;
-		labels[1] = PDEUIMessages.Product_PluginSection_working;
-		labels[2] = PDEUIMessages.Product_PluginSection_required;
-		labels[3] = PDEUIMessages.PluginSection_remove;
-		labels[4] = PDEUIMessages.Product_PluginSection_removeAll;
-		labels[5] = PDEUIMessages.Product_FeatureSection_properties;
-		return labels;
+		super(formPage, parent, BUTTON_LABELS, BUTTON_HANDLERS, IProductPlugin.class::isInstance);
 	}
 
 	@Override
-	protected void createClient(Section section, FormToolkit toolkit) {
+	void populateSection(Section section, Composite container, FormToolkit toolkit) {
 
-		section.setLayout(FormLayoutFactory.createClearGridLayout(false, 1));
-		GridData sectionData = new GridData(GridData.FILL_BOTH);
-		sectionData.verticalSpan = 2;
-		section.setLayoutData(sectionData);
+		createAutoIncludeRequirementsButton(container, PDEUIMessages.Product_PluginSection_autoIncludeRequirements);
 
-		Composite container = createClientContainer(section, 2, toolkit);
-		createViewerPartControl(container, SWT.MULTI, 2, toolkit);
-		container.setLayoutData(new GridData(GridData.FILL_BOTH));
-
-		createAutoIncludeRequirementsButton(container);
 		new Label(container, SWT.NONE); // fills column 2
 		createOptionalDependenciesButton(container);
 
-		TablePart tablePart = getTablePart();
-		fPluginTable = tablePart.getTableViewer();
-		fPluginTable.setContentProvider(new ContentProvider());
-		fPluginTable.setLabelProvider(PDEPlugin.getDefault().getLabelProvider());
-		fPluginTable.setComparator(new ViewerComparator() {
-			@Override
-			public int compare(Viewer viewer, Object e1, Object e2) {
-				IProductPlugin p1 = (IProductPlugin) e1;
-				IProductPlugin p2 = (IProductPlugin) e2;
-				return super.compare(viewer, p1.getId(), p2.getId());
-			}
-		});
-		GridData data = (GridData) tablePart.getControl().getLayoutData();
-		data.minimumWidth = 200;
-		fPluginTable.setInput(getProduct());
+		configureTable(IProduct::getPlugins, new ViewerComparator());
 
-		tablePart.setButtonEnabled(0, isEditable());
-		tablePart.setButtonEnabled(1, isEditable());
-		tablePart.setButtonEnabled(2, isEditable());
-
+		enableTableButtons(BTN_ADD, BTN_ADD_WORKING_SET, BTN_ADD_REQUIRED, BTN_PROPS);
 		// remove buttons will be updated on refresh
-
-		tablePart.setButtonEnabled(5, isEditable());
-
-		toolkit.paintBordersFor(container);
-		section.setClient(container);
 
 		section.setText(PDEUIMessages.Product_PluginSection_title);
 		section.setDescription(PDEUIMessages.Product_PluginSection_desc);
-		getModel().addModelChangedListener(this);
-		createSectionToolbar(section, toolkit);
-	}
-
-	private void createSectionToolbar(Section section, FormToolkit toolkit) {
-		ToolBarManager toolBarManager = new ToolBarManager(SWT.FLAT);
-		ToolBar toolbar = toolBarManager.createControl(section);
-		final Cursor handCursor = Display.getCurrent().getSystemCursor(SWT.CURSOR_HAND);
-		toolbar.setCursor(handCursor);
-		fNewPluginAction = new NewPluginAction();
-		fNewFragmentAction = new NewFragmentAction();
-		toolBarManager.add(fNewPluginAction);
-		toolBarManager.add(fNewFragmentAction);
-
-		toolBarManager.update(true);
-		section.setTextClient(toolbar);
-	}
-
-	private void createAutoIncludeRequirementsButton(Composite container) {
-		Button autoInclude = new Button(container, SWT.CHECK);
-		autoInclude.setText(PDEUIMessages.Product_PluginSection_autoIncludeRequirements);
-		autoInclude.setSelection(getProduct().includeRequirementsAutomatically());
-		if (isEditable()) {
-			autoInclude.addSelectionListener(widgetSelectedAdapter(
-					e -> getProduct().setIncludeRequirementsAutomatically(autoInclude.getSelection())));
-		} else {
-			autoInclude.setEnabled(false); // default is true
-		}
 	}
 
 	private void createOptionalDependenciesButton(Composite container) {
@@ -237,8 +146,8 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 			fIncludeOptionalButton.setText(PDEUIMessages.PluginSection_includeOptional);
 			// initialize value
 			IEditorInput input = getPage().getEditorInput();
-			if (input instanceof IFileEditorInput) {
-				IFile file = ((IFileEditorInput) input).getFile();
+			if (input instanceof IFileEditorInput fileEditorInput) {
+				IFile file = fileEditorInput.getFile();
 				try {
 					fIncludeOptionalButton.setSelection("true".equals(file.getPersistentProperty(OPTIONAL_PROPERTY))); //$NON-NLS-1$
 				} catch (CoreException e) {
@@ -246,10 +155,11 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 			}
 			// create listener to save value when the checkbox is changed
 			fIncludeOptionalButton.addSelectionListener(widgetSelectedAdapter(e -> {
-				if (input instanceof IFileEditorInput) {
-					IFile file = ((IFileEditorInput) input).getFile();
+				if (input instanceof IFileEditorInput fileEditorInput) {
+					IFile file = fileEditorInput.getFile();
 					try {
-						file.setPersistentProperty(OPTIONAL_PROPERTY, fIncludeOptionalButton.getSelection() ? "true" : null); //$NON-NLS-1$
+						file.setPersistentProperty(OPTIONAL_PROPERTY,
+								fIncludeOptionalButton.getSelection() ? "true" : null); //$NON-NLS-1$
 					} catch (CoreException e1) {
 					}
 				}
@@ -258,27 +168,12 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 	}
 
 	@Override
-	protected void buttonSelected(int index) {
-		switch (index) {
-			case 0 :
-				handleAdd();
-				break;
-			case 1 :
-				handleAddWorkingSet();
-				break;
-			case 2 :
-				handleAddRequired(getProduct().getPlugins(), fIncludeOptionalButton.getSelection());
-				break;
-			case 3 :
-				handleDelete();
-				break;
-			case 4 :
-				handleRemoveAll();
-				break;
-			case 5 :
-				handleProperties();
-				break;
-		}
+	List<Action> getToolbarActions() {
+		Action newPluginAction = createPushAction(PDEUIMessages.Product_PluginSection_newPlugin,
+				PDEPluginImages.DESC_NEWPPRJ_TOOL, () -> handleNewPlugin());
+		Action newFragmentAction = createPushAction(PDEUIMessages.Product_PluginSection_newFragment,
+				PDEPluginImages.DESC_NEWFRAGPRJ_TOOL, () -> handleNewFragment());
+		return List.of(newPluginAction, newFragmentAction);
 	}
 
 	private void handleNewFragment() {
@@ -304,10 +199,10 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 	}
 
 	private void handleProperties() {
-		IStructuredSelection ssel = fPluginTable.getStructuredSelection();
-		if (ssel.size() == 1) {
-			IProductPlugin plugin = (IProductPlugin) ssel.toArray()[0];
-			VersionDialog dialog = new VersionDialog(PDEPlugin.getActiveWorkbenchShell(), isEditable(), plugin.getVersion());
+		IStructuredSelection ssel = getTableSelection();
+		if (ssel.size() == 1 && ssel.getFirstElement() instanceof IProductPlugin plugin) {
+			VersionDialog dialog = new VersionDialog(PDEPlugin.getActiveWorkbenchShell(), isEditable(),
+					plugin.getVersion());
 			dialog.create();
 			SWTUtil.setDialogSize(dialog, 400, 200);
 			if (dialog.open() == Window.OK) {
@@ -318,98 +213,19 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 
 	@Override
 	protected void handleDoubleClick(IStructuredSelection selection) {
-		handleOpen(selection);
-	}
-
-	@Override
-	public void dispose() {
-		IProductModel model = getModel();
-		if (model != null)
-			model.removeModelChangedListener(this);
-		super.dispose();
-	}
-
-	@Override
-	public boolean doGlobalAction(String actionId) {
-		if (actionId.equals(ActionFactory.DELETE.getId())) {
-			handleDelete();
-			return true;
-		}
-		if (actionId.equals(ActionFactory.CUT.getId())) {
-			handleDelete();
-			return false;
-		}
-		if (actionId.equals(ActionFactory.PASTE.getId())) {
-			doPaste();
-			return true;
-		}
-		return super.doGlobalAction(actionId);
-	}
-
-	@Override
-	protected boolean canPaste(Object target, Object[] objects) {
-		for (Object object : objects) {
-			if (object instanceof IProductPlugin)
-				return true;
-		}
-		return false;
-	}
-
-	@Override
-	protected void fillContextMenu(IMenuManager manager) {
-		IStructuredSelection ssel = fPluginTable.getStructuredSelection();
-		if (ssel == null)
-			return;
-
-		Action openAction = new Action(PDEUIMessages.PluginSection_open) {
-			@Override
-			public void run() {
-				handleDoubleClick(fPluginTable.getStructuredSelection());
-			}
-		};
-		openAction.setEnabled(isEditable() && ssel.size() == 1);
-		manager.add(openAction);
-
-		manager.add(new Separator());
-
-		Action removeAction = new Action(PDEUIMessages.PluginSection_remove) {
-			@Override
-			public void run() {
-				handleDelete();
-			}
-		};
-		removeAction.setEnabled(isEditable() && !ssel.isEmpty());
-		manager.add(removeAction);
-
-		Action removeAll = new Action(PDEUIMessages.PluginSection_removeAll) {
-			@Override
-			public void run() {
-				handleRemoveAll();
-			}
-		};
-		removeAll.setEnabled(isEditable());
-		manager.add(removeAll);
-
-		manager.add(new Separator());
-
-		getPage().getPDEEditor().getContributor().contextMenuAboutToShow(manager);
-	}
-
-	private void handleOpen(IStructuredSelection selection) {
-		Object object = selection.getFirstElement();
-		if (object instanceof IProductPlugin) {
-			ManifestEditor.openPluginEditor(((IProductPlugin) object).getId());
+		if (selection.getFirstElement() instanceof IProductPlugin plugin) {
+			ManifestEditor.openPluginEditor(plugin.getId());
 		}
 	}
 
 	public static void handleAddRequired(IProductPlugin[] plugins, boolean includeOptional) {
-		if (plugins.length == 0)
+		if (plugins.length == 0) {
 			return;
-
-		List<BundleDescription> list = Arrays.stream(plugins).map(plugin -> {
+		}
+		List<BundleDescription> list = Stream.of(plugins).map(plugin -> {
 			String version = VersionUtil.isEmptyVersion(plugin.getVersion()) ? null : plugin.getVersion();
 			return PluginRegistry.findModel(plugin.getId(), version, IMatchRules.PERFECT, null);
-		}).filter(Objects::nonNull).map(IPluginModelBase::getBundleDescription).collect(Collectors.toList());
+		}).filter(Objects::nonNull).map(IPluginModelBase::getBundleDescription).toList();
 
 		DependencyManager.Options[] options = includeOptional
 				? new Options[] { Options.INCLUDE_NON_TEST_FRAGMENTS, Options.INCLUDE_OPTIONAL_DEPENDENCIES }
@@ -417,57 +233,52 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 		Set<BundleDescription> dependencies = DependencyManager.findRequirementsClosure(list, options);
 
 		IProduct product = plugins[0].getProduct();
-		IProductModelFactory factory = product.getModel().getFactory();
-		IProductPlugin[] requiredPlugins = dependencies.stream().map(d -> {
-			IProductPlugin plugin = factory.createPlugin();
-			plugin.setId(d.getSymbolicName());
-			return plugin;
-		}).toArray(IProductPlugin[]::new);
-		product.addPlugins(requiredPlugins);
+		addPluginsWithSymbolicName(product, dependencies.stream().map(BundleDescription::getSymbolicName));
 	}
 
 	private void handleAddWorkingSet() {
 		IWorkingSetManager manager = PlatformUI.getWorkbench().getWorkingSetManager();
-		IWorkingSetSelectionDialog dialog = manager.createWorkingSetSelectionDialog(PDEPlugin.getActiveWorkbenchShell(), true);
+		IWorkingSetSelectionDialog dialog = manager.createWorkingSetSelectionDialog(PDEPlugin.getActiveWorkbenchShell(),
+				true);
 		if (dialog.open() == Window.OK) {
 			IWorkingSet[] workingSets = dialog.getSelection();
-			IProduct product = getProduct();
-			IProductModelFactory factory = product.getModel().getFactory();
-			ArrayList<IProductPlugin> pluginList = new ArrayList<>();
-			for (IWorkingSet workingSet : workingSets) {
-				IAdaptable[] elements = workingSet.getElements();
-				for (IAdaptable element : elements) {
-					IPluginModelBase model = findModel(element);
-					if (model != null) {
-						IProductPlugin plugin = factory.createPlugin();
-						IPluginBase base = model.getPluginBase();
-						plugin.setId(base.getId());
-						pluginList.add(plugin);
-					}
-				}
-			}
-			product.addPlugins(pluginList.toArray(new IProductPlugin[pluginList.size()]));
+			Stream<String> plugins = Stream.of(workingSets).flatMap(ws -> Stream.of(ws.getElements()))
+					.map(this::findModel).filter(Objects::nonNull).map(model -> model.getPluginBase().getId());
+			addPluginsWithSymbolicName(getProduct(), plugins);
 		}
 	}
 
-	private void handleRemoveAll() {
+	private static void addPluginsWithSymbolicName(IProduct product, Stream<String> pluginIds) {
+		IProductModelFactory factory = product.getModel().getFactory();
+		IProductPlugin[] plugins = pluginIds.map(symbolicName -> {
+			IProductPlugin plugin = factory.createPlugin();
+			plugin.setId(symbolicName);
+			return plugin;
+		}).toArray(IProductPlugin[]::new);
+		product.addPlugins(plugins);
+	}
+
+	@Override
+	void handleRemoveAll() {
 		IProduct product = getProduct();
 		product.removePlugins(product.getPlugins());
 	}
 
-	private void handleDelete() {
-		IStructuredSelection ssel = fPluginTable.getStructuredSelection();
-		if (!ssel.isEmpty()) {
-			Object[] objects = ssel.toArray();
-			IProductPlugin[] plugins = new IProductPlugin[objects.length];
-			System.arraycopy(objects, 0, plugins, 0, objects.length);
-			getProduct().removePlugins(plugins);
-			updateRemoveButtons(true, true);
-		}
+	@Override
+	protected void doPaste(Object target, Object[] objects) {
+		IProductPlugin[] plugins = filterToArray(Stream.of(objects), IProductPlugin.class);
+		getProduct().addPlugins(plugins);
+	}
+
+	@Override
+	void removeElements(IProduct product, List<Object> elements) {
+		IProductPlugin[] plugins = filterToArray(elements.stream(), IProductPlugin.class);
+		getProduct().removePlugins(plugins);
 	}
 
 	private void handleAdd() {
-		PluginSelectionDialog pluginSelectionDialog = new PluginSelectionDialog(PDEPlugin.getActiveWorkbenchShell(), getBundles(), true);
+		PluginSelectionDialog pluginSelectionDialog = new PluginSelectionDialog(PDEPlugin.getActiveWorkbenchShell(),
+				getBundles(getProduct()), true);
 		if (pluginSelectionDialog.open() == Window.OK) {
 			Object[] result = pluginSelectionDialog.getResult();
 			for (Object object : result) {
@@ -477,9 +288,8 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 		}
 	}
 
-	private IPluginModelBase[] getBundles() {
+	private static IPluginModelBase[] getBundles(IProduct product) {
 		List<IPluginModelBase> pluginModelBaseList = new ArrayList<>();
-		IProduct product = getProduct();
 		BundleDescription[] bundles = TargetPlatformHelper.getState().getBundles();
 		for (BundleDescription bundleDescription : bundles) {
 			if (!product.containsPlugin(bundleDescription.getSymbolicName())) {
@@ -499,154 +309,32 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 		IProductPlugin plugin = factory.createPlugin();
 		plugin.setId(id);
 		plugin.setVersion(version);
-		product.addPlugins(new IProductPlugin[] {plugin});
-		fPluginTable.setSelection(new StructuredSelection(plugin));
-	}
-
-	private IProduct getProduct() {
-		return getModel().getProduct();
-	}
-
-	private IProductModel getModel() {
-		return (IProductModel) getPage().getPDEEditor().getAggregateModel();
-	}
-
-	@Override
-	public void modelChanged(IModelChangedEvent e) {
-		// No need to call super, handling world changed event here
-		if (e.getChangeType() == IModelChangedEvent.WORLD_CHANGED) {
-			handleModelEventWorldChanged(e);
-			return;
-		}
-		Object[] objects = e.getChangedObjects();
-		if (e.getChangeType() == IModelChangedEvent.INSERT) {
-			for (Object object : objects) {
-				if (object instanceof IProductPlugin)
-					fPluginTable.add(object);
-			}
-		} else if (e.getChangeType() == IModelChangedEvent.REMOVE) {
-
-			Table table = fPluginTable.getTable();
-			int index = table.getSelectionIndex();
-
-			for (Object object : objects) {
-				if (object instanceof IProductPlugin)
-					fPluginTable.remove(object);
-			}
-
-			// Update Selection
-
-			int count = table.getItemCount();
-
-			if (count == 0) {
-				// Nothing to select
-			} else if (index < count) {
-				table.setSelection(index);
-			} else {
-				table.setSelection(count - 1);
-			}
-
-		} else if (e.getChangeType() == IModelChangedEvent.CHANGE) {
-			fPluginTable.refresh();
-		}
-		updateRemoveButtons(false, true);
-	}
-
-	/**
-	 * @param event
-	 */
-	private void handleModelEventWorldChanged(IModelChangedEvent event) {
-		// This section can get disposed if the configuration is changed from
-		// plugins to features or vice versa.  Subsequently, the configuration
-		// page is removed and readded.  In this circumstance, abort the
-		// refresh
-		if (fPluginTable.getTable().isDisposed()) {
-			return;
-		}
-		// Reload the input
-		fPluginTable.setInput(getProduct());
-		// Perform the refresh
-		refresh();
-	}
-
-	@Override
-	public void refresh() {
-		fPluginTable.refresh();
-		updateRemoveButtons(true, true);
-		super.refresh();
-	}
-
-	@Override
-	public void modelsChanged(PluginModelDelta delta) {
-		final Control control = fPluginTable.getControl();
-		if (!control.isDisposed()) {
-			control.getDisplay().asyncExec(() -> {
-				if (!control.isDisposed()) {
-					fPluginTable.refresh();
-					updateRemoveButtons(true, true);
-				}
-			});
-		}
+		product.addPlugins(new IProductPlugin[] { plugin });
+		getTableViewer().setSelection(new StructuredSelection(plugin));
 	}
 
 	private IPluginModelBase findModel(IAdaptable object) {
-		if (object instanceof IJavaProject)
-			object = ((IJavaProject) object).getProject();
-		if (object instanceof IProject)
-			return PluginRegistry.findModel((IProject) object);
-		if (object instanceof PersistablePluginObject) {
-			return PluginRegistry.findModel(((PersistablePluginObject) object).getPluginID());
+		if (object instanceof IJavaProject javaProject) {
+			object = javaProject.getProject();
+		}
+		if (object instanceof IProject project) {
+			return PluginRegistry.findModel(project);
+		} else if (object instanceof PersistablePluginObject pluginObject) {
+			return PluginRegistry.findModel(pluginObject.getPluginID());
 		}
 		return null;
 	}
 
 	@Override
-	protected void selectionChanged(IStructuredSelection selection) {
-		getPage().getPDEEditor().setSelection(selection);
-		updateRemoveButtons(true, false);
-	}
+	void updateButtons(boolean updateRemove, boolean updateRemoveAll) {
 
-	@Override
-	public boolean setFormInput(Object input) {
-		if (input instanceof IProductPlugin) {
-			fPluginTable.setSelection(new StructuredSelection(input), true);
-			return true;
-		}
-		return super.setFormInput(input);
-	}
+		updateRemoveButtons(updateRemove ? BTN_REMOVE : -1, updateRemoveAll ? BTN_REMOVE_ALL : -1);
 
-	@Override
-	protected void doPaste(Object target, Object[] objects) {
-		IProductPlugin[] plugins;
-		if (objects instanceof IProductPlugin[])
-			plugins = (IProductPlugin[]) objects;
-		else {
-			plugins = new IProductPlugin[objects.length];
-			for (int i = 0; i < objects.length; i++)
-				if (objects[i] instanceof IProductPlugin)
-					plugins[i] = (IProductPlugin) objects[i];
-		}
-		getProduct().addPlugins(plugins);
-	}
-
-	private void updateRemoveButtons(boolean updateRemove, boolean updateRemoveAll) {
 		TablePart tablePart = getTablePart();
-		Table table = tablePart.getTableViewer().getTable();
-		TableItem[] tableSelection = table.getSelection();
-		if (updateRemove) {
-			ISelection selection = getViewerSelection();
-			tablePart.setButtonEnabled(3, isEditable() && !selection.isEmpty() && selection instanceof IStructuredSelection && ((IStructuredSelection) selection).getFirstElement() instanceof IProductPlugin);
-		}
-		int count = fPluginTable.getTable().getItemCount();
-		if (updateRemoveAll)
-			tablePart.setButtonEnabled(4, isEditable() && count > 0);
-		tablePart.setButtonEnabled(2, isEditable() && count > 0);
-		tablePart.setButtonEnabled(5, isEditable() && tableSelection.length == 1);
-	}
+		Table table = getTable();
 
-	@Override
-	protected boolean createCount() {
-		return true;
+		tablePart.setButtonEnabled(BTN_PROPS, isEditable() && table.getSelection().length == 1);
+		tablePart.setButtonEnabled(BTN_ADD_REQUIRED, isEditable() && table.getItemCount() > 0);
 	}
 
 	public boolean includeOptionalDependencies() {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -1239,7 +1239,6 @@ FeatureImportWizard_errors_buildFolderMissing= The directory specified does not 
 FeatureImportWizard_messages_updating = Updating...
 FeatureImportWizard_title = Import Features
 FeatureSection_addRequired=Add Required
-FeatureSection_removeAll=Remove All
 FeatureSection_toggleRoot=Toggle Install Mode
 FeatureImportWizard_noToAll = No to A&ll
 FeatureImportWizard_messages_noFeatures = No features found. Ensure that the chosen directory contains 'features' folder.
@@ -2057,7 +2056,7 @@ ProductIntroWizardPage_introNotSet=Intro ID is not set
 Product_PluginSection_add=Add...
 Product_PluginSection_autoIncludeRequirements=Include required Plug-ins automatically
 Product_PluginSection_title=Plug-ins and Fragments
-Product_FeatureSection_desc=List the features that constitute the product.  Nested features need not be listed.
+Product_FeatureSection_desc=List the Features that constitute the product. Nested Features need not be listed.
 ProductInfoSection_plugins=plug-ins
 ProductInfoSection_features=features
 ProductExportWizardPage_desc=Use an existing Eclipse product configuration to export the product in one of the available formats.
@@ -2095,7 +2094,7 @@ ProductExportWizardPage_syncText=Synchronization of the product configuration wi
 ProductExportWizardPage_syncButton=&Synchronize before exporting
 ProductExportWizardPage_noProduct=Product configuration is not specified.
 Product_OverviewPage_testing=Testing
-Product_PluginSection_desc=List all the plug-ins and fragments that constitute the product.
+Product_PluginSection_desc=List all the Plug-ins and Fragments that constitute the product.
 Product_FeatureSection_add=Add...
 Product_FeatureSection_autoIncludeRequirements=Include required Features and Plug-ins automatically
 ProductFileWizadPage_title=Create a new product configuration and initialize its content.
@@ -2185,8 +2184,6 @@ ProductJRESection_eeName=Execution environment:
 ProductJRESection_browseEEs=Environments...
 ProdctJRESection_bundleJRE=Bundle JRE for this environment with the product.
 
-Product_FeatureSection_remove = Remove
-Product_FeatureSection_open = Open
 Product_FeatureSection_up = Up
 Product_FeatureSection_down = Down
 Product_FeatureSection_sortAlpha = Sort the features alphabetically


### PR DESCRIPTION
Unify the Product Editor's `PluginSection` and `FeatureSection`, so that it can be re-used in https://github.com/eclipse-pde/eclipse.pde/pull/291 for a future `MixedSection` too.

Removes unused code like the implementation of `IPluginModelListener` in `PluginSection`.