### PR TITLE
Code Cleanup: Java 16 instanceof pattern matching

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotations.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotations.java
@@ -57,8 +57,7 @@ public class ApiAnnotations implements IApiAnnotations {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ApiAnnotations) {
-			ApiAnnotations desc = (ApiAnnotations) obj;
+		if (obj instanceof ApiAnnotations desc) {
 			return this.bits == desc.bits;
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescriptionManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescriptionManager.java
@@ -356,8 +356,7 @@ public final class ApiDescriptionManager implements ISaveParticipant {
 			break;
 		}
 		case IApiXmlConstants.ELEMENT_FIELD:
-			if (parentNode.element instanceof IReferenceTypeDescriptor) {
-				IReferenceTypeDescriptor type = (IReferenceTypeDescriptor) parentNode.element;
+			if (parentNode.element instanceof IReferenceTypeDescriptor type) {
 				int vis = getInt(element, IApiXmlConstants.ATTR_VISIBILITY);
 				int res = getInt(element, IApiXmlConstants.ATTR_RESTRICTIONS);
 				String name = element.getAttribute(IApiXmlConstants.ATTR_NAME);
@@ -366,8 +365,7 @@ public final class ApiDescriptionManager implements ISaveParticipant {
 			}
 			break;
 		case IApiXmlConstants.ELEMENT_METHOD:
-			if (parentNode.element instanceof IReferenceTypeDescriptor) {
-				IReferenceTypeDescriptor type = (IReferenceTypeDescriptor) parentNode.element;
+			if (parentNode.element instanceof IReferenceTypeDescriptor type) {
 				int vis = getInt(element, IApiXmlConstants.ATTR_VISIBILITY);
 				int res = getInt(element, IApiXmlConstants.ATTR_RESTRICTIONS);
 				String name = element.getAttribute(IApiXmlConstants.ATTR_NAME);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/BundleVersionRange.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/BundleVersionRange.java
@@ -68,8 +68,7 @@ public class BundleVersionRange implements IVersionRange {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof BundleVersionRange) {
-			BundleVersionRange range = (BundleVersionRange) obj;
+		if (obj instanceof BundleVersionRange range) {
 			return fRange.equals(range.fRange);
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/JavadocTagManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/JavadocTagManager.java
@@ -50,8 +50,7 @@ public final class JavadocTagManager {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof Key) {
-				Key other = (Key) obj;
+			if (obj instanceof Key other) {
 				return type == other.type && member == other.member;
 			}
 			return super.equals(obj);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/RequiredComponentDescription.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/RequiredComponentDescription.java
@@ -59,8 +59,7 @@ public class RequiredComponentDescription implements IRequiredComponentDescripti
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof RequiredComponentDescription) {
-			RequiredComponentDescription desc = (RequiredComponentDescription) obj;
+		if (obj instanceof RequiredComponentDescription desc) {
 			return fId.equals(desc.fId) && fRange.equals(desc.fRange);
 		}
 		return super.equals(obj);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractIllegalMethodReference.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractIllegalMethodReference.java
@@ -74,8 +74,7 @@ public abstract class AbstractIllegalMethodReference extends AbstractProblemDete
 				} catch (CoreException ce) {
 					// do nothing, skip it
 				}
-				if (member instanceof IApiMethod) {
-					IApiMethod method = (IApiMethod) member;
+				if (member instanceof IApiMethod method) {
 					if (method.isDefaultMethod()) {
 						return considerReference(reference, monitor);
 					}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractProblemDetector.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractProblemDetector.java
@@ -517,8 +517,7 @@ public abstract class AbstractProblemDetector implements IApiProblemDetector {
 					IApiComponent component = reference.getMember().getApiComponent();
 					try {
 						IApiProblem problem = null;
-						if (component instanceof ProjectComponent) {
-							ProjectComponent ppac = (ProjectComponent) component;
+						if (component instanceof ProjectComponent ppac) {
 							IJavaProject project = ppac.getJavaProject();
 							problem = createProblem(reference, project);
 						} else {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ApiAnalysisBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ApiAnalysisBuilder.java
@@ -629,10 +629,9 @@ public class ApiAnalysisBuilder extends IncrementalProjectBuilder {
 
 		@Override
 		public boolean isConflicting(ISchedulingRule rule) {
-			if (!(rule instanceof ApiAnalysisJobRule)) {
+			if (!(rule instanceof ApiAnalysisJobRule other)) {
 				return false;
 			}
-			ApiAnalysisJobRule other = (ApiAnalysisJobRule) rule;
 			return project.equals(other.project);
 		}
 

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
@@ -2666,8 +2666,7 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 	 * @return Java project or <code>null</code>
 	 */
 	private IJavaProject getJavaProject(IApiComponent component) {
-		if (component instanceof ProjectComponent) {
-			ProjectComponent pp = (ProjectComponent) component;
+		if (component instanceof ProjectComponent pp) {
 			return pp.getJavaProject();
 		}
 		return null;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/IncrementalApiBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/IncrementalApiBuilder.java
@@ -166,8 +166,7 @@ public class IncrementalApiBuilder {
 							if (component != null) {
 								try {
 									IApiAnnotations annotations = component.getApiDescription().resolveAnnotations(Factory.typeDescriptor(type.replace('/', '.')));
-									if (annotations instanceof TypeAnnotations) {
-										TypeAnnotations ta = (TypeAnnotations) annotations;
+									if (annotations instanceof TypeAnnotations ta) {
 										if (ta.getBuildStamp() == BuildStamps.getBuildStamp(resource.getProject())) {
 											// note description change in
 											// addition to structure

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ProblemDetectorBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ProblemDetectorBuilder.java
@@ -197,8 +197,7 @@ public class ProblemDetectorBuilder extends ApiDescriptionVisitor {
 	 *         not a {@link PluginProjectApiComponent}
 	 */
 	private IProject getProject(IApiComponent component) {
-		if (component instanceof ProjectComponent) {
-			ProjectComponent comp = (ProjectComponent) component;
+		if (component instanceof ProjectComponent comp) {
 			return comp.getJavaProject().getProject();
 		}
 		return null;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ReferenceExtractor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ReferenceExtractor.java
@@ -417,8 +417,7 @@ public class ReferenceExtractor extends ClassVisitor {
 		@Override
 		public void visitInvokeDynamicInsn(String name, String desc, Handle bsm, Object... bsmArgs) {
 			for (Object arg : bsmArgs) {
-				if (arg instanceof Handle) {
-					Handle handle = (Handle) arg;
+				if (arg instanceof Handle handle) {
 					Type declaringType = Type.getObjectType(handle.getOwner());
 					Reference reference = ReferenceExtractor.this.addMethodReference(declaringType, handle.getName(), handle.getDesc(), IReference.REF_VIRTUALMETHOD, 0);
 					if (reference != null) {
@@ -564,14 +563,12 @@ public class ReferenceExtractor extends ClassVisitor {
 
 		@Override
 		public void visitLdcInsn(Object cst) {
-			if (cst instanceof Type) {
-				Type type = (Type) cst;
+			if (cst instanceof Type type) {
 				Reference reference = ReferenceExtractor.this.addTypeReference(type, IReference.REF_CONSTANTPOOL);
 				if (reference != null) {
 					this.linePositionTracker.addLocation(reference);
 				}
-			} else if (cst instanceof String) {
-				String str = (String) cst;
+			} else if (cst instanceof String str) {
 				this.stringLiteral = (Util.EMPTY_STRING.equals(str) ? null : str);
 			}
 		}
@@ -762,15 +759,13 @@ public class ReferenceExtractor extends ClassVisitor {
 							remainingCatchLabelInfos = remaingEntriesTemp;
 						}
 					}
-				} else if (current instanceof Reference) {
-					Reference ref = (Reference) current;
+				} else if (current instanceof Reference ref) {
 					if (ref.getLineNumber() == -1) {
 						ref.setLineNumber(currentLineNumber);
 					} else {
 						currentLineNumber = ref.getLineNumber();
 					}
-				} else if (current instanceof LineInfo) {
-					LineInfo lineInfo = (LineInfo) current;
+				} else if (current instanceof LineInfo lineInfo) {
 					currentLineNumber = lineInfo.line;
 				}
 			}
@@ -810,8 +805,7 @@ public class ReferenceExtractor extends ClassVisitor {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof LineInfo) {
-				LineInfo lineInfo2 = (LineInfo) obj;
+			if (obj instanceof LineInfo lineInfo2) {
 				return this.line == lineInfo2.line && this.label.equals(lineInfo2.label);
 			}
 			return super.equals(obj);
@@ -841,8 +835,7 @@ public class ReferenceExtractor extends ClassVisitor {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof LocalLineNumberMarker) {
-				LocalLineNumberMarker marker = (LocalLineNumberMarker) obj;
+			if (obj instanceof LocalLineNumberMarker marker) {
 				return this.lineNumber == marker.lineNumber && this.varIndex == marker.varIndex;
 			}
 			return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/SystemApiDetector.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/SystemApiDetector.java
@@ -393,8 +393,7 @@ public class SystemApiDetector extends AbstractProblemDetector {
 				try {
 					IApiProblem problem = null;
 					IApiComponent component = reference.getMember().getApiComponent();
-					if (component instanceof ProjectComponent) {
-						ProjectComponent ppac = (ProjectComponent) component;
+					if (component instanceof ProjectComponent ppac) {
 						IJavaProject project = ppac.getJavaProject();
 						problem = createProblem(reference, project);
 					} else {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/Validator.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/Validator.java
@@ -210,8 +210,7 @@ public abstract class Validator extends ASTVisitor {
 		if (node == null) {
 			return 0;
 		}
-		if (node instanceof AbstractTypeDeclaration) {
-			AbstractTypeDeclaration type = (AbstractTypeDeclaration) node;
+		if (node instanceof AbstractTypeDeclaration type) {
 			return type.getModifiers();
 		}
 		return getParentModifiers(node.getParent());

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/Delta.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/Delta.java
@@ -187,10 +187,9 @@ public class Delta implements IDelta {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof Delta)) {
+		if (!(obj instanceof Delta other)) {
 			return false;
 		}
-		Delta other = (Delta) obj;
 		if (this.elementType != other.elementType) {
 			return false;
 		}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/FieldDescriptorImpl.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/FieldDescriptorImpl.java
@@ -46,8 +46,7 @@ public class FieldDescriptorImpl extends MemberDescriptorImpl implements IFieldD
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IFieldDescriptor) {
-			IFieldDescriptor field = (IFieldDescriptor) obj;
+		if (obj instanceof IFieldDescriptor field) {
 			return getName().equals(field.getName()) && getEnclosingType().equals(field.getEnclosingType());
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/MethodDescriptorImpl.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/MethodDescriptorImpl.java
@@ -53,8 +53,7 @@ public class MethodDescriptorImpl extends MemberDescriptorImpl implements IMetho
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IMethodDescriptor) {
-			IMethodDescriptor method = (IMethodDescriptor) obj;
+		if (obj instanceof IMethodDescriptor method) {
 			return getName().equals(method.getName()) && getEnclosingType().equals(method.getEnclosingType()) && getSignature().equals(method.getSignature());
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/PackageDescriptorImpl.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/PackageDescriptorImpl.java
@@ -41,8 +41,7 @@ public class PackageDescriptorImpl extends NamedElementDescriptorImpl implements
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IPackageDescriptor) {
-			IPackageDescriptor pkg = (IPackageDescriptor) obj;
+		if (obj instanceof IPackageDescriptor pkg) {
 			return getName().equals(pkg.getName());
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/ReferenceTypeDescriptorImpl.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/descriptors/ReferenceTypeDescriptorImpl.java
@@ -118,8 +118,7 @@ public class ReferenceTypeDescriptorImpl extends MemberDescriptorImpl implements
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IReferenceTypeDescriptor) {
-			IReferenceTypeDescriptor refType = (IReferenceTypeDescriptor) obj;
+		if (obj instanceof IReferenceTypeDescriptor refType) {
 			return getQualifiedName().equals(refType.getQualifiedName());
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
@@ -396,8 +396,7 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 		}
 
 		fComponentsById.put(component.getSymbolicName(), component);
-		if (component instanceof ProjectComponent) {
-			ProjectComponent projectApiComponent = (ProjectComponent) component;
+		if (component instanceof ProjectComponent projectApiComponent) {
 			if (this.fComponentsByProjectNames == null) {
 				this.fComponentsByProjectNames = new HashMap<>();
 			}
@@ -805,8 +804,7 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IApiBaseline) {
-			IApiBaseline baseline = (IApiBaseline) obj;
+		if (obj instanceof IApiBaseline baseline) {
 			return this.getName().equals(baseline.getName());
 		}
 		return super.equals(obj);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiMember.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiMember.java
@@ -99,8 +99,7 @@ public abstract class ApiMember extends ApiElement implements IApiMember {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IApiElement) {
-			IApiElement element = (IApiElement) obj;
+		if (obj instanceof IApiElement element) {
 			if (element.getType() == this.getType()) {
 				return enclosingTypesEqual(this, element) && getName().equals(element.getName());
 			}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiType.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiType.java
@@ -321,8 +321,7 @@ public class ApiType extends ApiMember implements IApiType {
 		if (javaEE != null) {
 			for (int i = 0; i < components.length; i++) {
 				IApiComponent iComponent = components[i];
-				if (iComponent instanceof SystemLibraryApiComponent) {
-					SystemLibraryApiComponent sysCom = (SystemLibraryApiComponent) iComponent;
+				if (iComponent instanceof SystemLibraryApiComponent sysCom) {
 					if (sysCom.getSymbolicName().equals(javaEE)) {
 						// swap i and 0;
 						IApiComponent temp = components[i];
@@ -495,8 +494,7 @@ public class ApiType extends ApiMember implements IApiType {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IApiType) {
-			IApiType type = (IApiType) obj;
+		if (obj instanceof IApiType type) {
 			if (getApiComponent() == null) {
 				return type.getApiComponent() == null && getName().equals(type.getName());
 			}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ArchiveApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ArchiveApiTypeContainer.java
@@ -81,8 +81,7 @@ public class ArchiveApiTypeContainer extends ApiElement implements IApiTypeConta
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof ArchiveApiTypeRoot) {
-				ArchiveApiTypeRoot classFile = (ArchiveApiTypeRoot) obj;
+			if (obj instanceof ArchiveApiTypeRoot classFile) {
 				return this.getName().equals(classFile.getName());
 			}
 			return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
@@ -260,8 +260,7 @@ public class BundleComponent extends Component {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof BundleComponent) {
-			BundleComponent comp = (BundleComponent) obj;
+		if (obj instanceof BundleComponent comp) {
 			return getName().equals(comp.getName()) && getSymbolicName().equals(comp.getSymbolicName()) && getVersion().equals(comp.getVersion());
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/MethodKey.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/MethodKey.java
@@ -44,8 +44,7 @@ public class MethodKey {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof MethodKey) {
-			MethodKey key = (MethodKey) obj;
+		if (obj instanceof MethodKey key) {
 			return fSelector.equals(key.fSelector) && signaturesEqual(fSig, key.fSig) && (fConsiderTypename ? fTypename.equals(key.fTypename) : true);
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ResourceApiTypeRoot.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ResourceApiTypeRoot.java
@@ -96,8 +96,7 @@ public class ResourceApiTypeRoot extends AbstractApiTypeRoot {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IApiTypeRoot) {
-			IApiTypeRoot file = (IApiTypeRoot) obj;
+		if (obj instanceof IApiTypeRoot file) {
 			return getName().equals(file.getTypeName());
 		}
 		return super.equals(obj);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/StubArchiveApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/StubArchiveApiTypeContainer.java
@@ -79,8 +79,7 @@ public class StubArchiveApiTypeContainer extends ApiElement implements IApiTypeC
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof ArchiveApiTypeRoot) {
-				ArchiveApiTypeRoot classFile = (ArchiveApiTypeRoot) obj;
+			if (obj instanceof ArchiveApiTypeRoot classFile) {
 				return this.getName().equals(classFile.getName());
 			}
 			return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/TypeStructureBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/TypeStructureBuilder.java
@@ -282,8 +282,7 @@ public class TypeStructureBuilder extends ClassVisitor {
 	 */
 	public static void setEnclosingMethod(IApiType enclosingType, ApiType currentAnonymousLocalType) {
 		IApiTypeRoot typeRoot = enclosingType.getTypeRoot();
-		if (typeRoot instanceof AbstractApiTypeRoot) {
-			AbstractApiTypeRoot abstractApiTypeRoot = (AbstractApiTypeRoot) typeRoot;
+		if (typeRoot instanceof AbstractApiTypeRoot abstractApiTypeRoot) {
 			EnclosingMethodSetter visitor = new EnclosingMethodSetter(new ClassNode(), currentAnonymousLocalType.getName());
 			try {
 				ClassReader classReader = new ClassReader(abstractApiTypeRoot.getContents());

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/ApiProblem.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/ApiProblem.java
@@ -209,8 +209,7 @@ public class ApiProblem implements IApiProblem {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IApiProblem) {
-			IApiProblem problem = (IApiProblem) obj;
+		if (obj instanceof IApiProblem problem) {
 			if (problem.getId() == fId && argumentsEqual(problem.getMessageArguments())) {
 				String resourcePath = problem.getResourcePath();
 				if (resourcePath == null) {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/ApiProblemFilter.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/ApiProblemFilter.java
@@ -68,8 +68,7 @@ public class ApiProblemFilter implements IApiProblemFilter, Cloneable {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IApiProblemFilter) {
-			IApiProblemFilter filter = (IApiProblemFilter) obj;
+		if (obj instanceof IApiProblemFilter filter) {
 			return elementsEqual(filter.getComponentId(), fComponentId) && filter.getUnderlyingProblem().equals(fProblem);
 		} else if (obj instanceof IApiProblem) {
 			return fProblem.equals(obj);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/scanner/TagScanner.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/scanner/TagScanner.java
@@ -245,8 +245,7 @@ public class TagScanner {
 				if (JavadocTagManager.ANNOTATION_NOOVERRIDE.equals(name)) {
 					if (!Flags.isFinal(node.getModifiers()) && !Flags.isStatic(node.getModifiers())) {
 						ASTNode parent = node.getParent();
-						if (parent instanceof TypeDeclaration) {
-							TypeDeclaration type = (TypeDeclaration) parent;
+						if (parent instanceof TypeDeclaration type) {
 							if (type.isInterface()) {
 								if (Flags.isDefaultMethod(node.getModifiers())) {
 									restrictions |= RestrictionModifiers.NO_OVERRIDE;
@@ -480,8 +479,7 @@ public class TagScanner {
 		public boolean visit(MethodDeclaration node) {
 			if (isNotVisible(node.getModifiers())) {
 				ASTNode parent = node.getParent();
-				if (parent instanceof TypeDeclaration) {
-					TypeDeclaration type = (TypeDeclaration) parent;
+				if (parent instanceof TypeDeclaration type) {
 					if (!type.isInterface()) {
 						return false;
 					}
@@ -532,8 +530,7 @@ public class TagScanner {
 								continue;
 							}
 							ASTNode parent = node.getParent();
-							if (parent instanceof TypeDeclaration) {
-								TypeDeclaration type = (TypeDeclaration) parent;
+							if (parent instanceof TypeDeclaration type) {
 								if (type.isInterface()) {
 									if (Flags.isDefaultMethod(node.getModifiers())) {
 										restrictions |= RestrictionModifiers.NO_OVERRIDE;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/ConsumerReportConvertor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/ConsumerReportConvertor.java
@@ -512,8 +512,7 @@ public class ConsumerReportConvertor extends UseReportConverter {
 					File refereehtml = null;
 					String link = null;
 					for (Object obj : scanResult) {
-						if (obj instanceof Consumer) {
-							Consumer consumer = (Consumer) obj;
+						if (obj instanceof Consumer consumer) {
 							refereehtml = new File(getReportsRoot(), consumer.name + File.separator + "index.html"); //$NON-NLS-1$
 							link = extractLinkFrom(getReportsRoot(), refereehtml.getAbsolutePath());
 							buffer.append(getReferenceTableEntry(consumer.counts, link, consumer.name, true));

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/MissingRefReportConverter.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/MissingRefReportConverter.java
@@ -374,8 +374,7 @@ public class MissingRefReportConverter extends UseReportConverter {
 				buffer.append(getProblemSummaryTable());
 				if (result.size() > 0) {
 					for (Object obj : result) {
-						if (obj instanceof Report) {
-							Report report = (Report) obj;
+						if (obj instanceof Report report) {
 							File refereehtml = new File(getReportsRoot(), report.name + File.separator + "index.html"); //$NON-NLS-1$
 							String link = extractLinkFrom(getReportsRoot(), refereehtml.getAbsolutePath());
 							buffer.append(getReferenceTableEntry(report, link));

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/ReferenceDescriptor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/ReferenceDescriptor.java
@@ -48,8 +48,7 @@ public class ReferenceDescriptor implements IReferenceDescriptor {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ReferenceDescriptor) {
-			ReferenceDescriptor rd = (ReferenceDescriptor) obj;
+		if (obj instanceof ReferenceDescriptor rd) {
 			return origin.equals(rd.origin) && target.equals(rd.target) && from.equals(rd.from) && to.equals(rd.to) && line == rd.line && kind == rd.kind && visibility == rd.visibility;
 		}
 		return false;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseReportConverter.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseReportConverter.java
@@ -1463,8 +1463,7 @@ public class UseReportConverter extends HTMLConvertor {
 					File refereehtml = null;
 					String link = null;
 					for (Object obj : scanResult) {
-						if (obj instanceof Report) {
-							Report report = (Report) obj;
+						if (obj instanceof Report report) {
 							refereehtml = new File(getReportsRoot(), report.name + File.separator + "index.html"); //$NON-NLS-1$
 							link = extractLinkFrom(getReportsRoot(), refereehtml.getAbsolutePath());
 							buffer.append(getReferenceTableEntry(report.counts, link, report.name, true));

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Signatures.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Signatures.java
@@ -795,8 +795,7 @@ public final class Signatures {
 				}
 				continue;
 			}
-			if (parent instanceof CompilationUnit) {
-				CompilationUnit cunit = (CompilationUnit) parent;
+			if (parent instanceof CompilationUnit cunit) {
 				PackageDeclaration pdec = cunit.getPackage();
 				if (pdec != null) {
 					name.insert(0, '.');

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
@@ -261,8 +261,7 @@ public final class Util {
 		private void cancelBuild(Object jobfamily) {
 			Job[] buildJobs = Job.getJobManager().find(jobfamily);
 			for (Job curr : buildJobs) {
-				if (curr != this && curr instanceof BuildJob) {
-					BuildJob job = (BuildJob) curr;
+				if (curr != this && curr instanceof BuildJob job) {
 					if (job.isCoveredBy(this)) {
 						curr.cancel(); // cancel all other build jobs of our
 										// kind
@@ -1198,12 +1197,10 @@ public final class Util {
 		IPath path = IPath.fromOSString(typeNameWithSeparator);
 		IPath pathExceptLastSegment = path.removeLastSegments(1);
 		IJavaElement packFrag = javaProject.findElement(pathExceptLastSegment, DefaultWorkingCopyOwner.PRIMARY);
-		if (packFrag instanceof PackageFragment) {
-			PackageFragment pf = (PackageFragment) packFrag;
+		if (packFrag instanceof PackageFragment pf) {
 			List<JavaElement> children = pf.getChildrenOfType(IJavaElement.COMPILATION_UNIT);
 			for (JavaElement object : children) {
-				if (object instanceof CompilationUnit) {
-					CompilationUnit compilationUn = (CompilationUnit) object;
+				if (object instanceof CompilationUnit compilationUn) {
 					ITypeRoot typeRoot = compilationUn.getTypeRoot();
 					if (typeRoot.findPrimaryType() == null) {
 						continue;
@@ -1216,8 +1213,7 @@ public final class Util {
 			}
 			List<JavaElement> children2 = pf.getChildrenOfType(IJavaElement.CLASS_FILE);
 			for (JavaElement object : children2) {
-				if (object instanceof ClassFile) {
-					ClassFile compilationUn = (ClassFile) object;
+				if (object instanceof ClassFile compilationUn) {
 					ITypeRoot typeRoot = compilationUn.getTypeRoot();
 					if (typeRoot.findPrimaryType() == null) {
 						continue;
@@ -1251,8 +1247,7 @@ public final class Util {
 		IJavaElement ancestor = type.getAncestor(IJavaElement.JAVA_PROJECT);
 		IType newType = null;
 		try {
-			if (ancestor instanceof IJavaProject) {
-				IJavaProject pro = (IJavaProject) ancestor;
+			if (ancestor instanceof IJavaProject pro) {
 				if (!pro.equals(javaProject)) {
 					newType = updateType(typeName, javaProject);
 					if (newType != null) {
@@ -2853,8 +2848,7 @@ public final class Util {
 		IType type = null;
 		try {
 			String pkgName = typeName.substring(0, typeName.lastIndexOf('.'));
-			if (javaProject instanceof JavaProject) {
-				JavaProject jp = (JavaProject) javaProject;
+			if (javaProject instanceof JavaProject jp) {
 				NameLookup newNameLookup = null;
 				try {
 					newNameLookup = jp.newNameLookup(DefaultWorkingCopyOwner.PRIMARY);


### PR DESCRIPTION
The commit tries to implement a code cleanup in pattern matching using instanceof operator according to Java 16 guidelines, making the code more concise. 
The change has been applied in org.eclipse.pde.api.tools project. 

Kindly review @akurtakov @iloveeclipse @vik-chand @gireeshpunathil and do let me know in case of any edits.
