### PR TITLE
Do not fail if cleaning orphan targets fails on shutdown

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -325,8 +325,12 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		workspace.addSaveParticipant(PLUGIN_ID, new ISaveParticipant() {
 			@Override
-			public void saving(ISaveContext saveContext) throws CoreException {
-				P2TargetUtils.cleanOrphanedTargetDefinitionProfiles();
+			public void saving(ISaveContext saveContext) {
+				try {
+					P2TargetUtils.cleanOrphanedTargetDefinitionProfiles();
+				} catch (CoreException e) {
+					getLog().warn("Can't cleanup orphaned target definition profiles, will retry later.", e); //$NON-NLS-1$
+				}
 			}
 
 			@Override


### PR DESCRIPTION
Cleaning is not an operation that should fail the saving and show an error to the user therefore we only write a warning to the log.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/628