### PR TITLE
StringIndexOutOfBoundsException when creating a new PDE project

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -656,10 +656,10 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 					try (ZipFile zip = new ZipFile(path.toFile())) {
 						// Collect names of all directories that contain a .class file
 						zip.stream().filter(e -> !e.isDirectory()).map(ZipEntry::getName) //
-								.filter(n -> n.endsWith(".class")) //$NON-NLS-1$
+								.filter(n -> n.endsWith(".class") && n.indexOf('/') > 0) //$NON-NLS-1$
 								.map(n -> n.substring(0, n.lastIndexOf('/'))) //
 								.forEach(classFileDirectories::add);
-					} catch (IOException e) {
+					} catch (Exception e) {
 						LOGGER.error("Failed to read packages in JVM library for " + vm + ", at " + path, e); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				}


### PR DESCRIPTION
Don't try to map class files in the root directories and catch whatever obscure exception may be thrown to avoid basic functionality to be broken.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/724