### PR TITLE
Display correct plugin selection count under only-show-selected option

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
@@ -512,6 +512,16 @@ public abstract class AbstractPluginBlock {
 			Object element = event.getElement();
 			if (element instanceof IPluginModelBase) {
 				handleCheckStateChanged(event);
+			} else if (element instanceof NamedElement namedElement) {
+				TreeItem item = (TreeItem) fPluginTreeViewer.testFindItem(namedElement);
+				if (item != null) {
+					if (item.getText().equals("Workspace")) { //$NON-NLS-1$
+						fNumWorkspaceChecked = event.getChecked() ? getWorkspaceModels().length : 0;
+					} else {
+						fNumExternalChecked = event.getChecked() ? getExternalModels().length : 0;
+					}
+					updateCounter();
+				}
 			} else {
 				countSelectedModels();
 			}


### PR DESCRIPTION
While configuring launch/debug, the number of plugins selected (under plug-ins tab) is not updated when
 i) only show selected option is on,
ii) top level checkbox is used instead of individual checkboxes for plugins.

This PR identifies the check state of the top level controls and makes sure the 
plugin count is computed / reset appropriately.

Fixes: [668](https://github.com/eclipse-pde/eclipse.pde/issues/668)