### PR TITLE
Code Cleanup: Java 16 instanceof pattern matching in pde.core

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/NameVersionDescriptor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/NameVersionDescriptor.java
@@ -78,8 +78,7 @@ public class NameVersionDescriptor {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof NameVersionDescriptor) {
-			NameVersionDescriptor iud = (NameVersionDescriptor) obj;
+		if (obj instanceof NameVersionDescriptor iud) {
 			if (fId.equals(iud.fId)) {
 				return (fVersion != null && fVersion.equals(iud.fVersion)) || (fVersion == null && iud.fVersion == null);
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -206,8 +206,7 @@ public class DependencyManager {
 				BundleRevision provider = wire.getCapability().getRevision();
 				// Use revision of required capability to support the case if
 				// fragments contribute new packages to their host's API.
-				if (provider instanceof BundleDescription && (includeOptional || !isOptional(wire.getRequirement()))) {
-					BundleDescription requiredBundle = (BundleDescription) provider;
+				if (provider instanceof BundleDescription requiredBundle && (includeOptional || !isOptional(wire.getRequirement()))) {
 					addNewRequiredBundle(requiredBundle, closure, pending);
 				}
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/FeatureModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/FeatureModelManager.java
@@ -275,10 +275,9 @@ public class FeatureModelManager {
 		if ((e.getEventTypes() & IModelProviderEvent.MODELS_REMOVED) != 0) {
 			IModel[] removed = e.getRemovedModels();
 			for (int i = 0; i < removed.length; i++) {
-				if (!(removed[i] instanceof IFeatureModel)) {
+				if (!(removed[i] instanceof IFeatureModel model)) {
 					continue;
 				}
-				IFeatureModel model = (IFeatureModel) removed[i];
 				FeatureTable.Idver idver = fActiveModels.remove(model);
 				if (idver != null) {
 					// may need to activate another model
@@ -295,10 +294,9 @@ public class FeatureModelManager {
 		if ((e.getEventTypes() & IModelProviderEvent.MODELS_ADDED) != 0) {
 			IModel[] added = e.getAddedModels();
 			for (int i = 0; i < added.length; i++) {
-				if (!(added[i] instanceof IFeatureModel)) {
+				if (!(added[i] instanceof IFeatureModel model)) {
 					continue;
 				}
-				IFeatureModel model = (IFeatureModel) added[i];
 				if (model.getUnderlyingResource() != null) {
 					FeatureTable.Idver idver = fActiveModels.add(model);
 					delta.add(model, IFeatureModelDelta.ADDED);
@@ -339,11 +337,9 @@ public class FeatureModelManager {
 		if ((e.getEventTypes() & IModelProviderEvent.MODELS_CHANGED) != 0) {
 			IModel[] changed = e.getChangedModels();
 			for (int i = 0; i < changed.length; i++) {
-				if (!(changed[i] instanceof IFeatureModel)) {
+				if (!(changed[i] instanceof IFeatureModel model)) {
 					continue;
 				}
-				IFeatureModel model = (IFeatureModel) changed[i];
-
 				String id = model.getFeature().getId();
 				String version = model.getFeature().getVersion();
 
@@ -373,10 +369,9 @@ public class FeatureModelManager {
 		if ((e.getEventTypes() & IModelProviderEvent.MODELS_CHANGED) != 0) {
 			IModel[] changed = e.getChangedModels();
 			for (int i = 0; i < changed.length; i++) {
-				if (!(changed[i] instanceof IFeatureModel)) {
+				if (!(changed[i] instanceof IFeatureModel model)) {
 					continue;
 				}
-				IFeatureModel model = (IFeatureModel) changed[i];
 				if (!delta.contains(model, IFeatureModelDelta.ADDED | IFeatureModelDelta.REMOVED)) {
 					delta.add(model, IFeatureModelDelta.CHANGED);
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/JavaElementChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/JavaElementChangeListener.java
@@ -101,8 +101,7 @@ public class JavaElementChangeListener implements IElementChangedListener {
 			return true;
 		}
 
-		if (kind == IJavaElementDelta.CHANGED && element instanceof IPackageFragmentRoot) {
-			IPackageFragmentRoot root = (IPackageFragmentRoot) element;
+		if (kind == IJavaElementDelta.CHANGED && element instanceof IPackageFragmentRoot root) {
 			return root.isArchive();
 		}
 		return false;
@@ -111,8 +110,7 @@ public class JavaElementChangeListener implements IElementChangedListener {
 	private boolean ignoreDelta(IJavaElementDelta delta) {
 		try {
 			IJavaElement element = delta.getElement();
-			if (element instanceof IPackageFragmentRoot) {
-				IPackageFragmentRoot root = (IPackageFragmentRoot) element;
+			if (element instanceof IPackageFragmentRoot root) {
 				IClasspathEntry entry = root.getRawClasspathEntry();
 				if (entry != null && entry.getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
 					return true;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEExtensionRegistry.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEExtensionRegistry.java
@@ -256,10 +256,9 @@ public class PDEExtensionRegistry {
 
 	// make sure we return the right IPluginModelBase when we have multiple versions of a plug-in Id
 	private IPluginModelBase getPlugin(IContributor icontributor, boolean searchAll) {
-		if (!(icontributor instanceof RegistryContributor)) {
+		if (!(icontributor instanceof RegistryContributor contributor)) {
 			return null;
 		}
-		RegistryContributor contributor = (RegistryContributor) icontributor;
 		long bundleId = Long.parseLong(contributor.getActualId());
 		BundleDescription desc = PDECore.getDefault().getModelManager().getState().getState().getBundle(Long.parseLong(contributor.getActualId()));
 		if (desc != null) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SearchablePluginsManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SearchablePluginsManager.java
@@ -95,8 +95,7 @@ public class SearchablePluginsManager implements IFileAdapterFactory, IPluginMod
 				}
 				return true;
 			}
-			if (element instanceof IJavaProject) {
-				IJavaProject project = (IJavaProject) element;
+			if (element instanceof IJavaProject project) {
 				if (project.getElementName().equals(PROXY_PROJECT_NAME)) {
 					if (delta.getKind() == IJavaElementDelta.REMOVED) {
 						synchronized (fPluginIdSet) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/WorkspaceModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/WorkspaceModelManager.java
@@ -96,8 +96,7 @@ public abstract class WorkspaceModelManager<T> extends AbstractModelManager
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof ModelChange) {
-				ModelChange change = (ModelChange) obj;
+			if (obj instanceof ModelChange change) {
 				IProject project = change.model.getUnderlyingResource().getProject();
 				int type = change.type;
 				return model.getUnderlyingResource().getProject().equals(project) && this.type == type;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/CustomHeaderAnnotationProcessor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/CustomHeaderAnnotationProcessor.java
@@ -53,8 +53,7 @@ public class CustomHeaderAnnotationProcessor implements OSGiAnnotationProcessor 
 
 	@Override
 	public void apply(IBaseModel model) {
-		if (model instanceof IBundlePluginModelBase) {
-			IBundlePluginModelBase pluginModel = (IBundlePluginModelBase) model;
+		if (model instanceof IBundlePluginModelBase pluginModel) {
 			IBundleModel bundleModel = pluginModel.getBundleModel();
 			IBundle bundle = bundleModel.getBundle();
 			for (Entry<String, String> entry : headers) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/ExportPackageAnnotationProcessor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/ExportPackageAnnotationProcessor.java
@@ -58,8 +58,7 @@ public class ExportPackageAnnotationProcessor implements OSGiAnnotationProcessor
 	}
 
 	private static ExportPackageObject getExportPackage(IBaseModel model, String packageName) {
-		if (model instanceof IBundlePluginModelBase) {
-			IBundlePluginModelBase pluginModel = (IBundlePluginModelBase) model;
+		if (model instanceof IBundlePluginModelBase pluginModel) {
 			IBundleModel bundleModel = pluginModel.getBundleModel();
 			IBundle bundle = bundleModel.getBundle();
 			IManifestHeader header = bundle.getManifestHeader(Constants.EXPORT_PACKAGE);
@@ -67,8 +66,7 @@ public class ExportPackageAnnotationProcessor implements OSGiAnnotationProcessor
 				bundle.setHeader(Constants.EXPORT_PACKAGE, packageName);
 				header = bundle.getManifestHeader(Constants.EXPORT_PACKAGE);
 			}
-			if (header instanceof ExportPackageHeader) {
-				ExportPackageHeader exportPackageHeader = (ExportPackageHeader) header;
+			if (header instanceof ExportPackageHeader exportPackageHeader) {
 				ExportPackageObject packageObject = exportPackageHeader.getPackage(packageName);
 				if (packageObject == null) {
 					return exportPackageHeader.addPackage(packageName);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationProcessor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationProcessor.java
@@ -67,8 +67,7 @@ public interface OSGiAnnotationProcessor {
 	 */
 	static Stream<Expression> expressions(Expression expression) {
 		Expression unwrap = value(expression).orElse(expression);
-		if (unwrap instanceof ArrayInitializer) {
-			ArrayInitializer arrayInitializer = (ArrayInitializer) unwrap;
+		if (unwrap instanceof ArrayInitializer arrayInitializer) {
 			return arrayInitializer.expressions().stream().filter(Expression.class::isInstance)
 					.map(Expression.class::cast);
 		}
@@ -98,11 +97,9 @@ public interface OSGiAnnotationProcessor {
 	 *         optional if no such member exits.
 	 */
 	static Optional<Expression> member(Expression annotation, String memberName) {
-		if (annotation instanceof NormalAnnotation) {
-			NormalAnnotation normalAnnotation = (NormalAnnotation) annotation;
+		if (annotation instanceof NormalAnnotation normalAnnotation) {
 			for (Object value : normalAnnotation.values()) {
-				if (value instanceof MemberValuePair) {
-					MemberValuePair pair = (MemberValuePair) value;
+				if (value instanceof MemberValuePair pair) {
 					SimpleName name = pair.getName();
 					if (name != null && name.toString().equals(memberName)) {
 						return Optional.ofNullable(pair.getValue());
@@ -110,8 +107,7 @@ public interface OSGiAnnotationProcessor {
 				}
 			}
 		}
-		if (annotation instanceof SingleMemberAnnotation && "value".equals(memberName)) { //$NON-NLS-1$
-			SingleMemberAnnotation singleMemberAnnotation = (SingleMemberAnnotation) annotation;
+		if (annotation instanceof SingleMemberAnnotation singleMemberAnnotation && "value".equals(memberName)) { //$NON-NLS-1$
 			return Optional.ofNullable(singleMemberAnnotation.getValue());
 		}
 		return Optional.empty();

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndBuilder.java
@@ -159,8 +159,7 @@ public class BndBuilder extends IncrementalProjectBuilder {
 				@Override
 				public boolean visit(IResourceDelta delta) throws CoreException {
 					IResource resource = delta.getResource();
-					if (resource instanceof IFile) {
-						IFile file = (IFile) resource;
+					if (resource instanceof IFile file) {
 						String name = file.getName();
 						if (name.endsWith(CLASS_EXTENSION) || file.getName().equals(BndProject.INSTRUCTIONS_FILE)
 								|| name.equals(ICoreConstants.MANIFEST_FILENAME)) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndProjectManager.java
@@ -132,8 +132,7 @@ public class BndProjectManager {
 			@SuppressWarnings("deprecation")
 			IContainer[] containers = root.findContainersForLocation(IPath.fromOSString(base.getAbsolutePath()));
 			for (IContainer container : containers) {
-				if (container instanceof IProject) {
-					IProject p = (IProject) container;
+				if (container instanceof IProject p) {
 					entries.add(JavaCore.newProjectEntry(p.getFullPath()));
 				}
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -49,8 +49,7 @@ public class BndResourceChangeListener implements IResourceChangeListener {
 					@Override
 					public boolean visit(IResourceDelta delta) throws CoreException {
 						IResource resource = delta.getResource();
-						if (resource instanceof IFile) {
-							IFile file = (IFile) resource;
+						if (resource instanceof IFile file) {
 							if (BndProject.INSTRUCTIONS_FILE.equals(file.getName())
 									&& BndProject.isBndProject(file.getProject())) {
 								updateProjects.add(file.getProject());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BuildErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BuildErrorReporter.java
@@ -119,10 +119,9 @@ public class BuildErrorReporter extends ErrorReporter implements IBuildPropertie
 
 		@Override
 		public boolean equals(Object obj) {
-			if (!(obj instanceof BuildProblem)) {
+			if (!(obj instanceof BuildProblem bp)) {
 				return false;
 			}
-			BuildProblem bp = (BuildProblem) obj;
 			if (!fEntryName.equals(bp.fEntryName)) {
 				return false;
 			}
@@ -1235,10 +1234,9 @@ public class BuildErrorReporter extends ErrorReporter implements IBuildPropertie
 	}
 
 	private int getLineNumber(IBuildEntry ibe, String tokenString) {
-		if (!(ibe instanceof BuildEntry)) {
+		if (!(ibe instanceof BuildEntry be)) {
 			return 0;
 		}
-		BuildEntry be = (BuildEntry) ibe;
 		IDocument doc = ((BuildModel) be.getModel()).getDocument();
 		try {
 			int buildEntryLineNumber = doc.getLineOfOffset(be.getOffset()) + 1;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
@@ -237,8 +237,7 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 		IHeader header = getHeader(Constants.EXPORT_PACKAGE);
 
 		// check for missing exported packages
-		if (fModel instanceof IBundlePluginModelBase) {
-			IBundlePluginModelBase bundleModel = (IBundlePluginModelBase) fModel;
+		if (fModel instanceof IBundlePluginModelBase bundleModel) {
 			IBundle bundle = bundleModel.getBundleModel().getBundle();
 			IManifestHeader bundleClasspathheader = bundle.getManifestHeader(Constants.BUNDLE_CLASSPATH);
 
@@ -251,8 +250,7 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 					if (ManifestUtils.isImmediateRoot(root)) {
 						IJavaElement[] javaElements = root.getChildren();
 						for (int j = 0; j < javaElements.length; j++) {
-							if (javaElements[j] instanceof IPackageFragment) {
-								IPackageFragment fragment = (IPackageFragment) javaElements[j];
+							if (javaElements[j] instanceof IPackageFragment fragment) {
 								String name = fragment.getElementName();
 								if (name.length() == 0) {
 									continue;
@@ -1728,12 +1726,11 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 		}
 
 		IResource res = PDEProject.getBundleRoot(fProject).findMember(location);
-		if (res == null || !(res instanceof IContainer)) {
+		if (res == null || !(res instanceof IContainer folder)) {
 			VirtualMarker marker = report(PDECoreMessages.BundleErrorReporter_localization_folder_not_exist, header.getLineNumber(), CompilerFlags.getFlag(fProject, CompilerFlags.P_UNKNOWN_RESOURCE), PDEMarkerFactory.CAT_OTHER);
 			addMarkerAttribute(marker, PDEMarkerFactory.compilerKey, CompilerFlags.P_UNKNOWN_RESOURCE);
 			return;
 		}
-		IContainer folder = (IContainer) res;
 		try {
 			IResource[] children = folder.members();
 			for (int i = 0; i < children.length; i++) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ElementOccurenceChecker.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ElementOccurenceChecker.java
@@ -281,24 +281,20 @@ public class ElementOccurenceChecker {
 	}
 
 	private static void processObjectMax(ISchemaObject schemaObject, HashSet<ElementOccurrenceResult> elementSet, HashMap<String, Integer> siblings, int multiplicityTracker, Element element) {
-		if (schemaObject instanceof ISchemaElement) {
-			ISchemaElement schemaElement = (ISchemaElement) schemaObject;
+		if (schemaObject instanceof ISchemaElement schemaElement) {
 			Element childElement = findChildElement(element, schemaElement.getName());
 			if (childElement != null) {
 				processElementMax(schemaElement, elementSet, siblings, multiplicityTracker, childElement);
 			}
-		} else if (schemaObject instanceof ISchemaCompositor) {
-			ISchemaCompositor sCompositor = (ISchemaCompositor) schemaObject;
+		} else if (schemaObject instanceof ISchemaCompositor sCompositor) {
 			processCompositorMax(sCompositor, elementSet, siblings, multiplicityTracker, element);
 		}
 	}
 
 	private static void processObjectMin(ISchemaObject schemaObject, HashSet<ElementOccurrenceResult> elementSet, HashMap<String, Integer> siblings, int multiplicityTracker) {
-		if (schemaObject instanceof ISchemaElement) {
-			ISchemaElement schemaElement = (ISchemaElement) schemaObject;
+		if (schemaObject instanceof ISchemaElement schemaElement) {
 			processElementMin(schemaElement, elementSet, siblings, multiplicityTracker);
-		} else if (schemaObject instanceof ISchemaCompositor) {
-			ISchemaCompositor sCompositor = (ISchemaCompositor) schemaObject;
+		} else if (schemaObject instanceof ISchemaCompositor sCompositor) {
 			processCompositorMin(sCompositor, elementSet, siblings, multiplicityTracker);
 		}
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ExtensionPointSchemaBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ExtensionPointSchemaBuilder.java
@@ -70,6 +70,7 @@ public class ExtensionPointSchemaBuilder extends IncrementalProjectBuilder {
 			}
 
 			if (resource instanceof IFile candidate) {
+				// see if this is it
 				if (isSchemaFile(candidate)) {
 					// That's it, but only check it if it has been added or changed
 					if (delta.getKind() != IResourceDelta.REMOVED) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ExtensionPointSchemaBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ExtensionPointSchemaBuilder.java
@@ -69,9 +69,7 @@ public class ExtensionPointSchemaBuilder extends IncrementalProjectBuilder {
 				return true;
 			}
 
-			if (resource instanceof IFile) {
-				// see if this is it
-				IFile candidate = (IFile) resource;
+			if (resource instanceof IFile candidate) {
 				if (isSchemaFile(candidate)) {
 					// That's it, but only check it if it has been added or changed
 					if (delta.getKind() != IResourceDelta.REMOVED) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ExtensionsErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ExtensionsErrorReporter.java
@@ -276,8 +276,7 @@ public class ExtensionsErrorReporter extends ManifestErrorReporter {
 			return;
 		}
 
-		if (schemaElement instanceof ISchemaRootElement) {
-			ISchemaRootElement rootElement = (ISchemaRootElement) schemaElement;
+		if (schemaElement instanceof ISchemaRootElement rootElement) {
 			String epid = schemaElement.getSchema().getPluginId();
 			if (fModel == null || fModel.getPluginBase() == null) {
 				return;
@@ -331,8 +330,7 @@ public class ExtensionsErrorReporter extends ManifestErrorReporter {
 	}
 
 	private void computeAllowedElements(ISchemaType type, HashSet<String> elementSet) {
-		if (type instanceof ISchemaComplexType) {
-			ISchemaComplexType complexType = (ISchemaComplexType) type;
+		if (type instanceof ISchemaComplexType complexType) {
 			ISchemaCompositor compositor = complexType.getCompositor();
 			if (compositor != null) {
 				computeAllowedElements(compositor, elementSet);
@@ -350,8 +348,7 @@ public class ExtensionsErrorReporter extends ManifestErrorReporter {
 	private void computeAllowedElements(ISchemaCompositor compositor, HashSet<String> elementSet) {
 		ISchemaObject[] children = compositor.getChildren();
 		for (ISchemaObject child : children) {
-			if (child instanceof ISchemaObjectReference) {
-				ISchemaObjectReference ref = (ISchemaObjectReference) child;
+			if (child instanceof ISchemaObjectReference ref) {
 				ISchemaElement refElement = (ISchemaElement) ref.getReferencedObject();
 				if (refElement != null) {
 					elementSet.add(refElement.getName());
@@ -664,8 +661,7 @@ public class ExtensionsErrorReporter extends ManifestErrorReporter {
 		Object[] children = restriction.getChildren();
 		String value = attr.getValue();
 		for (Object child : children) {
-			if (child instanceof ISchemaEnumeration) {
-				ISchemaEnumeration enumeration = (ISchemaEnumeration) child;
+			if (child instanceof ISchemaEnumeration enumeration) {
 				if (enumeration.getName().equals(value)) {
 					return;
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureConsistencyChecker.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureConsistencyChecker.java
@@ -48,9 +48,7 @@ public class FeatureConsistencyChecker extends IncrementalProjectBuilder {
 		public boolean visit(IResourceDelta delta) {
 			IResource resource = delta.getResource();
 
-			if (resource instanceof IProject) {
-				// Only check projects with feature nature
-				IProject project = (IProject) resource;
+			if (resource instanceof IProject project) {
 				try {
 					return (project.hasNature(PDE.FEATURE_NATURE));
 				} catch (CoreException e) {
@@ -58,9 +56,7 @@ public class FeatureConsistencyChecker extends IncrementalProjectBuilder {
 					return false;
 				}
 			}
-			if (resource instanceof IFile) {
-				// see if this is it
-				IFile candidate = (IFile) resource;
+			if (resource instanceof IFile candidate) {
 				if (isManifestFile(candidate)) {
 					// That's it, but only check it if it has been added or changed
 					if (delta.getKind() != IResourceDelta.REMOVED) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureConsistencyChecker.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureConsistencyChecker.java
@@ -49,6 +49,7 @@ public class FeatureConsistencyChecker extends IncrementalProjectBuilder {
 			IResource resource = delta.getResource();
 
 			if (resource instanceof IProject project) {
+				// Only check projects with feature nature
 				try {
 					return (project.hasNature(PDE.FEATURE_NATURE));
 				} catch (CoreException e) {
@@ -57,6 +58,7 @@ public class FeatureConsistencyChecker extends IncrementalProjectBuilder {
 				}
 			}
 			if (resource instanceof IFile candidate) {
+				// see if this is it
 				if (isManifestFile(candidate)) {
 					// That's it, but only check it if it has been added or changed
 					if (delta.getKind() != IResourceDelta.REMOVED) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureErrorReporter.java
@@ -448,8 +448,7 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 			return;
 		}
 
-		if (pModel instanceof IBundlePluginModel) {
-			IBundlePluginModel bModel = (IBundlePluginModel) pModel;
+		if (pModel instanceof IBundlePluginModel bModel) {
 			IManifestHeader header = bModel.getBundleModel().getBundle().getManifestHeader(ICoreConstants.ECLIPSE_BUNDLE_SHAPE);
 			if (header != null) {
 				String value = header.getValue();

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/SchemaErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/SchemaErrorReporter.java
@@ -106,8 +106,7 @@ public class SchemaErrorReporter extends XMLErrorReporter {
 			NodeList children = element.getChildNodes();
 			for (int i = 0; i < children.getLength(); i++) {
 				Node child = children.item(i);
-				if (child instanceof Element) {
-					Element childElement = (Element) child;
+				if (child instanceof Element childElement) {
 					String name = childElement.getNodeName();
 					if (name != null && name.equals(ELEMENT)) {
 						String value = childElement.getAttribute(ATTR_NAME);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/SourceEntryErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/SourceEntryErrorReporter.java
@@ -209,8 +209,7 @@ public class SourceEntryErrorReporter extends BuildErrorReporter {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof EncodingEntry) {
-				EncodingEntry other = (EncodingEntry) obj;
+			if (obj instanceof EncodingEntry other) {
 				return other.fEncoding.equals(fEncoding) && other.fResource.equals(fResource);
 			}
 			return false;
@@ -412,8 +411,7 @@ public class SourceEntryErrorReporter extends BuildErrorReporter {
 
 	private IPath getPath(Object entry) {
 		IPath path = null;
-		if (entry instanceof IClasspathEntry) {
-			IClasspathEntry cpes = (IClasspathEntry) entry;
+		if (entry instanceof IClasspathEntry cpes) {
 			path = cpes.getPath();
 		} else if (entry instanceof IPath) {
 			path = (IPath) entry;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/UpdateSiteBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/UpdateSiteBuilder.java
@@ -46,6 +46,7 @@ public class UpdateSiteBuilder extends IncrementalProjectBuilder {
 			IResource resource = delta.getResource();
 
 			if (resource instanceof IProject project) {
+				// Only check projects with feature nature
 				try {
 					return (project.hasNature(PDE.SITE_NATURE));
 				} catch (CoreException e) {
@@ -54,6 +55,7 @@ public class UpdateSiteBuilder extends IncrementalProjectBuilder {
 				}
 			}
 			if (resource instanceof IFile candidate) {
+				// see if this is it
 				if (candidate.getName().equals("site.xml")) { //$NON-NLS-1$
 					// That's it, but only check it if it has been added or changed
 					if (delta.getKind() != IResourceDelta.REMOVED) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/UpdateSiteBuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/UpdateSiteBuilder.java
@@ -45,9 +45,7 @@ public class UpdateSiteBuilder extends IncrementalProjectBuilder {
 		public boolean visit(IResourceDelta delta) {
 			IResource resource = delta.getResource();
 
-			if (resource instanceof IProject) {
-				// Only check projects with feature nature
-				IProject project = (IProject) resource;
+			if (resource instanceof IProject project) {
 				try {
 					return (project.hasNature(PDE.SITE_NATURE));
 				} catch (CoreException e) {
@@ -55,9 +53,7 @@ public class UpdateSiteBuilder extends IncrementalProjectBuilder {
 					return false;
 				}
 			}
-			if (resource instanceof IFile) {
-				// see if this is it
-				IFile candidate = (IFile) resource;
+			if (resource instanceof IFile candidate) {
 				if (candidate.getName().equals("site.xml")) { //$NON-NLS-1$
 					// That's it, but only check it if it has been added or changed
 					if (delta.getKind() != IResourceDelta.REMOVED) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundlePluginModelBase.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundlePluginModelBase.java
@@ -96,14 +96,12 @@ public abstract class BundlePluginModelBase extends AbstractNLModel implements I
 
 	@Override
 	public void save() {
-		if (fBundleModel != null && fBundleModel instanceof IEditableModel) {
-			IEditableModel emodel = (IEditableModel) fBundleModel;
+		if (fBundleModel != null && fBundleModel instanceof IEditableModel emodel) {
 			if (emodel.isDirty()) {
 				emodel.save();
 			}
 		}
-		if (fExtensionsModel != null && fExtensionsModel instanceof IEditableModel) {
-			IEditableModel emodel = (IEditableModel) fExtensionsModel;
+		if (fExtensionsModel != null && fExtensionsModel instanceof IEditableModel emodel) {
 			if (emodel.isDirty()) {
 				emodel.save();
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/WorkspaceExportHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/WorkspaceExportHelper.java
@@ -187,8 +187,7 @@ public class WorkspaceExportHelper extends LaunchConfigurationDelegate {
 					if (project.exists()) {
 						projects.add(project);
 					}
-				} else if (exportedItem instanceof IFeatureModel) {
-					IFeatureModel feature = (IFeatureModel) exportedItem;
+				} else if (exportedItem instanceof IFeatureModel feature) {
 					IFeaturePlugin[] plugins = feature.getFeature().getPlugins();
 					for (IFeaturePlugin plugin : plugins) {
 						IPluginModelBase model = PDECore.getDefault().getModelManager().findModel(plugin.getId());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/ImportObject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/ImportObject.java
@@ -40,8 +40,7 @@ public class ImportObject extends PluginReference implements IWritable, Serializ
 
 	@Override
 	public boolean equals(Object object) {
-		if (object instanceof ImportObject) {
-			ImportObject io = (ImportObject) object;
+		if (object instanceof ImportObject io) {
 			if (iimport.equals(io.getImport())) {
 				return true;
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginAttribute.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginAttribute.java
@@ -53,8 +53,7 @@ public class PluginAttribute extends PluginObject implements IPluginAttribute {
 		if (obj == null) {
 			return false;
 		}
-		if (obj instanceof IPluginAttribute) {
-			IPluginAttribute target = (IPluginAttribute) obj;
+		if (obj instanceof IPluginAttribute target) {
 			if (target.getModel().equals(getModel())) {
 				return false;
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginElement.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginElement.java
@@ -77,8 +77,7 @@ public class PluginElement extends PluginParent implements IPluginElement {
 		if (obj == null) {
 			return false;
 		}
-		if (obj instanceof IPluginElement) {
-			IPluginElement target = (IPluginElement) obj;
+		if (obj instanceof IPluginElement target) {
 			// Equivalent models must return false to get proper source range selection, see bug 267954.
 			if (target.getModel().equals(getModel())) {
 				return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginExtension.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginExtension.java
@@ -101,9 +101,7 @@ public class PluginExtension extends PluginParent implements IPluginExtension {
 		if (obj == null) {
 			return false;
 		}
-		if (obj instanceof IPluginExtension) {
-			IPluginExtension target = (IPluginExtension) obj;
-
+		if (obj instanceof IPluginExtension target) {
 			// comparing the model is a little complicated since we need to allow text and non-text models representing the same file
 			if (target.getModel().getClass() == getModel().getClass()) {
 				if (!target.getModel().equals(getModel())) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginExtensionPoint.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginExtensionPoint.java
@@ -84,8 +84,7 @@ public class PluginExtensionPoint extends IdentifiablePluginObject implements IP
 		if (obj == this) {
 			return true;
 		}
-		if (obj instanceof IPluginExtensionPoint) {
-			IPluginExtensionPoint target = (IPluginExtensionPoint) obj;
+		if (obj instanceof IPluginExtensionPoint target) {
 			// Objects from the same model must be
 			// binary equal
 			if (target.getModel().equals(getModel())) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginImport.java
@@ -129,8 +129,7 @@ public class PluginImport extends IdentifiablePluginObject implements IPluginImp
 		if (obj == null) {
 			return false;
 		}
-		if (obj instanceof IPluginImport) {
-			IPluginImport target = (IPluginImport) obj;
+		if (obj instanceof IPluginImport target) {
 			// Objects from the same model must be
 			// binary equal
 			if (target.getModel().equals(getModel())) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginObject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginObject.java
@@ -100,8 +100,7 @@ public abstract class PluginObject extends PlatformObject implements IPluginObje
 
 	protected void fireModelChanged(IModelChangedEvent e) {
 		IModel model = getModel();
-		if (model.isEditable() && model instanceof IModelChangeProvider) {
-			IModelChangeProvider provider = (IModelChangeProvider) model;
+		if (model.isEditable() && model instanceof IModelChangeProvider provider) {
 			provider.fireModelChanged(e);
 		}
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginParent.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginParent.java
@@ -66,8 +66,7 @@ public abstract class PluginParent extends IdentifiablePluginObject implements I
 		if (obj == null) {
 			return false;
 		}
-		if (obj instanceof IPluginParent) {
-			IPluginParent target = (IPluginParent) obj;
+		if (obj instanceof IPluginParent target) {
 			if (target.getChildCount() != getChildCount()) {
 				return false;
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ProductModel.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ProductModel.java
@@ -85,8 +85,7 @@ public class ProductModel extends AbstractModel implements IProductModel {
 				processDocument(handler.getDocument());
 				String copyright = chandler.getCopyright();
 				if (copyright != null) {
-					if (fProduct instanceof Product) {
-						Product product = (Product) fProduct;
+					if (fProduct instanceof Product product) {
 						product.setCopyright(copyright);
 					}
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/RepositoryInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/RepositoryInfo.java
@@ -96,10 +96,9 @@ public class RepositoryInfo extends ProductObject implements IRepositoryInfo {
 		if (this == obj) {
 			return true;
 		}
-		if (!(obj instanceof RepositoryInfo)) {
+		if (!(obj instanceof RepositoryInfo other)) {
 			return false;
 		}
-		RepositoryInfo other = (RepositoryInfo) obj;
 		return Objects.equals(fURL, other.fURL);
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleClasspathSpecification.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleClasspathSpecification.java
@@ -57,8 +57,7 @@ public class BundleClasspathSpecification implements IBundleClasspathEntry {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IBundleClasspathEntry) {
-			IBundleClasspathEntry spec = (IBundleClasspathEntry) obj;
+		if (obj instanceof IBundleClasspathEntry spec) {
 			return equalOrNull(getSourcePath(), spec.getSourcePath()) && equalOrNull(getBinaryPath(), spec.getBinaryPath()) && equalOrNull(getLibrary(), spec.getLibrary());
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PackageExportDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PackageExportDescription.java
@@ -58,8 +58,7 @@ public class PackageExportDescription implements IPackageExportDescription {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof PackageExportDescription) {
-			PackageExportDescription spec = (PackageExportDescription) obj;
+		if (obj instanceof PackageExportDescription spec) {
 			return getName().equals(spec.getName()) && isApi() == spec.isApi() && equalOrNull(getVersion(), spec.getVersion()) && equalOrNull(getFriends(), spec.getFriends());
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
@@ -507,8 +507,7 @@ public class ProjectModifyOperation {
 		}
 
 		// manifest version
-		if (fModel instanceof IBundlePluginModelBase) {
-			IBundlePluginModelBase bmodel = ((IBundlePluginModelBase) fModel);
+		if (fModel instanceof IBundlePluginModelBase bmodel) {
 			// Target version is not persisted and does not make the model dirty.
 			// It is only used by the new project wizard to determine which templates are available.
 			((IBundlePluginBase) bmodel.getPluginBase()).setTargetVersion(targetVersion);
@@ -517,9 +516,7 @@ public class ProjectModifyOperation {
 				bmodel.getBundleModel().getBundle().setHeader(Constants.BUNDLE_MANIFESTVERSION, "2"); //$NON-NLS-1$
 			}
 		}
-		if (pluginBase instanceof IFragment) {
-			// host specification
-			IFragment fragment = (IFragment) pluginBase;
+		if (pluginBase instanceof IFragment fragment) {
 			IHostDescription host = description.getHost();
 			if (!isEqual(host, before.getHost())) {
 				fragment.setPluginId(host.getName());
@@ -688,8 +685,7 @@ public class ProjectModifyOperation {
 			}
 			// if the bundle model has been made dirty, ensure that propagates back to the root model
 			IBundleModel bundleModel = bundle.getModel();
-			if (bundleModel instanceof WorkspaceBundleModel) {
-				WorkspaceBundleModel wbm = (WorkspaceBundleModel) bundleModel;
+			if (bundleModel instanceof WorkspaceBundleModel wbm) {
 				if (wbm.isDirty()) {
 					fModel.setDirty(true);
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
@@ -517,6 +517,7 @@ public class ProjectModifyOperation {
 			}
 		}
 		if (pluginBase instanceof IFragment fragment) {
+			// host specification
 			IHostDescription host = description.getHost();
 			if (!isEqual(host, before.getHost())) {
 				fragment.setPluginId(host.getName());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/RequirementSpecification.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/RequirementSpecification.java
@@ -54,8 +54,7 @@ public abstract class RequirementSpecification {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof RequirementSpecification) {
-			RequirementSpecification spec = (RequirementSpecification) obj;
+		if (obj instanceof RequirementSpecification spec) {
 			return getName().equals(spec.getName()) && isExported() == spec.isExported() && isOptional() == spec.isOptional() && equalOrNull(getVersionRange(), spec.getVersionRange());
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/ChoiceRestriction.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/ChoiceRestriction.java
@@ -115,8 +115,7 @@ public class ChoiceRestriction extends SchemaObject implements ISchemaRestrictio
 
 		for (int i = 0; i < children.size(); i++) {
 			Object child = children.get(i);
-			if (child instanceof ISchemaEnumeration) {
-				ISchemaEnumeration enumeration = (ISchemaEnumeration) child;
+			if (child instanceof ISchemaEnumeration enumeration) {
 				if (i > 0) {
 					buffer.append(", "); //$NON-NLS-1$
 				}
@@ -131,8 +130,7 @@ public class ChoiceRestriction extends SchemaObject implements ISchemaRestrictio
 		writer.println(indent + "<restriction base=\"" + baseType.getName() + "\">"); //$NON-NLS-1$ //$NON-NLS-2$
 		for (int i = 0; i < children.size(); i++) {
 			Object child = children.get(i);
-			if (child instanceof ISchemaEnumeration) {
-				ISchemaEnumeration enumeration = (ISchemaEnumeration) child;
+			if (child instanceof ISchemaEnumeration enumeration) {
 				enumeration.write(indent + Schema.INDENT, writer);
 			}
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/Schema.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/Schema.java
@@ -164,8 +164,7 @@ public class Schema extends PlatformObject implements ISchema {
 		for (Object child : children) {
 			if (child instanceof ISchemaCompositor) {
 				collectElements((ISchemaCompositor) child, result);
-			} else if (child instanceof ISchemaObjectReference) {
-				ISchemaObjectReference ref = (ISchemaObjectReference) child;
+			} else if (child instanceof ISchemaObjectReference ref) {
 				Object referenced = ref.getReferencedObject();
 				if (referenced instanceof ISchemaElement) {
 					result.addElement(referenced);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaCompositor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaCompositor.java
@@ -158,8 +158,7 @@ public class SchemaCompositor extends RepeatableSchemaObject implements ISchemaC
 	public void updateReferencesFor(ISchemaElement element, int kind) {
 		for (int i = children.size() - 1; i >= 0; i--) {
 			Object child = children.elementAt(i);
-			if (child instanceof SchemaElementReference) {
-				SchemaElementReference ref = (SchemaElementReference) child;
+			if (child instanceof SchemaElementReference ref) {
 				String refName = ref.getReferenceName();
 				switch (kind) {
 					case ISchema.REFRESH_ADD :

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaElement.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaElement.java
@@ -153,8 +153,7 @@ public class SchemaElement extends RepeatableSchemaObject implements ISchemaElem
 		if (type == null) {
 			text += "EMPTY"; //$NON-NLS-1$
 		} else {
-			if (type instanceof ISchemaComplexType) {
-				ISchemaComplexType complexType = (ISchemaComplexType) type;
+			if (type instanceof ISchemaComplexType complexType) {
 				ISchemaCompositor compositor = complexType.getCompositor();
 				if (compositor != null) {
 					text += calculateChildRepresentation(compositor, addLinks);
@@ -220,8 +219,7 @@ public class SchemaElement extends RepeatableSchemaObject implements ISchemaElem
 		super.setParent(parent);
 		if (type != null) {
 			type.setSchema(getSchema());
-			if (type instanceof ISchemaComplexType) {
-				ISchemaComplexType ctype = (ISchemaComplexType) type;
+			if (type instanceof ISchemaComplexType ctype) {
 				ISchemaCompositor comp = ctype.getCompositor();
 				if (comp != null) {
 					comp.setParent(this);
@@ -318,8 +316,7 @@ public class SchemaElement extends RepeatableSchemaObject implements ISchemaElem
 			writer.println(indent2 + "</annotation>"); //$NON-NLS-1$
 		}
 
-		if (type instanceof SchemaComplexType) {
-			SchemaComplexType complexType = (SchemaComplexType) type;
+		if (type instanceof SchemaComplexType complexType) {
 			complexType.write(indent2, writer);
 		}
 		writer.println(indent + "</element>"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaInclude.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaInclude.java
@@ -126,8 +126,7 @@ public class SchemaInclude extends SchemaObject implements ISchemaInclude {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ISchemaInclude) {
-			ISchemaInclude other = (ISchemaInclude) obj;
+		if (obj instanceof ISchemaInclude other) {
 			if (fLocation != null) {
 				return fLocation.equals(other.getLocation());
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/DirectoryBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/DirectoryBundleContainer.java
@@ -123,8 +123,7 @@ public class DirectoryBundleContainer extends AbstractBundleContainer {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof DirectoryBundleContainer) {
-			DirectoryBundleContainer dbc = (DirectoryBundleContainer) o;
+		if (o instanceof DirectoryBundleContainer dbc) {
 			return fPath.equals(dbc.fPath);
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/ExternalFileTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/ExternalFileTargetHandle.java
@@ -105,8 +105,7 @@ public class ExternalFileTargetHandle extends AbstractTargetHandle {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ExternalFileTargetHandle) {
-			ExternalFileTargetHandle target = (ExternalFileTargetHandle) obj;
+		if (obj instanceof ExternalFileTargetHandle target) {
 			return target.getLocation().equals(fURI);
 		}
 		return super.equals(obj);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/FeatureBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/FeatureBundleContainer.java
@@ -200,8 +200,7 @@ public class FeatureBundleContainer extends AbstractBundleContainer {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof FeatureBundleContainer) {
-			FeatureBundleContainer fbc = (FeatureBundleContainer) o;
+		if (o instanceof FeatureBundleContainer fbc) {
 			return fHome.equals(fbc.fHome) && fId.equals(fbc.fId) && isNullOrEqual(fVersion, fVersion);
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IUBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IUBundleContainer.java
@@ -505,10 +505,9 @@ public class IUBundleContainer extends AbstractBundleContainer {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof IUBundleContainer)) {
+		if (!(obj instanceof IUBundleContainer other)) {
 			return false;
 		}
-		IUBundleContainer other = (IUBundleContainer) obj;
 		if (getIncludeAllRequired() != other.getIncludeAllRequired()) {
 			return false;
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/LocalTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/LocalTargetHandle.java
@@ -154,8 +154,7 @@ public class LocalTargetHandle extends AbstractTargetHandle {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof LocalTargetHandle) {
-			LocalTargetHandle handle = (LocalTargetHandle) obj;
+		if (obj instanceof LocalTargetHandle handle) {
 			return handle.fTimeStamp == fTimeStamp;
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
@@ -583,8 +583,7 @@ public class P2TargetUtils {
 			return installedIUs.isEmpty();
 		}
 		for (ITargetLocation container : containers) {
-			if (container instanceof IUBundleContainer) {
-				IUBundleContainer bc = (IUBundleContainer) container;
+			if (container instanceof IUBundleContainer bc) {
 				String[] ids = bc.getIds();
 				Version[] versions = bc.getVersions();
 				for (int j = 0; j < versions.length; j++) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/ProfileBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/ProfileBundleContainer.java
@@ -288,8 +288,7 @@ public class ProfileBundleContainer extends AbstractBundleContainer {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof ProfileBundleContainer) {
-			ProfileBundleContainer pbc = (ProfileBundleContainer) o;
+		if (o instanceof ProfileBundleContainer pbc) {
 			return fHome.equals(pbc.fHome) && isNullOrEqual(pbc.fConfiguration, fConfiguration);
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/RemoteTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/RemoteTargetHandle.java
@@ -68,8 +68,7 @@ public class RemoteTargetHandle implements ITargetHandle {
 						state = file.isFile() ? RemoteState.EXISTS : RemoteState.NOT_FOUND;
 					} else {
 						URLConnection connection = uri.toURL().openConnection();
-						if (connection instanceof HttpURLConnection) {
-							HttpURLConnection http = (HttpURLConnection) connection;
+						if (connection instanceof HttpURLConnection http) {
 							try {
 								http.setInstanceFollowRedirects(true);
 								http.setRequestMethod("HEAD"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
@@ -1219,9 +1219,8 @@ public class TargetDefinition implements ITargetDefinition {
 		NodeList nodes = containersElement.getChildNodes();
 		for (int j = 0; j < nodes.getLength(); j++) {
 			Node node = nodes.item(j);
-			if (node instanceof Element
+			if (node instanceof Element element
 					&& node.getNodeName().equalsIgnoreCase(TargetDefinitionPersistenceHelper.LOCATION)) {
-				Element element = (Element) node;
 				String type = (element).getAttribute(TargetDefinitionPersistenceHelper.ATTR_LOCATION_TYPE);
 				switch (type) {
 				case IUBundleContainer.TYPE:

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/WorkspaceFileTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/WorkspaceFileTargetHandle.java
@@ -106,8 +106,7 @@ public class WorkspaceFileTargetHandle extends AbstractTargetHandle {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof WorkspaceFileTargetHandle) {
-			WorkspaceFileTargetHandle handle = (WorkspaceFileTargetHandle) obj;
+		if (obj instanceof WorkspaceFileTargetHandle handle) {
 			return fFile.equals(handle.fFile);
 		}
 		return false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/update/configurator/VersionedIdentifier.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/update/configurator/VersionedIdentifier.java
@@ -44,11 +44,10 @@ class VersionedIdentifier {
 		if (this == obj) {
 			return true;
 		}
-		if (!(obj instanceof VersionedIdentifier)) {
+		if (!(obj instanceof VersionedIdentifier other)) {
 			return false;
 		}
 
-		VersionedIdentifier other = (VersionedIdentifier) obj;
 		if (!equalIdentifiers(other)) {
 			return false;
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDESchemaHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDESchemaHelper.java
@@ -63,8 +63,7 @@ public class PDESchemaHelper {
 		if (restriction != null) {
 			Object[] children = restriction.getChildren();
 			for (Object child : children) {
-				if (child instanceof ISchemaEnumeration) {
-					ISchemaEnumeration enumeration = (ISchemaEnumeration) child;
+				if (child instanceof ISchemaEnumeration enumeration) {
 					String value = enumeration.getName();
 					if (value != null && value.length() > 0) {
 						attributeMap.put(value, null);
@@ -146,8 +145,7 @@ public class PDESchemaHelper {
 	}
 
 	private static String buildBasedOnValue(ISchemaObject object) {
-		if (object instanceof ISchemaElement && !(object instanceof ISchemaRootElement)) {
-			ISchemaElement schemaElement = (ISchemaElement) object;
+		if (object instanceof ISchemaElement schemaElement && !(object instanceof ISchemaRootElement)) {
 			ISchema schema = schemaElement.getSchema();
 			ISchemaElement[] elements = schema.getElements();
 			for (ISchemaElement element : elements) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PackageFragmentRootPropertyTester.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PackageFragmentRootPropertyTester.java
@@ -42,8 +42,7 @@ public class PackageFragmentRootPropertyTester extends PropertyTester {
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
 		if (property.equals(PROP_IN_PLUGIN_CONTAINER)) {
 
-			if (receiver instanceof IPackageFragmentRoot) {
-				IPackageFragmentRoot element = (IPackageFragmentRoot) receiver;
+			if (receiver instanceof IPackageFragmentRoot element) {
 				try {
 					IClasspathEntry entry = element.getRawClasspathEntry();
 					IPath path = entry.getPath();

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/DocumentObject.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/DocumentObject.java
@@ -136,8 +136,7 @@ public abstract class DocumentObject extends DocumentElementNode implements IDoc
 	 * @param newValue
 	 */
 	private void firePropertyChanged(Object object, String property, Object oldValue, Object newValue) {
-		if (fModel.isEditable() && (fModel instanceof IModelChangeProvider)) {
-			IModelChangeProvider provider = (IModelChangeProvider) fModel;
+		if (fModel.isEditable() && (fModel instanceof IModelChangeProvider provider)) {
 			provider.fireModelObjectChanged(object, property, oldValue, newValue);
 		}
 	}
@@ -155,8 +154,7 @@ public abstract class DocumentObject extends DocumentElementNode implements IDoc
 	 * @param changeType
 	 */
 	protected void fireStructureChanged(Object[] children, int changeType) {
-		if (fModel.isEditable() && (fModel instanceof IModelChangeProvider)) {
-			IModelChangeProvider provider = (IModelChangeProvider) fModel;
+		if (fModel.isEditable() && (fModel instanceof IModelChangeProvider provider)) {
 			IModelChangedEvent event = new ModelChangedEvent(provider, changeType, children, null);
 			provider.fireModelChanged(event);
 		}

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/BundleTextChangeListener.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/BundleTextChangeListener.java
@@ -92,8 +92,7 @@ public class BundleTextChangeListener extends AbstractKeyValueTextChangeListener
 				object = ((PackageFriend) object).getHeader();
 			}
 
-			if (object instanceof ManifestHeader) {
-				ManifestHeader header = (ManifestHeader) object;
+			if (object instanceof ManifestHeader header) {
 				Object op = fOperationTable.remove(header);
 				if (fReadableNames != null) {
 					fReadableNames.remove(op);

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginBaseNode.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginBaseNode.java
@@ -35,8 +35,7 @@ public abstract class PluginBaseNode extends PluginObjectNode implements IPlugin
 	@Override
 	public void add(IPluginLibrary library) throws CoreException {
 		IDocumentElementNode parent = getEnclosingElement("runtime", true); //$NON-NLS-1$
-		if (library instanceof PluginLibraryNode) {
-			PluginLibraryNode node = (PluginLibraryNode) library;
+		if (library instanceof PluginLibraryNode node) {
 			node.setModel(getModel());
 			parent.addChildNode(node);
 			fireStructureChanged(library, IModelChangedEvent.INSERT);
@@ -46,8 +45,7 @@ public abstract class PluginBaseNode extends PluginObjectNode implements IPlugin
 	@Override
 	public void add(IPluginImport pluginImport) throws CoreException {
 		IDocumentElementNode parent = getEnclosingElement("requires", true); //$NON-NLS-1$
-		if (pluginImport instanceof PluginImportNode) {
-			PluginImportNode node = (PluginImportNode) pluginImport;
+		if (pluginImport instanceof PluginImportNode node) {
 			parent.addChildNode(node);
 			fireStructureChanged(pluginImport, IModelChangedEvent.INSERT);
 		}
@@ -56,8 +54,7 @@ public abstract class PluginBaseNode extends PluginObjectNode implements IPlugin
 	public void add(IPluginImport[] pluginImports) {
 		IDocumentElementNode parent = getEnclosingElement("requires", true); //$NON-NLS-1$
 		for (IPluginImport pluginImport : pluginImports) {
-			if (pluginImport != null && pluginImport instanceof PluginImportNode) {
-				PluginImportNode node = (PluginImportNode) pluginImport;
+			if (pluginImport != null && pluginImport instanceof PluginImportNode node) {
 				parent.addChildNode(node);
 			}
 		}
@@ -198,8 +195,7 @@ public abstract class PluginBaseNode extends PluginObjectNode implements IPlugin
 
 	@Override
 	public void add(IPluginExtension extension) throws CoreException {
-		if (extension instanceof PluginExtensionNode) {
-			PluginExtensionNode node = (PluginExtensionNode) extension;
+		if (extension instanceof PluginExtensionNode node) {
 			node.setModel(getModel());
 			addChildNode(node);
 			fireStructureChanged(extension, IModelChangedEvent.INSERT);
@@ -226,8 +222,7 @@ public abstract class PluginBaseNode extends PluginObjectNode implements IPlugin
 
 	@Override
 	public void add(IPluginExtensionPoint extensionPoint) throws CoreException {
-		if (extensionPoint instanceof PluginExtensionPointNode) {
-			PluginExtensionPointNode node = (PluginExtensionPointNode) extensionPoint;
+		if (extensionPoint instanceof PluginExtensionPointNode node) {
 			node.setModel(getModel());
 			extensionPoint.setInTheModel(true);
 			node.setParentNode(this);

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginObjectNode.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginObjectNode.java
@@ -170,8 +170,7 @@ public class PluginObjectNode extends DocumentElementNode implements IPluginObje
 
 	private void fireModelChanged(IModelChangedEvent e) {
 		IModel model = getModel();
-		if (model.isEditable() && model instanceof IModelChangeProvider) {
-			IModelChangeProvider provider = (IModelChangeProvider) model;
+		if (model.isEditable() && model instanceof IModelChangeProvider provider) {
 			provider.fireModelChanged(e);
 		}
 	}

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/XMLTextChangeListener.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/XMLTextChangeListener.java
@@ -468,10 +468,9 @@ public class XMLTextChangeListener extends AbstractTextChangeListener {
 			return;
 		}
 		for (int i = 0; i < objects.length; i++) {
-			if (!(objects[i] instanceof IDocumentElementNode)) {
+			if (!(objects[i] instanceof IDocumentElementNode node)) {
 				continue;
 			}
-			IDocumentElementNode node = (IDocumentElementNode) objects[i];
 			Object op = fOperationTable.remove(node);
 			fOperationList.remove(op);
 			if (fReadableNames != null) {


### PR DESCRIPTION
The commit tries to implement a code cleanup in pattern matching using instanceof operator according to Java 16 guidelines, making the code more concise.
The change has been applied in org.eclipse.pde.core project.

Kindly review @akurtakov @iloveeclipse @vik-chand @gireeshpunathil and do let me know in case of any edits.