### PR TITLE
Compute junit5 runtime Plug-ins dynamically in RequiredPlugins-Container and reference junit and hamcrest only via Import-Package

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.pde.api.tools.tests
 Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
- org.junit,
  org.eclipse.pde.api.tools;bundle-version="1.0.600",
  org.eclipse.jdt.launching;bundle-version="[3.6.100,4.0.0)",
  org.eclipse.debug.core,
@@ -33,15 +32,19 @@ Export-Package: org.eclipse.pde.api.tools.anttasks.tests,
  org.eclipse.pde.api.tools.builder.tests.tags,
  org.eclipse.pde.api.tools.builder.tests.usage,
  org.eclipse.pde.api.tools.comparator.tests,
- org.eclipse.pde.api.tools.model.tests;uses:="junit.framework,org.eclipse.pde.api.tools.model.component",
+ org.eclipse.pde.api.tools.model.tests,
  org.eclipse.pde.api.tools.problems.tests,
  org.eclipse.pde.api.tools.reference.tests,
  org.eclipse.pde.api.tools.search.tests,
  org.eclipse.pde.api.tools.tests,
  org.eclipse.pde.api.tools.tests.util,
- org.eclipse.pde.api.tools.util.tests;uses:="junit.framework"
+ org.eclipse.pde.api.tools.util.tests
 Bundle-Activator: org.eclipse.pde.api.tools.tests.ApiTestsPlugin
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
-Import-Package: org.eclipse.equinox.frameworkadmin
+Import-Package: junit.framework,
+ org.eclipse.equinox.frameworkadmin,
+ org.junit,
+ org.junit.runner,
+ org.junit.runners
 Automatic-Module-Name: org.eclipse.pde.api.tools.tests

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/UtilTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/UtilTests.java
@@ -25,8 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -458,8 +457,7 @@ public class UtilTests {
 				return false;
 			}
 		}
