### PR TITLE
Run/ Debug Configurations tab Plug-ins issue #311

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
@@ -1113,12 +1113,12 @@ public abstract class AbstractPluginBlock {
 	}
 
 	protected final void initializePluginsState(Map<IPluginModelBase, String> selectedPlugins) {
+		fPluginTreeViewer.setCheckedElements(selectedPlugins.keySet().toArray());
 		for (Entry<IPluginModelBase, String> entry : selectedPlugins.entrySet()) {
 			IPluginModelBase model = entry.getKey();
 			setText(model, entry.getValue());
 		}
 
-		fPluginTreeViewer.setCheckedElements(selectedPlugins.keySet().toArray());
 		countSelectedModels();
 		resetGroup(fWorkspacePlugins);
 		resetGroup(fExternalPlugins);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/CachedCheckboxTreeViewer.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/CachedCheckboxTreeViewer.java
@@ -161,7 +161,7 @@ public class CachedCheckboxTreeViewer extends ContainerCheckedTreeViewer {
 
 	@Override
 	public void setCheckedElements(Object[] elements) {
-		super.setCheckedElements(elements);
+
 		if (checkState == null) {
 			checkState = new HashSet<>();
 		} else {
@@ -180,6 +180,7 @@ public class CachedCheckboxTreeViewer extends ContainerCheckedTreeViewer {
 				}
 			}
 		}
+		super.setCheckedElements(elements);
 	}
 
 	@Override


### PR DESCRIPTION
In Run/Debug configurations when changing Start Level/ Auto-Start for some plug-ins and apply the changes,
and closing and reopening the popup will make changes to disappear provided "Only show selected" is selected.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/311