### PR TITLE
back-port Use the actual system-packages from the JVM for export

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -410,13 +410,7 @@ public class TargetPlatformHelper {
 		if (vm == null || !JavaRuntime.isModularJava(vm)) {
 			return null;
 		}
-
-		String release = null;
-		Map<String, String> complianceOptions = environment.getComplianceOptions();
-		if (complianceOptions != null) {
-			release = complianceOptions.get(JavaCore.COMPILER_COMPLIANCE);
-		}
-
+		String release = environment.getProfileProperties().getProperty(JavaCore.COMPILER_COMPLIANCE);
 		try {
 			Collection<String> packages = new TreeSet<>();
 			File jrtPath = new File(vm.getInstallLocation(), "lib/" + JRTUtil.JRT_FS_JAR); //$NON-NLS-1$
@@ -440,12 +434,10 @@ public class TargetPlatformHelper {
 		if (defaultVM != null) {
 			return defaultVM;
 		}
-
 		IVMInstall[] compatible = environment.getCompatibleVMs();
 		if (compatible.length == 0) {
 			return null;
 		}
-
 		for (IVMInstall vm : compatible) {
 			if (environment.isStrictlyCompatible(vm)) {
 				return vm;


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/194 for PDE-build

Refs: https://github.com/eclipse-pde/eclipse.pde/issues/624

Refs: https://github.com/eclipse-pde/eclipse.pde.build/pull/16

(commit of this PR should be paired together with the commit in the referenced PR in eclipse.pde.build repo, as they constitute a single commit logically, but got split up physically due to the the fact that they were in two repos then)