### PR TITLE
fix file Utils regression #661

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ProductGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ProductGenerator.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
@@ -187,8 +188,8 @@ public class ProductGenerator extends AbstractScriptGenerator {
 		generateP2InfCUs(buffer, startIndex, cus, launchers);
 
 		try {
-			File p2Inf = new File(root, "p2.inf"); //$NON-NLS-1$
-			Files.writeString(p2Inf.toPath(), buffer.toString());
+			Files.createDirectories(Path.of(root));
+			Files.writeString(Path.of(root, "p2.inf"), buffer.toString()); //$NON-NLS-1$
 		} catch (IOException e) {
 			return false;
 		}

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/Utils.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/Utils.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -476,7 +477,7 @@ public final class Utils implements IPDEBuildConstants, IBuildPropertiesConstant
 					}
 					String fileToCopy = toDir + '/' + file.getName();
 					try {
-						Files.copy(file.toPath(), Path.of(fileToCopy));
+						Files.copy(file.toPath(), Path.of(fileToCopy), StandardCopyOption.REPLACE_EXISTING);
 						copiedFiles.add(file.getName());
 					} catch (IOException e) {
 						String message = NLS.bind(Messages.exception_writingFile, fileToCopy);


### PR DESCRIPTION
fixes regressions from a2612ef2a43488c4c71632c56a240b8f022f1c09 
for example:

"FileAlreadyExistsException: license.html" in
org.eclipse.pde.build.internal.tests.p2.PublishingTests.testBug266488()

"p2.inf doesn't exist" in
org.eclipse.pde.build.internal.tests.p2.PublishingTests.testBug271373()