### PR TITLE
Handle missing default VMInstall when querying JVM system-packages

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -532,14 +532,18 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 				if (javaPackages == null) {
 					String profileSystemPackages = preJava9ProfileProperties.getProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, ""); //$NON-NLS-1$
 					if (profileSystemPackages.isBlank()) {
-						return null;
+						return List.of();
 					}
 					javaPackages = COMMA.splitAsStream(profileSystemPackages).filter(p -> p.startsWith("java.")).toList(); //$NON-NLS-1$
 				}
 				IVMInstall targetVM = JavaRuntime.getDefaultVMInstall(); // Set by the Target-Definition if specified there
+				if (targetVM == null) {
+					LOGGER.warn("No default JRE installation selected"); //$NON-NLS-1$
+					return List.of();
+				}
 				Collection<String> targetVMSystemPackages = querySystemPackages(targetVM, null);
 				if (targetVMSystemPackages == null) {
-					return null;
+					return List.of();
 				}
 				Stream<String> targetVMNonJavaPackages = targetVMSystemPackages.stream().filter(p -> !p.startsWith("java.")); //$NON-NLS-1$
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/721

This handles the case that `JavaRuntime.getDefaultVMInstall()` returns null, which according to the docs happens
`when no defaultVM was set or when the default VM has been disposed.`

I also considered to just select any of the available VMs, maybe the 'latest' one, but since no default JRE should actually not happen (at least I get an error in the preferences if I don't select one), for me it seems to be better to warn the user about that instead of selecting just any VM.

@akurtakov should we merge this now to have this in RC1 or better wait for RC2?