-		List<IApiComponent> allComponents = new ArrayList<>();
-		String[] componentNames = new String[] {
+		IApiComponent[] components = Stream.of( //
 				"org.eclipse.swt", //$NON-NLS-1$
 				"org.eclipse.equinox.simpleconfigurator.manipulator", //$NON-NLS-1$
 				"org.eclipse.team.ui", //$NON-NLS-1$
@@ -503,7 +501,6 @@ public class UtilTests {
 				"org.eclipse.jdt", //$NON-NLS-1$
 				"org.eclipse.osgi.util", //$NON-NLS-1$
 				"org.sat4j.pb", //$NON-NLS-1$
-				"org.hamcrest.core", //$NON-NLS-1$
 				"org.eclipse.jdt.junit4.runtime", //$NON-NLS-1$
 				"org.eclipse.equinox.p2.artifact.repository", //$NON-NLS-1$
 				"org.eclipse.core.databinding.property", //$NON-NLS-1$
@@ -644,13 +641,8 @@ public class UtilTests {
 				"org.eclipse.equinox.app", //$NON-NLS-1$
 				"org.eclipse.ui.net", //$NON-NLS-1$
 				"org.eclipse.equinox.p2.publisher", //$NON-NLS-1$
-				"org.eclipse.ecf.provider.filetransfer.httpclient", //$NON-NLS-1$
-		};
-		for (String componentName : componentNames) {
-			allComponents.add(new LocalApiComponent(componentName));
-		}
-		IApiComponent[] components = new IApiComponent[allComponents.size()];
-		allComponents.toArray(components);
+				"org.eclipse.ecf.provider.filetransfer.httpclient" //$NON-NLS-1$
+		).map(LocalApiComponent::new).toArray(IApiComponent[]::new);
 		FilteredElements excludedElements = new FilteredElements();
 		try {
 			Util.collectRegexIds(line, excludedElements, components, false);

--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Export-Package: org.eclipse.pde.build.internal.tests;x-internal:=true,
  org.eclipse.pde.build.internal.tests.p2;x-internal:=true,
  org.eclipse.pde.build.tests
 Require-Bundle: org.eclipse.core.runtime,
- org.junit,
  org.eclipse.pde.build,
  org.eclipse.ant.core,
  org.apache.ant,
@@ -29,7 +28,10 @@ Import-Package: org.eclipse.equinox.frameworkadmin;version="2.0.0",
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.metadata;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.simpleconfigurator.manipulator;version="2.0.0"
+ org.eclipse.equinox.simpleconfigurator.manipulator;version="2.0.0",
+ org.junit,
+ org.junit.runner,
+ org.junit.runners
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.pde.build.tests

--- a/ds/org.eclipse.pde.ds.annotations.tests/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.annotations.tests/META-INF/MANIFEST.MF
@@ -10,11 +10,13 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.pde.ds.annotations;bundle-version="[1.1.0,1.4.0)",
  org.eclipse.pde.ds.core;bundle-version="[1.1.0,2.0.0)",
  org.eclipse.pde.ui;bundle-version="[3.9.0,4.0.0)",
- org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.core.resources;bundle-version="[3.11.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)"
 Export-Package: org.eclipse.pde.ds.internal.annotations.tests;x-internal:=true
+Import-Package: org.junit,
+ org.junit.runner,
+ org.junit.runners
 Eclipse-BundleShape: dir
 Bundle-ClassPath: tests.jar
 Automatic-Module-Name: org.eclipse.pde.ds.annotations.tests

--- a/ds/org.eclipse.pde.ds.tests/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.pde.ds.tests
 Bundle-Version: 1.3.100.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ds.tests.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.junit;bundle-version="3.8.2",
  org.eclipse.pde.core;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.pde.ds.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.3.0,4.0.0)"
@@ -14,5 +13,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.pde.internal.ds.tests;x-internal:=true
+Import-Package: org.junit,
+ org.junit.runner,
+ org.junit.runners
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.pde.ds.tests

--- a/ua/org.eclipse.pde.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.pde.ua.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 1.3.100.qualifier
 Bundle-ClassPath: tests.jar
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.pde.ua.core;bundle-version="[1.0.0,2.0.0)",
- org.junit;bundle-version="3.8.2",
  org.eclipse.text;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.pde.ui;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.5.0,4.0.0)",
@@ -27,3 +26,6 @@ Export-Package: org.eclipse.pde.internal.ua.tests;x-internal:="true",
 Bundle-Localization: plugin
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.pde.ua.tests
+Import-Package: org.junit,
+ org.junit.runner,
+ org.junit.runners

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension.tests
 Bundle-Version: 1.2.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="3.12.0",
  org.eclipse.jface.text;bundle-version="3.13.0",
  org.eclipse.ui;bundle-version="3.109.100",
@@ -16,3 +15,6 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.equinox.p2.metadata,
  org.eclipse.core.filebuffers
 Automatic-Module-Name: org.eclipse.pde.genericeditor.extension.tests
+Import-Package: org.junit,
+ org.junit.runner,
+ org.junit.runners

--- a/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
-Require-Bundle: org.junit,
- org.eclipse.core.runtime;bundle-version="3.29.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.pde.launching;bundle-version="3.7.700",
  org.eclipse.core.resources;bundle-version="3.13.500",
  org.eclipse.pde.ui;bundle-version="3.11.100",
@@ -18,4 +17,7 @@ Require-Bundle: org.junit,
  org.eclipse.debug.ui;bundle-version="3.14.200",
  org.eclipse.ui;bundle-version="3.114.0",
  org.eclipse.pde.ui.tests;bundle-version="3.11.500"
-Import-Package: org.assertj.core.api;version="3.14.0"
+Import-Package: org.assertj.core.api;version="3.14.0",
+ org.junit,
+ org.junit.runner,
+ org.junit.runners

--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-ClassPath: tests.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.pde.ui;bundle-version="3.10.0",
  org.eclipse.pde.ui.templates;bundle-version="3.6.0",
- org.junit;bundle-version="4.13.0",
  org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.core.resources;bundle-version="3.12.0",
  org.eclipse.ui.ide;bundle-version="3.13.0",
@@ -17,3 +16,7 @@ Require-Bundle: org.eclipse.pde.ui;bundle-version="3.10.0",
  org.eclipse.pde.ui.tests
 Automatic-Module-Name: org.eclipse.pde.ui.templates.tests
 Eclipse-BundleShape: dir
+Import-Package: org.hamcrest,
+ org.junit,
+ org.junit.runner,
+ org.junit.runners

--- a/ui/org.eclipse.pde.ui.tests.smartimport/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests.smartimport/META-INF/MANIFEST.MF
@@ -18,10 +18,13 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.reddeer.workbench;bundle-version="[3.0.0,5.0.0)",
  org.eclipse.reddeer.workbench.core;bundle-version="[3.0.0,5.0.0)",
  org.eclipse.swt,
- org.junit,
  org.eclipse.jdt.ui,
  org.eclipse.pde.ui
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.pde.ui.tests.smartimport
+Import-Package: org.hamcrest,
+ org.junit,
+ org.junit.runner,
+ org.junit.runners

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-Version: 3.12.200.qualifier
 Bundle-ClassPath: tests.jar
 Bundle-Activator: org.eclipse.pde.ui.tests.PDETestsPlugin
 Bundle-Vendor: Eclipse.org
-Require-Bundle: org.junit,
- org.eclipse.pde.ui,
+Require-Bundle: org.eclipse.pde.ui,
  org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
@@ -47,7 +46,13 @@ Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  org.assertj.core.api;version="3.14.0",
  org.assertj.core.presentation;version="3.21.0",
  org.eclipse.pde.internal.build,
+ org.hamcrest,
+ org.junit,
  org.junit.jupiter.api.function;version="5.8.1",
+ org.junit.rules,
+ org.junit.runner,
+ org.junit.runners,
+ org.junit.runners.model,
  org.osgi.service.event;version="[1.3.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/performance/parts/TargetPlatformPerfTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/performance/parts/TargetPlatformPerfTest.java
@@ -50,6 +50,7 @@ import org.eclipse.pde.ui.tests.util.TargetPlatformUtil;
 import org.eclipse.pde.ui.tests.util.TestBundleCreator;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
+import org.junit.Assert;
 import org.osgi.framework.Version;
 
 /**
@@ -117,7 +118,7 @@ public class TargetPlatformPerfTest extends PerformanceTestCase {
 		// Create a workspace model
 		IWorkspace ws = ResourcesPlugin.getWorkspace();
 		IProject proj = ws.getRoot().getProject(SEARCH_TEST_WORKSPACE_NAME);
-		assertFalse("Project should not exist", proj.exists());
+		Assert.assertFalse("Project should not exist", proj.exists());
 		IBundleProjectDescription description = service.getDescription(proj);
 		description.setSymbolicName(SEARCH_TEST_WORKSPACE_NAME);
 		description.setBundleVersion(new Version("1.1.1"));
@@ -203,19 +204,19 @@ public class TargetPlatformPerfTest extends PerformanceTestCase {
 	private void executeSearchTest() {
 		IPluginModelBase[] models;
 		models = PluginRegistry.getAllModels();
-		assertEquals(SEARCH_TEST_EXTERNAL_COUNT + 1, models.length);
+		Assert.assertEquals(SEARCH_TEST_EXTERNAL_COUNT + 1, models.length);
 		models = PluginRegistry.getWorkspaceModels();
-		assertEquals(1, models.length);
+		Assert.assertEquals(1, models.length);
 		models = PluginRegistry.getExternalModels();
-		assertEquals(SEARCH_TEST_EXTERNAL_COUNT, models.length);
+		Assert.assertEquals(SEARCH_TEST_EXTERNAL_COUNT, models.length);
 
 		IPluginModelBase model;
 		IWorkspace ws = ResourcesPlugin.getWorkspace();
 		model = PluginRegistry.findModel(SEARCH_TEST_WORKSPACE_NAME);
-		assertNotNull(model);
+		Assert.assertNotNull(model);
 		IProject project = ws.getRoot().getProject(SEARCH_TEST_WORKSPACE_NAME);
 		model = PluginRegistry.findModel(project);
-		assertNotNull(model);
+		Assert.assertNotNull(model);
 
 		model = PluginRegistry.findModel(SEARCH_TEST_EXTERNAL_NAME);
 		openRequiredBundles(model, new HashSet<>());
@@ -230,7 +231,7 @@ public class TargetPlatformPerfTest extends PerformanceTestCase {
 	 * @param allBundleNames set of symbolic names that have been looked up to prevent stack overflows
 	 */
 	private void openRequiredBundles(IPluginModelBase model, Set<String> allBundleNames) {
-		assertNotNull(model);
+		Assert.assertNotNull(model);
 		BundleSpecification[] required = model.getBundleDescription().getRequiredBundles();
 		for (BundleSpecification element : required) {
 			if (!allBundleNames.contains(element.getName())) {


### PR DESCRIPTION
This PR does two things, mainly with the goal to not require a specific hamcrest bundle name:

1. Compute junit5 runtime Plug-ins dynamically in RequiredPlugins-Container
And add support for old junit bundle names from Orbit.
2. Reference junit and hamcrest only via Import-Package
This requires to import the hamcrest packages, if they are used and those test-plugins don't rely on the re-export of hamcrest by org.junit anymore.

Additionally only use junit-4 assertion methods and replace use of junit-3 assertions.
And remove unnecessary hard-coded references to the hamcrest bundle name.

@merks what do you think?