### PR TITLE
Simplify UpdateClasspathJob

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathupdater/ClasspathUpdaterTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathupdater/ClasspathUpdaterTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ *  Copyright (c) 2023, 2023 Michael Haubenwallner and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Michael Haubenwallner - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.pde.ui.tests.classpathupdater;
 
 import static org.junit.Assert.assertEquals;
@@ -5,6 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -12,6 +26,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
@@ -163,8 +178,7 @@ public class ClasspathUpdaterTest {
 
 	private void runUpdateClasspathJob() throws InterruptedException {
 		IPluginModelBase model = PluginRegistry.findModel(project.getProject());
-		UpdateClasspathJob job = new UpdateClasspathJob(new IPluginModelBase[] { model });
-		job.schedule();
+		Job job = UpdateClasspathJob.scheduleFor(List.of(model), false);
 		job.join();
 		assertTrue("Update Classpath Job failed", job.getResult().isOK());
 	}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExecutionEnvironmentTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExecutionEnvironmentTests.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Hashtable;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -257,10 +258,7 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 
 			// updating class path should increase severity to warning
 			IPluginModelBase model = PluginRegistry.findModel(project.getProject());
-			UpdateClasspathJob job = new UpdateClasspathJob(new IPluginModelBase[] { model });
-			job.schedule();
-			job.join();
-
+			UpdateClasspathJob.scheduleFor(List.of(model), false).join();
 			// re-validate options
 			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
@@ -305,9 +303,7 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 
 			// updating class path should increase severity to warning
 			IPluginModelBase model = PluginRegistry.findModel(project.getProject());
-			UpdateClasspathJob job = new UpdateClasspathJob(new IPluginModelBase[] { model });
-			job.schedule();
-			job.join();
+			UpdateClasspathJob.scheduleFor(List.of(model), false).join();
 
 			// re-validate options
 			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateBuildpathWizard.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateBuildpathWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *  Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.wizards.tools;
 
-import org.eclipse.core.runtime.jobs.Job;
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -48,16 +50,13 @@ public class UpdateBuildpathWizard extends Wizard {
 
 	@Override
 	public boolean performFinish() {
-		if (!PlatformUI.getWorkbench().saveAllEditors(true))
+		if (!PlatformUI.getWorkbench().saveAllEditors(true)) {
 			return false;
-
+		}
 		Object[] finalSelected = page1.getSelected();
 		page1.storeSettings();
-		IPluginModelBase[] modelArray = new IPluginModelBase[finalSelected.length];
-		System.arraycopy(finalSelected, 0, modelArray, 0, finalSelected.length);
-		Job j = new UpdateClasspathJob(modelArray);
-		j.setUser(true);
-		j.schedule();
+		List<IPluginModelBase> modelArray = Arrays.stream(finalSelected).map(IPluginModelBase.class::cast).toList();
+		UpdateClasspathJob.scheduleFor(modelArray, true);
 		return true;
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateClasspathJob.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateClasspathJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *  Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -10,95 +10,73 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Simplify UpdateClasspathJob and leverage the implicit cancellation checks and progress reporting of SubMonitor.split()
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.wizards.tools;
+
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.ClasspathComputer;
 import org.eclipse.pde.internal.core.builders.PDEMarkerFactory;
-import org.eclipse.pde.internal.ui.IPDEUIConstants;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 
-public class UpdateClasspathJob extends Job {
-	IPluginModelBase[] fModels;
-
-	public UpdateClasspathJob(IPluginModelBase[] models) {
-		super(PDEUIMessages.UpdateClasspathJob_title);
-		setPriority(Job.LONG);
-		fModels = models;
+public class UpdateClasspathJob {
+	private UpdateClasspathJob() {
 	}
 
-	public boolean doUpdateClasspath(IProgressMonitor monitor, IPluginModelBase[] models) throws CoreException {
-		monitor.beginTask(PDEUIMessages.UpdateClasspathJob_task, models.length);
-		try {
-			for (IPluginModelBase model : models) {
-				monitor.subTask(model.getPluginBase().getId());
-				// no reason to compile classpath for a non-Java model
-				IProject project = model.getUnderlyingResource().getProject();
-				if (!project.hasNature(JavaCore.NATURE_ID)) {
-					monitor.worked(1);
-					continue;
+	public static Job scheduleFor(List<IPluginModelBase> models, boolean user) {
+		WorkspaceJob job = new WorkspaceJob(PDEUIMessages.UpdateClasspathJob_title) {
+			@Override
+			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+				SubMonitor mon = SubMonitor.convert(monitor, PDEUIMessages.UpdateClasspathJob_task, models.size());
+				for (IPluginModelBase model : models) {
+					updateClasspath(model, mon.split(1));
 				}
-				IProjectDescription projDesc = project.getDescription();
-				if (projDesc == null)
-					continue;
-				projDesc.setReferencedProjects(new IProject[0]);
-				project.setDescription(projDesc, null);
-				IFile file = project.getFile(".project"); //$NON-NLS-1$
-				if (file.exists())
-					file.deleteMarkers(PDEMarkerFactory.MARKER_ID, true, IResource.DEPTH_ZERO);
-				ClasspathComputer.setClasspath(project, model);
-				monitor.worked(1);
-				if (monitor.isCanceled())
-					return false;
+				return Status.OK_STATUS;
 			}
-		} finally {
-			monitor.done();
-		}
-		return true;
+		};
+		job.setUser(user);
+		job.setPriority(Job.LONG);
+		job.schedule();
+		return job;
 	}
 
-	class UpdateClasspathWorkspaceRunnable implements IWorkspaceRunnable {
-		boolean fCanceled = false;
-
-		@Override
-		public void run(IProgressMonitor monitor) throws CoreException {
-			fCanceled = !doUpdateClasspath(monitor, fModels);
-		}
-
-		public boolean isCanceled() {
-			return fCanceled;
-		}
-	}
-
-	@Override
-	protected IStatus run(IProgressMonitor monitor) {
+	private static void updateClasspath(IPluginModelBase model, SubMonitor monitor) throws CoreException {
 		try {
-			UpdateClasspathWorkspaceRunnable runnable = new UpdateClasspathWorkspaceRunnable();
-			PDEPlugin.getWorkspace().run(runnable, monitor);
-			if (runnable.isCanceled()) {
-				return new Status(IStatus.CANCEL, IPDEUIConstants.PLUGIN_ID, IStatus.CANCEL, "", null); //$NON-NLS-1$
+			monitor.subTask(model.getPluginBase().getId());
+			// no reason to compile classpath for a non-Java model
+			IProject project = model.getUnderlyingResource().getProject();
+			if (project.hasNature(JavaCore.NATURE_ID)) {
+				IProjectDescription projDesc = project.getDescription();
+				if (projDesc != null) {
+					projDesc.setReferencedProjects(new IProject[0]);
+					project.setDescription(projDesc, null);
+					IFile file = project.getFile(".project"); //$NON-NLS-1$
+					if (file.exists()) {
+						file.deleteMarkers(PDEMarkerFactory.MARKER_ID, true, IResource.DEPTH_ZERO);
+					}
+					ClasspathComputer.setClasspath(project, model);
+				}
 			}
-
 		} catch (CoreException e) {
-			String title = PDEUIMessages.UpdateClasspathJob_error_title;
 			String message = PDEUIMessages.UpdateClasspathJob_error_message;
-			PDEPlugin.logException(e, title, message);
-			return Status.error(message, e);
+			PDEPlugin.logException(e, PDEUIMessages.UpdateClasspathJob_error_title, message);
+			throw new CoreException(Status.error(message, e));
 		}
-		return Status.OK_STATUS;
 	}
 
 }


### PR DESCRIPTION
Leverage the implicit cancellation checks and progress reporting of `SubMonitor.split()`.

@haubi since you worked on the `ClasspathUpdate` recently, maybe you are interested in this as well?