### PR TITLE
Show warnings/errors from the BND build

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -80,12 +80,15 @@ Export-Package:
    org.eclipse.pde.unittest.junit",
  org.eclipse.pde.internal.core.variables;x-internal:=true
 Import-Package: aQute.bnd.build;version="[4.4.0,5.0.0)",
- aQute.bnd.header;version="2.5.0",
+ aQute.bnd.build.model;version="[4.2.0,5.0.0)",
+ aQute.bnd.header;version="[2.5.0,3.0.0)",
  aQute.bnd.osgi;version="[5.5.0,6.0.0)",
  aQute.bnd.osgi.repository;version="[3.0.0,4.0.0)",
  aQute.bnd.osgi.resource;version="[4.3.0,5.0.0)",
+ aQute.bnd.properties;version="[2.0.0,3.0.0)",
  aQute.bnd.service;version="[4.7.0,5.0.0)",
  aQute.bnd.version;version="[2.2.0,3.0.0)",
+ aQute.service.reporter;version="[1.2.0,2.0.0)",
  org.osgi.service.repository;version="[1.1.0,2.0.0)",
  org.osgi.util.promise;version="[1.3.0,2.0.0)"
 Require-Bundle: 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBadLocationException.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBadLocationException.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.pde.internal.ui.editor.bnd;
+package org.eclipse.pde.internal.core.bnd;
 
 import org.eclipse.jface.text.BadLocationException;
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
@@ -35,6 +35,7 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDECoreMessages;
+import org.eclipse.pde.internal.core.builders.PDEMarkerFactory;
 import org.eclipse.pde.internal.core.natures.BndProject;
 import org.eclipse.pde.internal.core.project.PDEProject;
 
@@ -86,6 +87,14 @@ public class BndBuilder extends IncrementalProjectBuilder {
 		return new IProject[] { project };
 	}
 
+	@Override
+	protected void clean(IProgressMonitor monitor) throws CoreException {
+		IFile file = getProject().getFile(BndProject.INSTRUCTIONS_FILE);
+		if (file.exists()) {
+			file.deleteMarkers(PDEMarkerFactory.MARKER_ID, true, IResource.DEPTH_ZERO);
+		}
+	}
+
 	private static final class BndBuild implements ICoreRunnable {
 
 		private IProject project;
@@ -127,6 +136,7 @@ public class BndBuilder extends IncrementalProjectBuilder {
 				ProjectJar jar = new ProjectJar(project, CLASS_FILTER);
 				builder.setJar(jar);
 				builder.build();
+				new BndErrorReporter(project, bnd).validateContent(monitor);
 			}
 			if (monitor.isCanceled()) {
 				return;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndDocument.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndDocument.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.pde.internal.ui.editor.bnd;
+package org.eclipse.pde.internal.core.bnd;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -21,7 +21,7 @@ import aQute.bnd.properties.IRegion;
 /**
  * This class wraps from JFace text framework to bnd-document
  */
-final class BndDocument implements aQute.bnd.properties.IDocument {
+public final class BndDocument implements aQute.bnd.properties.IDocument {
 
 	private final IDocument document;
 
@@ -38,6 +38,14 @@ final class BndDocument implements aQute.bnd.properties.IDocument {
 	public IRegion getLineInformation(int lineNum) throws BndBadLocationException {
 		try {
 			return new BndRegion(document.getLineInformation(lineNum));
+		} catch (BadLocationException e) {
+			throw new BndBadLocationException(e);
+		}
+	}
+
+	public int getLineOfOffset(int offset) throws BndBadLocationException {
+		try {
+			return document.getLineOfOffset(offset);
 		} catch (BadLocationException e) {
 			throw new BndBadLocationException(e);
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndErrorReporter.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.pde.internal.core.builders.CompilerFlags;
+import org.eclipse.pde.internal.core.builders.ErrorReporter;
+import org.eclipse.pde.internal.core.builders.PDEMarkerFactory;
+import org.eclipse.pde.internal.core.natures.BndProject;
+
+import aQute.bnd.properties.IRegion;
+import aQute.bnd.properties.LineType;
+import aQute.bnd.properties.PropertiesLineReader;
+import aQute.service.reporter.Report;
+import aQute.service.reporter.Report.Location;
+
+public class BndErrorReporter extends ErrorReporter {
+
+	private BndDocument bndDocument;
+	private Report report;
+
+	public BndErrorReporter(IProject project, Report report) {
+		super(project.getFile(BndProject.INSTRUCTIONS_FILE));
+		this.report = report;
+		IDocument document = createDocument(fFile);
+		if (document != null) {
+			bndDocument = new BndDocument(document);
+		}
+	}
+
+	@Override
+	protected void validate(IProgressMonitor monitor) {
+		if (report != null) {
+			for (String warn : report.getWarnings()) {
+				reportProblem(warn, CompilerFlags.WARNING, report.getLocation(warn));
+			}
+			for (String err : report.getErrors()) {
+				reportProblem(err, CompilerFlags.ERROR, report.getLocation(err));
+			}
+		}
+	}
+
+	private void reportProblem(String err, int severity, Location location) {
+		int line = -1;
+		if (location != null) {
+			if (location.line > 0) {
+				line = location.line;
+			} else if (location.header != null && bndDocument != null) {
+				try {
+					PropertiesLineReader reader = new PropertiesLineReader(bndDocument);
+					LineType type = reader.next();
+					while (type != LineType.eof) {
+						if (type == LineType.entry) {
+							String key = reader.key();
+							if (location.header.equals(key)) {
+								IRegion region = reader.region();
+								line = bndDocument.getLineOfOffset(region.getOffset()) + 1;
+								break;
+							}
+						}
+						type = reader.next();
+					}
+				} catch (Exception e) {
+					// can't do anything here then...
+				}
+			}
+		}
+		report(err, line, severity, PDEMarkerFactory.CAT_FATAL);
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndRegion.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndRegion.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.pde.internal.ui.editor.bnd;
+package org.eclipse.pde.internal.core.bnd;
 
 import org.eclipse.jface.text.IRegion;
 
@@ -34,5 +34,10 @@ final class BndRegion implements aQute.bnd.properties.IRegion {
 	@Override
 	public int getOffset() {
 		return textRegion.getOffset();
+	}
+
+	@Override
+	public String toString() {
+		return textRegion.toString();
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndModel.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndModel.java
@@ -20,6 +20,7 @@ import org.eclipse.pde.core.IBaseModel;
 import org.eclipse.pde.core.IModelChangeProvider;
 import org.eclipse.pde.core.IModelChangedEvent;
 import org.eclipse.pde.core.IModelChangedListener;
+import org.eclipse.pde.internal.core.bnd.BndDocument;
 
 import aQute.bnd.build.model.BndEditModel;
 


### PR DESCRIPTION
Currently if one has an error in the pde.bnd file there is no feedback for the user about the problem.

This adds a validator that reads the errors/warning and display them to the user as error markers mapping the error to a line number if possible.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/699

@HannesWell @vik-chand I'd like to include this into M3 as it is otherwise very hard for users to notice that something is wrong (beside from getting annoyed that 'something' seems not working)