### PR TITLE
Replace deprecated ResourceManager methods and create colors directly

### DIFF
--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ToggleLayoutControl.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ToggleLayoutControl.java
@@ -53,8 +53,8 @@ public class ToggleLayoutControl {
 		if (toolItem != null && !toolItem.isDisposed()) {
 			toolItem.setSelection(hierarchicalLayoutPreference);
 			toolItem.setImage(
-					hierarchicalLayoutPreference ? getResourceManager().createImage(getHierarchicalImageDescriptor())
-							: getResourceManager().createImage(getFlatImageDescriptor()));
+					hierarchicalLayoutPreference ? getResourceManager().create(getHierarchicalImageDescriptor())
+							: getResourceManager().create(getFlatImageDescriptor()));
 			toolItem.setToolTipText(
 					hierarchicalLayoutPreference ? Messages.ToggleLayoutControl_Toggle_to_flat_layout : Messages.ToggleLayoutControl_Toggle_to_hierarchical_layout);
 		}

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ToggleLayoutControl.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ToggleLayoutControl.java
@@ -52,9 +52,8 @@ public class ToggleLayoutControl {
 			@Preference(value = PreferenceConstants.HIERARCHICAL_LAYOUT) boolean hierarchicalLayoutPreference) {
 		if (toolItem != null && !toolItem.isDisposed()) {
 			toolItem.setSelection(hierarchicalLayoutPreference);
-			toolItem.setImage(
-					hierarchicalLayoutPreference ? getResourceManager().create(getHierarchicalImageDescriptor())
-							: getResourceManager().create(getFlatImageDescriptor()));
+			toolItem.setImage(getResourceManager().create(getImageDescriptor(
+					"$nl$/icons/" + (hierarchicalLayoutPreference ? "hierarchicalLayout.png" : "flatLayout.png"))));
 			toolItem.setToolTipText(
 					hierarchicalLayoutPreference ? Messages.ToggleLayoutControl_Toggle_to_flat_layout : Messages.ToggleLayoutControl_Toggle_to_hierarchical_layout);
 		}
@@ -69,8 +68,8 @@ public class ToggleLayoutControl {
 				hierarchicalLayoutPreference ? Messages.ToggleLayoutControl_Toggle_to_flat_layout : Messages.ToggleLayoutControl_Toggle_to_hierarchical_layout);
 		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(event -> {
 			Object source = event.getSource();
-			if (source instanceof ToolItem) {
-				preferences.putBoolean(PreferenceConstants.HIERARCHICAL_LAYOUT, ((ToolItem) source).getSelection());
+			if (source instanceof ToolItem item) {
+				preferences.putBoolean(PreferenceConstants.HIERARCHICAL_LAYOUT, item.getSelection());
 				try {
 					preferences.flush();
 				} catch (BackingStoreException e) {
@@ -95,15 +94,9 @@ public class ToggleLayoutControl {
 		return resourceManager;
 	}
 
-	protected ImageDescriptor getFlatImageDescriptor() {
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-		URL url = FileLocator.find(bundle, IPath.fromOSString("$nl$/icons/flatLayout.png"), null);
-		return ImageDescriptor.createFromURL(url);
-	}
-
-	protected ImageDescriptor getHierarchicalImageDescriptor() {
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-		URL url = FileLocator.find(bundle, IPath.fromOSString("$nl$/icons/hierarchicalLayout.png"), null);
+	static ImageDescriptor getImageDescriptor(String imagePath) {
+		Bundle bundle = FrameworkUtil.getBundle(ToggleLayoutControl.class);
+		URL url = FileLocator.find(bundle, IPath.fromOSString(imagePath), null);
 		return ImageDescriptor.createFromURL(url);
 	}
 }

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/TogglePreferenceTraceControl.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/TogglePreferenceTraceControl.java
@@ -62,7 +62,7 @@ public class TogglePreferenceTraceControl {
 		toolItem = new ToolItem(toolBar, SWT.CHECK);
 		toolItem.setSelection(tracePreferences);
 		toolItem.setToolTipText(Messages.TogglePreferenceTraceControl_Toggle_Preference_Trace);
-		toolItem.setImage(getResourceManager().createImage(getImageDescriptor()));
+		toolItem.setImage(getResourceManager().create(getImageDescriptor()));
 		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(event -> {
 			Object source = event.getSource();
 			if (source instanceof ToolItem) {

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/TogglePreferenceTraceControl.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/TogglePreferenceTraceControl.java
@@ -13,18 +13,15 @@
  *******************************************************************************/
 package org.eclipse.pde.spy.preferences.handler;
 
-import java.net.URL;
+import static org.eclipse.pde.spy.preferences.handler.ToggleLayoutControl.getImageDescriptor;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.e4.core.services.log.Logger;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.jface.resource.ResourceManager;
@@ -34,8 +31,6 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.prefs.BackingStoreException;
 
 @SuppressWarnings("restriction")
@@ -62,11 +57,10 @@ public class TogglePreferenceTraceControl {
 		toolItem = new ToolItem(toolBar, SWT.CHECK);
 		toolItem.setSelection(tracePreferences);
 		toolItem.setToolTipText(Messages.TogglePreferenceTraceControl_Toggle_Preference_Trace);
-		toolItem.setImage(getResourceManager().create(getImageDescriptor()));
+		toolItem.setImage(getResourceManager().create(getImageDescriptor("$nl$/icons/trace_preferences.png")));
 		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(event -> {
-			Object source = event.getSource();
-			if (source instanceof ToolItem) {
-				preferences.putBoolean(PreferenceConstants.TRACE_PREFERENCES, ((ToolItem) source).getSelection());
+			if (event.getSource() instanceof ToolItem item) {
+				preferences.putBoolean(PreferenceConstants.TRACE_PREFERENCES, item.getSelection());
 				try {
 					preferences.flush();
 				} catch (BackingStoreException e) {
@@ -88,11 +82,5 @@ public class TogglePreferenceTraceControl {
 			resourceManager = new LocalResourceManager(JFaceResources.getResources());
 		}
 		return resourceManager;
-	}
-
-	protected ImageDescriptor getImageDescriptor() {
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-		URL url = FileLocator.find(bundle, IPath.fromOSString("$nl$/icons/trace_preferences.png"), null);
-		return ImageDescriptor.createFromURL(url);
 	}
 }

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceMapLabelProvider.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceMapLabelProvider.java
@@ -39,8 +39,7 @@ public class PreferenceMapLabelProvider extends ObservableMapLabelProvider imple
 	@Override
 	public String getColumnText(Object element, int columnIndex) {
 		String columnText = super.getColumnText(element, columnIndex);
-		if ("".equals(columnText) && element instanceof PreferenceEntry) {
-			PreferenceEntry entry = (PreferenceEntry) element;
+		if ("".equals(columnText) && element instanceof PreferenceEntry entry) {
 			switch (columnIndex) {
 			case 1:
 				columnText = entry.getKey();
@@ -61,7 +60,7 @@ public class PreferenceMapLabelProvider extends ObservableMapLabelProvider imple
 
 	@Override
 	public Font getFont(Object element) {
-		if (element instanceof PreferenceEntry && ((PreferenceEntry) element).isRecentlyChanged()) {
+		if (element instanceof PreferenceEntry preferenceEntry && preferenceEntry.isRecentlyChanged()) {
 			return getResourceManager().create(fontDescriptor);
 		}
 		return null;

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceMapLabelProvider.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceMapLabelProvider.java
@@ -62,7 +62,7 @@ public class PreferenceMapLabelProvider extends ObservableMapLabelProvider imple
 	@Override
 	public Font getFont(Object element) {
 		if (element instanceof PreferenceEntry && ((PreferenceEntry) element).isRecentlyChanged()) {
-			return getResourceManager().createFont(fontDescriptor);
+			return getResourceManager().create(fontDescriptor);
 		}
 		return null;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/PluginStructureCreator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/PluginStructureCreator.java
@@ -89,11 +89,7 @@ public class PluginStructureCreator extends StructureCreator {
 
 	@Override
 	protected IStructureComparator createStructureComparator(Object input, IDocument document, ISharedDocumentAdapter adapter, IProgressMonitor monitor) throws CoreException {
-		final boolean isEditable;
-		if (input instanceof IEditableContent)
-			isEditable = ((IEditableContent) input).isEditable();
-		else
-			isEditable = false;
+		final boolean isEditable = input instanceof IEditableContent content && content.isEditable();
 
 		// Create a label provider to provide the text of the elements
 		final PDELabelProvider labelProvider = new PDELabelProvider();
@@ -129,8 +125,7 @@ public class PluginStructureCreator extends StructureCreator {
 
 	@Override
 	public String getContents(Object node, boolean ignoreWhitespace) {
-		if (node instanceof IStreamContentAccessor) {
-			IStreamContentAccessor sca = (IStreamContentAccessor) node;
+		if (node instanceof IStreamContentAccessor sca) {
 			try {
 				return ManifestStructureCreator.readString(sca);
 			} catch (CoreException ex) {
@@ -161,9 +156,8 @@ public class PluginStructureCreator extends StructureCreator {
 	}
 
 	private boolean isFragment(Object input) {
-		if (input instanceof ITypedElement && ((ITypedElement) input).getName().equals(ICoreConstants.FRAGMENT_FILENAME_DESCRIPTOR))
-			return true;
-		return false;
+		return input instanceof ITypedElement element
+				&& element.getName().equals(ICoreConstants.FRAGMENT_FILENAME_DESCRIPTOR);
 	}
 
 	private PluginModelBase createModel(Object input, IDocument document, boolean isFragment) throws CoreException {
@@ -180,9 +174,9 @@ public class PluginStructureCreator extends StructureCreator {
 
 	private String getCharset(Object input) {
 		String charset = null;
-		if (input instanceof IEncodedStreamContentAccessor) {
+		if (input instanceof IEncodedStreamContentAccessor accessor) {
 			try {
-				charset = ((IEncodedStreamContentAccessor) input).getCharset();
+				charset = accessor.getCharset();
 			} catch (Exception e) {
 				// ignore, will use default
 			}
@@ -233,8 +227,7 @@ public class PluginStructureCreator extends StructureCreator {
 	}
 
 	private void createNode(DocumentRangeNode parent, int type, Object element, PDELabelProvider labelProvider, ResourceManager resources) {
-		if (element instanceof IDocumentElementNode) {
-			IDocumentElementNode node = (IDocumentElementNode) element;
+		if (element instanceof IDocumentElementNode node) {
 			ImageDescriptor imageDescriptor = getImageDescriptor(element);
 			Image image = null;
 			if (imageDescriptor != null) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/PluginStructureCreator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/PluginStructureCreator.java
@@ -153,7 +153,7 @@ public class PluginStructureCreator extends StructureCreator {
 		try {
 			String id = isFragment ? "fragment" : "plugin"; //$NON-NLS-1$ //$NON-NLS-2$
 			ImageDescriptor icon = isFragment ? PDEPluginImages.DESC_FRAGMENT_MF_OBJ : PDEPluginImages.DESC_PLUGIN_MF_OBJ;
-			PluginNode parent = new PluginNode(rootNode, ROOT, id, resources.createImage(icon), document, 0, document.getLength());
+			PluginNode parent = new PluginNode(rootNode, ROOT, id, resources.create(icon), document, 0, document.getLength());
 			createChildren(parent, model, labelProvider, resources);
 		} finally {
 			model.dispose();
@@ -238,7 +238,7 @@ public class PluginStructureCreator extends StructureCreator {
 			ImageDescriptor imageDescriptor = getImageDescriptor(element);
 			Image image = null;
 			if (imageDescriptor != null) {
-				image = resources.createImage(imageDescriptor);
+				image = resources.create(imageDescriptor);
 			}
 			new PluginNode(parent, type, labelProvider.getText(element), image, parent.getDocument(), node.getOffset(), node.getLength());
 		}

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/ControlSelector.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/ControlSelector.java
@@ -20,15 +20,12 @@ import java.util.function.Consumer;
 import org.eclipse.core.databinding.observable.value.WritableValue;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.databinding.swt.WidgetSideEffects;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.jface.util.Geometry;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.Region;
 import org.eclipse.swt.widgets.Composite;
@@ -47,8 +44,7 @@ public class ControlSelector {
 	private static final int EDGE_SIZE = 4;
 
 	private Shell overlay;
-	private LocalResourceManager resources;
-	private Color selectionRectangleColor;
+	private final Color selectionRectangleColor = new Color(255, 255, 0);
 	private Display display;
 	private WritableValue<@Nullable Control> currentSelection = new WritableValue<>(null, null);
 	private Region region;
@@ -69,8 +65,6 @@ public class ControlSelector {
 		display = Display.getCurrent();
 		overlay = new Shell(SWT.ON_TOP | SWT.NO_TRIM);
 		overlay.addPaintListener(this::paint);
-		resources = new LocalResourceManager(JFaceResources.getResources(), overlay);
-		selectionRectangleColor = resources.createColor(new RGB(255, 255, 0));
 		display.addFilter(SWT.MouseMove, moveFilter);
 		display.addFilter(SWT.MouseDown, selectFilter);
 		overlay.addDisposeListener(this::disposed);

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
@@ -128,9 +128,7 @@ public class LayoutSpyDialog {
 		{
 			overlay.addPaintListener(this::paintOverlay);
 			region = new Region();
-			overlay.addDisposeListener((DisposeEvent) -> {
-				region.dispose();
-			});
+			overlay.addDisposeListener(e -> region.dispose());
 			overlay.setRegion(region);
 		}
 
@@ -211,7 +209,7 @@ public class LayoutSpyDialog {
 		overlayEnabled = WidgetProperties.buttonSelection().observe(showOverlayButton);
 		childList.setContentProvider(new ObservableListContentProvider<>());
 		childList.setLabelProvider(new LayoutSpyLabelProvider());
-		listContents = new ComputedList<Control>() {
+		listContents = new ComputedList<>() {
 			@Override
 			protected List<Control> calculate() {
 				Composite control = parentControl.getValue();

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
@@ -50,7 +50,6 @@ import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.Region;
 import org.eclipse.swt.layout.FormData;
@@ -76,9 +75,6 @@ import org.osgi.framework.FrameworkUtil;
  */
 public class LayoutSpyDialog {
 	private static final int EDGE_SIZE = 4;
-	private static final RGB SELECTED_PARENT_OVERLAY_COLOR = new RGB(255, 0, 0);
-	private static final RGB SELECTED_CHILD_OVERLAY_COLOR = new RGB(255, 255, 0);
-
 	/**
 	 * Value used to indicate an unknown hint value
 	 */
@@ -98,8 +94,8 @@ public class LayoutSpyDialog {
 	private WritableValue<Boolean> controlSelectorOpen = new WritableValue<>(Boolean.FALSE, null);
 	private ComputedList<Control> listContents;
 	private IViewerObservableValue<@Nullable Control> selectedChild;
-	private Color parentRectangleColor;
-	private Color childRectangleColor;
+	private final Color parentRectangleColor = new Color(255, 0, 0);
+	private final Color childRectangleColor = new Color(255, 255, 0);
 	private ResourceManager resources;
 	private Region region;
 	private ISWTObservableValue<Boolean> overlayEnabled;
@@ -142,14 +138,12 @@ public class LayoutSpyDialog {
 		shell.setText(Messages.LayoutSpyDialog_shell_text);
 
 		resources = new LocalResourceManager(JFaceResources.getResources(), shell);
-		parentRectangleColor = resources.createColor(SELECTED_PARENT_OVERLAY_COLOR);
-		childRectangleColor = resources.createColor(SELECTED_CHILD_OVERLAY_COLOR);
 		Bundle bundle = FrameworkUtil.getBundle(LayoutSpyDialog.class);
 		final URL fullPathString = FileLocator.find(bundle, IPath.fromOSString("icons/up_nav.png"), null);
 
 		ImageDescriptor imageDesc = ImageDescriptor.createFromURL(fullPathString);
 
-		upImage = resources.createImage(imageDesc);
+		upImage = resources.create(imageDesc);
 
 		Composite infoRegion = new Composite(shell, SWT.NONE);
 		{


### PR DESCRIPTION
Replace `ResourceManager` methods deprecated since https://github.com/eclipse-platform/eclipse.platform.ui/pull/838.

Create Colors directly, because SWT Color instances don't need to be disposed.
