### PR TITLE
Enhance computation of system-package provided by a ExecutionEnvironment

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -290,14 +290,9 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 	 */
 	@SuppressWarnings("deprecation")
 	private void initialize(Properties profile, ExecutionEnvironmentDescription description) throws CoreException {
-		String value = profile.getProperty(Constants.FRAMEWORK_SYSTEMPACKAGES);
-		if (value == null) {
-			// In Java-10 and beyond, we query system-packages list from the JRE
-			String environmentId = description.getProperty(ExecutionEnvironmentDescription.CLASS_LIB_LEVEL);
-			IExecutionEnvironmentsManager manager = JavaRuntime.getExecutionEnvironmentsManager();
-			IExecutionEnvironment environment = manager.getEnvironment(environmentId);
-			value = TargetPlatformHelper.querySystemPackages(environment);
-		}
+		String environmentId = description.getProperty(ExecutionEnvironmentDescription.CLASS_LIB_LEVEL);
+		IExecutionEnvironment ee = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(environmentId);
+		String value = TargetPlatformHelper.getSystemPackages(ee, profile);
 		String[] systemPackages = null;
 		if (value != null) {
 			systemPackages = value.split(","); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -53,6 +53,8 @@ Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  org.junit.runner,
  org.junit.runners,
  org.junit.runners.model,
+ org.mockito,
+ org.mockito.stubbing,
  org.osgi.service.event;version="[1.3.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExecutionEnvironmentTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExecutionEnvironmentTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -324,7 +324,7 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 	@Test
 	public void testDynamicSystemPackages() throws Exception {
 		IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-11");
-		String systemPackages = TargetPlatformHelper.querySystemPackages(env);
+		String systemPackages = TargetPlatformHelper.getSystemPackages(env, null);
 		assertThat(systemPackages).isNotNull();
 		assertThat(systemPackages.split(",")).contains("java.lang", "javax.sql", "org.w3c.dom.css");
 	}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/TargetEnvironmentTestCase.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/TargetEnvironmentTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2006, 2018 IBM Corporation and others.
+ *  Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -14,21 +14,67 @@
 package org.eclipse.pde.ui.tests.target;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
+import org.eclipse.pde.ui.tests.runtime.TestUtils;
+import org.eclipse.pde.ui.tests.util.ProjectUtils;
+import org.eclipse.pde.ui.tests.util.TargetPlatformUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.osgi.framework.Constants;
 
 public class TargetEnvironmentTestCase {
+
+	private static final String JAVA_SE_1_7 = "JavaSE-1.7";
+
+	@ClassRule
+	public static final TestRule RESTORE_TARGET_DEFINITION = TargetPlatformUtil.RESTORE_CURRENT_TARGET_DEFINITION_AFTER;
+	@ClassRule
+	public static final TestRule CLEAR_WORKSPACE = ProjectUtils.DELETE_ALL_WORKSPACE_PROJECTS_BEFORE_AND_AFTER;
+
+	@BeforeClass
+	public static void setupTargetPlatform() throws Exception {
+		TargetPlatformUtil.setRunningPlatformAsTarget();
+	}
+
+	private IExecutionEnvironment eeJava_1_7;
+	private IVMInstall eeJava_1_7DefaultVM;
+
+	@Before
+	public void saveJava1_7EEDefault() {
+		eeJava_1_7 = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(JAVA_SE_1_7);
+		eeJava_1_7DefaultVM = eeJava_1_7.getDefaultVM();
+	}
+
+	@After
+	public void restoreJava1_7EEDefault() {
+		eeJava_1_7.setDefaultVM(eeJava_1_7DefaultVM);
+	}
+
 	@Test
 	public void testOS() {
 		assertEquals(Platform.getOS(), TargetPlatform.getOS());
@@ -82,13 +128,12 @@ public class TargetEnvironmentTestCase {
 	@Test
 	public void testResolveOptional() {
 		Dictionary<String, String> dictionary = TargetPlatformHelper.getTargetEnvironment();
-		assertTrue("true".equals(dictionary.get("osgi.resolveOptional")));
+		assertEquals("true", dictionary.get("osgi.resolveOptional"));
 	}
 
 	/**
 	 * Tests that the OSGi state for the PDE models has the correct properties set, based on known execution environments
 	 */
-	@SuppressWarnings("deprecation")
 	@Test
 	public void testStateEEProperties() {
 		Dictionary<?, ?>[] platformProps = TargetPlatformHelper.getState().getPlatformProperties();
@@ -100,35 +145,75 @@ public class TargetEnvironmentTestCase {
 				Properties profileProps = environment.getProfileProperties();
 				if (profileProps != null) {
 					// If we have profile properties for an execution environment, ensure that they were added to the state
-					String systemPackages = profileProps.getProperty(Constants.FRAMEWORK_SYSTEMPACKAGES);
-					if (systemPackages != null){
-						boolean foundSystemPackage = false;
-						for (Dictionary<?, ?> platformProp : platformProps) {
-							if (systemPackages.equals(platformProp.get(Constants.FRAMEWORK_SYSTEMPACKAGES))){
-								foundSystemPackage = true;
-								break;
-							}
-						}
-						if (!foundSystemPackage){
+					Set<String> profileSystemPackages = getSystemPackages(profileProps)
+							.filter(p -> p.startsWith("java.")).collect(Collectors.toSet());
+					if (!profileSystemPackages.isEmpty()) {
+						String profileEE = getExecutionenvironment(profileProps);
+						boolean foundSystemPackage = Arrays.stream(platformProps)
+								.filter(pp -> profileEE.equals(getExecutionenvironment(pp))).anyMatch(pp -> {
+									Set<String> packages = getSystemPackages(pp).collect(Collectors.toSet());
+									return packages.containsAll(profileSystemPackages);
+								});
+						if (!foundSystemPackage) {
 							fail("The system packages property for EE " + profile + " was not found in the state's propeties");
 						}
 					}
-					String ee = profileProps.getProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT);
-					if (ee != null){
-						boolean foundEE = false;
-						for (Dictionary<?, ?> platformProp : platformProps) {
-							if (ee.equals(platformProp.get(Constants.FRAMEWORK_EXECUTIONENVIRONMENT))){
-								foundEE = true;
-								break;
-							}
-						}
-						if (!foundEE){
+					String ee = getExecutionenvironment(profileProps);
+					if (ee != null) {
+						if (Stream.of(platformProps).map(pp -> getExecutionenvironment(pp)).noneMatch(ee::equals)) {
 							fail("The framework EE property for EE " + profile + " was not found in the state's propeties");
 						}
 					}
 				}
 			}
 		}
+	}
+
+	@SuppressWarnings("deprecation")
+	private String getExecutionenvironment(Object profile) {
+		return (String) ((Map<?, ?>) profile).get(Constants.FRAMEWORK_EXECUTIONENVIRONMENT);
+	}
+
+	private static Stream<String> getSystemPackages(Object profile) {
+		String platformPackages = (String) ((Map<?, ?>) profile).get(Constants.FRAMEWORK_SYSTEMPACKAGES);
+		if (platformPackages == null) {
+			return Stream.empty();
+		}
+		return Arrays.stream(platformPackages.split(","));
+	}
+
+	@Test
+	public void testProjectWithJVMImports() throws CoreException {
+		// A Java-1.7 VM does not provide the java.util.function package
+		// introduced in 1.8. But if we say that a Java 1.8+ VM the default
+		// (which the one running this test and thus the workspaces default-VM
+		// should be), well then the system-packages of that Java 1.8+ VM should
+		// be used in the PDEState and thus there should not be errors. This
+		// might not be a good idea in production, but is a good test-case.
+		IProject project = ProjectUtils.createPluginProject("foo.bar", "foo.bar", "1.0.0.qualifier", (d, s) -> {
+			d.setExecutionEnvironments(new String[] { JAVA_SE_1_7 });
+			d.setHeader(Constants.IMPORT_PACKAGE, "java.util.function");
+			d.setHeader("Automatic-Module-Name", "foo.bar");
+		});
+		project.build(IncrementalProjectBuilder.FULL_BUILD, null);
+		List<IMarker> errorsWithoutEEDefault = findErrorMarkers(project);
+		assertEquals(errorsWithoutEEDefault.toString(), 1, errorsWithoutEEDefault.size());
+
+		eeJava_1_7.setDefaultVM(JavaRuntime.getDefaultVMInstall());
+
+		// await at least VMInstall/EE change delay in
+		// MinimalState.rereadSystemPackagesAndReloadTP()
+		TestUtils.waitForJobs("testProjectWithEEImports", 300, 10_000);
+
+		List<IMarker> errorsWithEEDefault = findErrorMarkers(project);
+		assertEquals(List.of(), errorsWithEEDefault);
+	}
+
+	private List<IMarker> findErrorMarkers(IProject project) throws CoreException {
+		IMarker[] markers = project.findMarkers(null, true, IResource.DEPTH_INFINITE);
+		List<IMarker> errorsWithoutEEDefault = Arrays.stream(markers)
+				.filter(m -> m.getAttribute(IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR).toList();
+		return errorsWithoutEEDefault;
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/429
- Only consider EE of running VM in launch validation to match the behavior later at runtime
- For the PDEState the EE's system-package is computed with the following distinction:
  - for a EE that corresponds to a Java-9 or higher release, get the 'best matching' VMInstall and query the system-packages for the EE's   java release version (which is possible for modular JVMs)
  - for a Java-8 or lower release check if there is a VMInstall selected/strictly compatible to that version and query the system-packages from that VM (i.e. its rt.jar and other libraries)
  - if there is no VMInstall for a for a Java-8 or lower release, combine the hard-coded list of 'java.*' packages with the set of
  non-java packages provided by the default VMInstall of the workspace. The default VMInstall of the WS is at the same time the JVM selected in the active target definition (which sets its selection as WS default upon loading).
  - In general the available system-packages are only really known at runtime. Therefore at any other time, e.g. in the workspace one can only guess/assume what packages are available and the implemented algorithm seems to be the best trade-off between probable accuracy, convenience and the possibility to let the user control the result.

- Listen to changes of available VMInstalls and ExecutionEnvironment defaults. Re-read them on changes and re-resolve the PDE-State again with a subsequent re-validation of all Plugin projects.

@laeubi in case one only has one JRE in the WS respectively none set as default of a EE, this is equivalent to your suggestion to just use the TP's JRE. This is convenient, but at the same time allows to be more specific if desired by providing/setting a JRE for an EE.

In my local testing that replicated the guice case, this worked well.

This is currently a draft since the list of java-packages still has to be completed. I'm on vacation for a week now, but will complete this once I'm back.