### PR TITLE
fix FeatureGenerator.addLauncher()

### DIFF
--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.build;singleton:=true
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.12.200.qualifier
 Bundle-ClassPath: pdebuild.jar
 Bundle-Activator: org.eclipse.pde.internal.build.BuildActivator
 Bundle-Vendor: %providerName


### PR DESCRIPTION
Even though Entry.equals(String) was defined String.equals(Entry) == false. It's pure implementation detail of the Set created in FeatureGenerator.createSet(String[]) if s.equals(e) or e.equals(s) is called and also Entry.hashCode() does not match String.hashCode();