### PR TITLE
Remove 'Eclipse-LazyStart' headers in favor of 'Bundle-ActivationPolicy'

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.ui/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,6 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools.ui; singleton:=true
 Bundle-Version: 1.3.100.qualifier
 Bundle-Localization: plugin
-Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -38,7 +38,5 @@ Import-Package: com.ibm.icu.util,
  org.objectweb.asm.signature;version="[9.4.0,10.0.0)",
  org.objectweb.asm.tree;version="[9.4.0,10.0.0)"
 Bundle-Activator: org.eclipse.pde.api.tools.internal.provisional.ApiPlugin
-Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.pde.api.tools

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -112,7 +112,6 @@ Require-Bundle:
  org.eclipse.equinox.p2.touchpoint.eclipse;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.0.0,2.0.0)"
-Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.pde.core

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Generic Target Platform Editor
 Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension.tests
 Bundle-Version: 1.2.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.jdt.ui;bundle-version="[3.3.0,4.0.0)";resolution:=optional,
  org.eclipse.pde.ui;bundle-version="[3.3.0,4.0.0)";resolution:=optional,
  org.eclipse.help;bundle-version="[3.3.0,4.0.0)";resolution:=optional
-Eclipse-LazyStart: true
 Export-Package: org.eclipse.pde.internal.runtime;x-internal:=true,
  org.eclipse.pde.internal.runtime.registry;x-internal:=true,
  org.eclipse.pde.internal.runtime.registry.model;x-internal:=true,

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -49,8 +49,8 @@ Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  org.eclipse.pde.internal.build,
  org.junit.jupiter.api.function;version="5.8.1",
  org.osgi.service.event;version="[1.3.0,2.0.0)"
-Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.pde.ui.tests
+Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.pde.ui.tests.util

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -120,7 +120,6 @@ Require-Bundle:
  org.eclipse.equinox.security;bundle-version="[1.2.200,2.0.0)",
  biz.aQute.bndlib;bundle-version="6.3.1",
  org.eclipse.ui.navigator
-Eclipse-LazyStart: true
 Import-Package: org.eclipse.jdt.debug.ui.console,
  org.eclipse.ui.internal.genericeditor,
  org.osgi.service.event;version="[1.4,2.0.0)"


### PR DESCRIPTION
Replace the use of the legacy and Eclipse-specific MANIFEST.MF header 'Eclipse-LazyStart: true' by the OSGi standard compliant header 'Bundle-ActivationPolicy: lazy' (which is already used in most cases.

@tjwatson do you know any reason to keep the old 'Eclipse-LazyStart: true' header?