### PR TITLE
Consider Bundle-Version when opening 'Plugin-Dependencies' from Manifest Editor

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyAnalysisSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyAnalysisSection.java
@@ -16,6 +16,8 @@ package org.eclipse.pde.internal.ui.editor.plugin;
 
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.pde.core.IBaseModel;
+import org.eclipse.pde.core.plugin.IMatchRules;
+import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
@@ -83,7 +85,7 @@ public class DependencyAnalysisSection extends PDESection {
 						doFindLoops(pluginModel);
 
 					} else {
-						IPluginModelBase plugin = PluginRegistry.findModel(pluginModel.getPluginBase().getId());
+						IPluginModelBase plugin = getStatePlugin(pluginModel);
 						if (e.getHref().equals("references")) { //$NON-NLS-1$
 							new OpenPluginReferencesAction(plugin).run();
 						} else if (e.getHref().equals("hierarchy")) { //$NON-NLS-1$
@@ -94,6 +96,13 @@ public class DependencyAnalysisSection extends PDESection {
 			}
 		});
 		section.setClient(formText);
+	}
+
+	private IPluginModelBase getStatePlugin(IPluginModelBase pluginModel) {
+		// The pluginModel set for this page does not have a BundleDescriptor
+		// set, therefore search the pluginModel from the registry that has it
+		IPluginBase pluginBase = pluginModel.getPluginBase();
+		return PluginRegistry.findModel(pluginBase.getId(), pluginBase.getVersion(), IMatchRules.PERFECT, null);
 	}
 
 	private void doFindLoops(IPluginModelBase pluginModelBase) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/dependencies/DependenciesView.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/dependencies/DependenciesView.java
@@ -17,6 +17,7 @@ package org.eclipse.pde.internal.ui.views.dependencies;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jface.action.Action;
@@ -228,7 +229,7 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 	private ShowLoopsAction fShowLoops;
 
 	// history of input elements (as Strings). No duplicates
-	private ArrayList<String> fInputHistory;
+	private List<String> fInputHistory;
 
 	private DependencyLoop[] fLoops;
 
@@ -374,8 +375,9 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 		fPartCallersList = new DummyPart(site);
 		fPartCallersTree = new DummyPart(site);
 
-		if (memento == null)
+		if (memento == null) {
 			return;
+		}
 		String id = memento.getString(MEMENTO_KEY_INPUT);
 		if (id != null) {
 			IPluginModelBase plugin = PluginRegistry.findModel(id);
@@ -393,11 +395,9 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 	}
 
 	public void openTo(Object object) {
-		if (object != null && !object.equals(fInput)) {
-			if (object instanceof IPluginModelBase) {
-				String id = ((IPluginModelBase) object).getPluginBase().getId();
-				addHistoryEntry(id);
-			}
+		if (object != null && !object.equals(fInput) && object instanceof IPluginModelBase pluginModel) {
+			String id = pluginModel.getPluginBase().getId();
+			addHistoryEntry(id);
 		}
 		updateInput(object);
 	}
@@ -431,9 +431,9 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 	 */
 	private void findLoops() {
 		fLoops = NO_LOOPS;
-		if (fInput != null && fInput instanceof IPluginModel) {
+		if (fInput instanceof IPluginModel pluginModel) {
 			BusyIndicator.showWhile(PDEPlugin.getActiveWorkbenchShell().getDisplay(), () -> {
-				IPlugin plugin = ((IPluginModel) fInput).getPlugin();
+				IPlugin plugin = pluginModel.getPlugin();
 				DependencyLoop[] loops = DependencyLoopFinder.findLoops(plugin);
 				if (loops.length > 0) {
 					fLoops = loops;
@@ -447,8 +447,8 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 	@Override
 	public void saveState(IMemento memento) {
 		super.saveState(memento);
-		if (fInput != null && fInput instanceof IPluginModelBase) {
-			String inputPluginId = ((IPluginModelBase) fInput).getPluginBase().getId();
+		if (fInput instanceof IPluginModelBase pluginModel) {
+			String inputPluginId = pluginModel.getPluginBase().getId();
 			memento.putString(MEMENTO_KEY_INPUT, inputPluginId);
 		}
 	}
@@ -500,20 +500,20 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 			return;
 		}
 		IStructuredSelection selection = null;
-		if (currPage instanceof DependenciesViewPage) {
-			selection = ((DependenciesViewPage) currPage).getSelection();
-			((DependenciesViewPage) currPage).setActive(false);
+		if (currPage instanceof DependenciesViewPage dependenciesViewPage) {
+			selection = dependenciesViewPage.getSelection();
+			dependenciesViewPage.setActive(false);
 		}
 		IPage p = pageRec.page;
-		if (p instanceof DependenciesViewPage) {
-			((DependenciesViewPage) p).setInput(fInput);
+		if (p instanceof DependenciesViewPage dependenciesViewPage) {
+			dependenciesViewPage.setInput(fInput);
 			// configure view before actually showing it
-			((DependenciesViewPage) p).setActive(true);
+			dependenciesViewPage.setActive(true);
 		}
 		super.showPageRec(pageRec);
-		if (p instanceof DependenciesViewPage) {
+		if (p instanceof DependenciesViewPage dependenciesViewPage) {
 			updateTitle(fInput);
-			((DependenciesViewPage) p).setSelection(selection);
+			dependenciesViewPage.setSelection(selection);
 		}
 	}
 
@@ -614,10 +614,11 @@ public class DependenciesView extends PageBookView implements IPreferenceConstan
 	}
 
 	protected void enableStateView(boolean enabled) {
-		if (fLastDependenciesPart != null)
+		if (fLastDependenciesPart != null) {
 			partActivated(fLastDependenciesPart);
-		else
+		} else {
 			partActivated(getDefaultPart());
+		}
 		fLastDependenciesPart = null;
 		getViewSite().getActionBars().getToolBarManager().update(true);
 	}


### PR DESCRIPTION
This fixes the issue that in the `Dependencies` section of the Manifest-Editor if one called one of the following actions only the 'Plugin-Dependencies' of the latest version of all Bundles with the same Bundle-SymbolicName was displayed:

For Plug-ins:
- `Show the plug-in dependency hierarchy`
- `Show dependent plug-ins and fragments`
For Fragments:
- `Find this fragment's host plug-in`

In a separate(first) commit this PR contains clean-ups in code associated with Plug-in Dependency Analysis
