### PR TITLE
ApiAnalysisApplication should wait until jobs are done

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnalysisApplication.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnalysisApplication.java
@@ -127,6 +127,11 @@ public class ApiAnalysisApplication implements IApplication {
 			setTargetPlatform(args.tpFile);
 
 			project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+			// wait untill all jobs has finished that might be sceduled as part of the
+			// build...
+			while (!Job.getJobManager().isIdle()) {
+				Thread.yield();
+			}
 			IMarker[] allProblemMarkers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
 			Predicate<IMarker> isAPIMarker = marker -> {
 				try {


### PR DESCRIPTION
As part of the build probabbly other jobs are sceduled, the ApiAnalysisApplication should wait for all jobs to complete before investigate error markers to prevent problems with outdated states.

Currently the ApiAnalysisApplication seem flaky as discovered here:
- https://github.com/eclipse-equinox/equinox/pull/246#issuecomment-1658189309

@HannesWell @vik-chand please give approval for M3 this should not affect any IDE users but can improve the situation for Tycho users.