### PR TITLE
Remove unused attributes in auto-generated feature.xml

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureErrorReporter.java
@@ -31,7 +31,6 @@ import org.eclipse.pde.internal.core.builders.IncrementalErrorReporter.VirtualMa
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModel;
 import org.eclipse.pde.internal.core.ibundle.IManifestHeader;
 import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
-import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.core.util.IdUtil;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
@@ -110,12 +109,11 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 			assertAttributeDefined(plugin, "id", CompilerFlags.ERROR); //$NON-NLS-1$
 			assertAttributeDefined(plugin, "version", CompilerFlags.ERROR); //$NON-NLS-1$
 			NamedNodeMap attributes = plugin.getAttributes();
-			boolean isFragment = plugin.getAttribute("fragment").equals("true"); //$NON-NLS-1$ //$NON-NLS-2$
 			for (int j = 0; j < attributes.getLength(); j++) {
 				Attr attr = (Attr) attributes.item(j);
 				String name = attr.getName();
 				if (name.equals("id")) { //$NON-NLS-1$
-					validatePluginExists(plugin, attr, isFragment);
+					validatePluginExists(plugin, attr);
 				} else if (name.equals("version")) { //$NON-NLS-1$
 					validateVersionAttribute(plugin, attr);
 					validateVersion(plugin, attr);
@@ -153,7 +151,7 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 			} else if (plugin != null && feature != null) {
 				reportExclusiveAttributes(element, "plugin", "feature", CompilerFlags.ERROR); //$NON-NLS-1$//$NON-NLS-2$
 			} else if (plugin != null) {
-				validatePluginExists(element, plugin, false);
+				validatePluginExists(element, plugin);
 			} else if (feature != null) {
 				validateFeatureExists(element, feature);
 			}
@@ -382,7 +380,7 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 			if (name.equals("primary")) { //$NON-NLS-1$
 				reportDeprecatedAttribute(element, (Attr) attributes.item(i));
 			} else if (name.equals("plugin")) { //$NON-NLS-1$
-				validatePluginExists(element, (Attr) attributes.item(i), false);
+				validatePluginExists(element, (Attr) attributes.item(i));
 			}
 		}
 	}
@@ -405,12 +403,12 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 		return true;
 	}
 
-	private void validatePluginExists(Element element, Attr attr, boolean isFragment) {
+	private void validatePluginExists(Element element, Attr attr) {
 		String id = attr.getValue();
 		int severity = CompilerFlags.getFlag(fProject, CompilerFlags.F_UNRESOLVED_PLUGINS);
 		if (severity != CompilerFlags.IGNORE) {
 			IPluginModelBase model = PluginRegistry.findModel(id);
-			if (model == null || !model.isEnabled() || (isFragment && !model.isFragmentModel()) || (!isFragment && model.isFragmentModel())) {
+			if (model == null || !model.isEnabled() || model.isFragmentModel()) {
 				VirtualMarker marker = report(NLS.bind(PDECoreMessages.Builders_Feature_reference, id), getLine(element, attr.getName()), severity, PDEMarkerFactory.CAT_OTHER);
 				addMarkerAttribute(marker, PDEMarkerFactory.compilerKey,  CompilerFlags.F_UNRESOLVED_PLUGINS);
 			}
@@ -459,12 +457,6 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 					addMarkerAttribute(marker, PDEMarkerFactory.compilerKey,  CompilerFlags.F_UNRESOLVED_PLUGINS);
 				}
 			}
-		}
-
-		if ("true".equals(unpack) && !CoreUtility.guessUnpack(pModel.getBundleDescription())) {//$NON-NLS-1$
-			String message = NLS.bind(PDECoreMessages.Builders_Feature_missingUnpackFalse, (new String[] {parent.getAttribute("id"), "unpack=\"false\""})); //$NON-NLS-1$ //$NON-NLS-2$
-			VirtualMarker marker = report(message, getLine(parent), severity, PDEMarkerFactory.CAT_OTHER);
-			addMarkerAttribute(marker, PDEMarkerFactory.compilerKey,  CompilerFlags.F_UNRESOLVED_PLUGINS);
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/FeatureExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/FeatureExportOperation.java
@@ -118,8 +118,8 @@ public class FeatureExportOperation extends Job {
 
 	protected State fStateCopy;
 
-	protected static String FEATURE_POST_PROCESSING = "features.postProcessingSteps.properties"; //$NON-NLS-1$
-	protected static String PLUGIN_POST_PROCESSING = "plugins.postProcessingSteps.properties"; //$NON-NLS-1$
+	protected static final String FEATURE_POST_PROCESSING = "features.postProcessingSteps.properties"; //$NON-NLS-1$
+	protected static final String PLUGIN_POST_PROCESSING = "plugins.postProcessingSteps.properties"; //$NON-NLS-1$
 
 	private static final String[] GENERIC_CONFIG = new String[] {"*", "*", "*", ""}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	protected FeatureExportInfo fInfo;
@@ -1159,7 +1159,6 @@ public class FeatureExportOperation extends Job {
 							plugin.setAttribute("id", bundle.getSymbolicName()); //$NON-NLS-1$
 							plugin.setAttribute("version", bundle.getVersion().toString()); //$NON-NLS-1$
 							setFilterAttributes(plugin, currentConfig);
-							setAdditionalAttributes(plugin, bundle);
 							root.appendChild(plugin);
 
 							if (fInfo.exportSource && fInfo.exportSourceBundle) {
@@ -1168,7 +1167,6 @@ public class FeatureExportOperation extends Job {
 									plugin.setAttribute("id", bundle.getSymbolicName() + ".source"); //$NON-NLS-1$ //$NON-NLS-2$
 									plugin.setAttribute("version", bundle.getVersion().toString()); //$NON-NLS-1$
 									setFilterAttributes(plugin, currentConfig);
-									setAdditionalAttributes(plugin, bundle);
 									root.appendChild(plugin);
 								} else // include the .source plugin, if available
 								{
@@ -1179,7 +1177,6 @@ public class FeatureExportOperation extends Job {
 										plugin.setAttribute("id", bundle.getSymbolicName()); //$NON-NLS-1$
 										plugin.setAttribute("version", bundle.getVersion().toString()); //$NON-NLS-1$
 										setFilterAttributes(plugin, currentConfig);
-										setAdditionalAttributes(plugin, bundle);
 										root.appendChild(plugin);
 									}
 								}
@@ -1201,9 +1198,6 @@ public class FeatureExportOperation extends Job {
 	static boolean isWorkspacePlugin(BundleDescription bundle) {
 		ModelEntry entry = PluginRegistry.findEntry(bundle.getSymbolicName());
 		return entry != null && Arrays.asList(entry.getWorkspaceModels()).contains(PluginRegistry.findModel(bundle));
-	}
-
-	protected void setAdditionalAttributes(Element plugin, BundleDescription bundle) {
 	}
 
 	public static void errorFound() {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/PluginExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/PluginExportOperation.java
@@ -20,8 +20,6 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
-import org.eclipse.pde.internal.core.util.CoreUtility;
-import org.w3c.dom.Element;
 
 public class PluginExportOperation extends FeatureBasedExportOperation {
 
@@ -61,10 +59,4 @@ public class PluginExportOperation extends FeatureBasedExportOperation {
 		// always include plug-ins, even ones with environment conflicts
 		return true;
 	}
-
-	@Override
-	protected void setAdditionalAttributes(Element plugin, BundleDescription bundle) {
-		plugin.setAttribute("unpack", Boolean.toString(CoreUtility.guessUnpack(bundle))); //$NON-NLS-1$
-	}
-
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/ProductExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/ProductExportOperation.java
@@ -52,7 +52,6 @@ import org.eclipse.pde.internal.core.iproduct.IJREInfo;
 import org.eclipse.pde.internal.core.iproduct.ILauncherInfo;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
 import org.eclipse.pde.internal.core.util.CoreUtility;
-import org.w3c.dom.Element;
 
 public class ProductExportOperation extends FeatureExportOperation {
 	private static final String STATUS_MESSAGE = "!MESSAGE"; //$NON-NLS-1$
@@ -488,10 +487,5 @@ public class ProductExportOperation extends FeatureExportOperation {
 		} finally {
 		}
 		return null;
-	}
-
-	@Override
-	protected void setAdditionalAttributes(Element plugin, BundleDescription bundle) {
-		plugin.setAttribute("unpack", Boolean.toString(CoreUtility.guessUnpack(bundle))); //$NON-NLS-1$
 	}
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeatureData.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeatureData.java
@@ -29,8 +29,6 @@ public class FeatureData extends IdentifiableObject implements IFeatureData {
 	private String nl;
 	private String arch;
 	private String filter;
-	private long downloadSize;
-	private long installSize;
 
 	public FeatureData() {
 	}
@@ -42,8 +40,6 @@ public class FeatureData extends IdentifiableObject implements IFeatureData {
 		ws = null;
 		nl = null;
 		arch = null;
-		downloadSize = 0;
-		installSize = 0;
 	}
 
 	@Override
@@ -64,8 +60,6 @@ public class FeatureData extends IdentifiableObject implements IFeatureData {
 		nl = getNodeAttribute(node, "nl"); //$NON-NLS-1$
 		arch = getNodeAttribute(node, "arch"); //$NON-NLS-1$
 		filter = getNodeAttribute(node, "filter"); //$NON-NLS-1$
-		downloadSize = getIntegerAttribute(node, "download-size"); //$NON-NLS-1$
-		installSize = getIntegerAttribute(node, "install-size"); //$NON-NLS-1$
 	}
 
 	protected void writeAttributes(String indent2, PrintWriter writer) {
@@ -75,10 +69,6 @@ public class FeatureData extends IdentifiableObject implements IFeatureData {
 		writeAttribute("nl", getNL(), indent2, writer); //$NON-NLS-1$
 		writeAttribute("arch", getArch(), indent2, writer); //$NON-NLS-1$
 		writeAttribute("filter", getFilter(), indent2, writer); //$NON-NLS-1$
-		writer.println();
-		writer.print(indent2 + "download-size=\"" + getDownloadSize() + "\""); //$NON-NLS-1$ //$NON-NLS-2$
-		writer.println();
-		writer.print(indent2 + "install-size=\"" + getInstallSize() + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private void writeAttribute(String attribute, String value, String indent2, PrintWriter writer) {
@@ -205,48 +195,6 @@ public class FeatureData extends IdentifiableObject implements IFeatureData {
 		firePropertyChanged(P_FILTER, oldValue, filter);
 	}
 
-	/**
-	 * Gets the downloadSize.
-	 * @return Returns a int
-	 */
-	@Override
-	public long getDownloadSize() {
-		return downloadSize;
-	}
-
-	/**
-	 * Sets the downloadSize.
-	 * @param downloadSize The downloadSize to set
-	 */
-	@Override
-	public void setDownloadSize(long downloadSize) throws CoreException {
-		ensureModelEditable();
-		Object oldValue = Long.valueOf(this.downloadSize);
-		this.downloadSize = downloadSize;
-		firePropertyChanged(P_DOWNLOAD_SIZE, oldValue, Long.valueOf(downloadSize));
-	}
-
-	/**
-	 * Gets the installSize.
-	 * @return Returns a int
-	 */
-	@Override
-	public long getInstallSize() {
-		return installSize;
-	}
-
-	/**
-	 * Sets the installSize.
-	 * @param installSize The installSize to set
-	 */
-	@Override
-	public void setInstallSize(long installSize) throws CoreException {
-		ensureModelEditable();
-		Object oldValue = Long.valueOf(this.installSize);
-		this.installSize = installSize;
-		firePropertyChanged(P_INSTALL_SIZE, oldValue, Long.valueOf(installSize));
-	}
-
 	@Override
 	public void restoreProperty(String name, Object oldValue, Object newValue) throws CoreException {
 		switch (name) {
@@ -261,12 +209,6 @@ public class FeatureData extends IdentifiableObject implements IFeatureData {
 			break;
 		case P_ARCH:
 			setArch((String) newValue);
-			break;
-		case P_DOWNLOAD_SIZE:
-			setDownloadSize(newValue != null ? ((Integer) newValue).intValue() : 0);
-			break;
-		case P_INSTALL_SIZE:
-			setInstallSize(newValue != null ? ((Integer) newValue).intValue() : 0);
 			break;
 		default:
 			super.restoreProperty(name, oldValue, newValue);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeaturePlugin.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeaturePlugin.java
@@ -15,12 +15,11 @@
 package org.eclipse.pde.internal.core.feature;
 
 import java.io.PrintWriter;
+import java.util.Arrays;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.pde.core.plugin.IFragment;
-import org.eclipse.pde.core.plugin.IFragmentModel;
 import org.eclipse.pde.core.plugin.IPluginBase;
-import org.eclipse.pde.core.plugin.IPluginModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.ModelEntry;
 import org.eclipse.pde.core.plugin.PluginRegistry;
@@ -30,23 +29,17 @@ import org.w3c.dom.Node;
 
 public class FeaturePlugin extends FeatureData implements IFeaturePlugin {
 	private static final long serialVersionUID = 1L;
-	private boolean fFragment;
 	private String fVersion;
-	private boolean fUnpack = true;
-
-	public FeaturePlugin() {
-	}
 
 	@Override
 	protected void reset() {
 		super.reset();
 		fVersion = null;
-		fFragment = false;
 	}
 
 	@Override
 	public boolean isFragment() {
-		return fFragment;
+		return getPluginBase() instanceof IFragment;
 	}
 
 	public IPluginBase getPluginBase() {
@@ -61,19 +54,12 @@ public class FeaturePlugin extends FeatureData implements IFeaturePlugin {
 			ModelEntry entry = PluginRegistry.findEntry(id);
 			// if no plug-ins match the id, entry == null
 			if (entry != null) {
-				IPluginModelBase bases[] = entry.getActiveModels();
-				for (IPluginModelBase base : bases) {
-					if (base.getPluginBase().getVersion().equals(version)) {
-						model = base;
-						break;
-					}
-				}
+				model = Arrays.stream(entry.getActiveModels())
+						.filter(base -> base.getPluginBase().getVersion().equals(version))
+						.findFirst().orElse(null);
 			}
 		}
-		if (fFragment && model instanceof IFragmentModel) {
-			return model.getPluginBase();
-		}
-		if (!fFragment && model instanceof IPluginModel) {
+		if (model != null) {
 			return model.getPluginBase();
 		}
 		return null;
@@ -85,24 +71,11 @@ public class FeaturePlugin extends FeatureData implements IFeaturePlugin {
 	}
 
 	@Override
-	public boolean isUnpack() {
-		return fUnpack;
-	}
-
-	@Override
 	public void setVersion(String version) throws CoreException {
 		ensureModelEditable();
 		Object oldValue = this.fVersion;
 		this.fVersion = version;
 		firePropertyChanged(this, P_VERSION, oldValue, version);
-	}
-
-	@Override
-	public void setUnpack(boolean unpack) throws CoreException {
-		ensureModelEditable();
-		boolean oldValue = fUnpack;
-		this.fUnpack = unpack;
-		firePropertyChanged(this, P_UNPACK, Boolean.valueOf(oldValue), Boolean.valueOf(unpack));
 	}
 
 	@Override
@@ -114,30 +87,16 @@ public class FeaturePlugin extends FeatureData implements IFeaturePlugin {
 		}
 	}
 
-	public void setFragment(boolean fragment) throws CoreException {
-		ensureModelEditable();
-		this.fFragment = fragment;
-	}
-
 	@Override
 	protected void parse(Node node) {
 		super.parse(node);
 		fVersion = getNodeAttribute(node, "version"); //$NON-NLS-1$
-		String f = getNodeAttribute(node, "fragment"); //$NON-NLS-1$
-		if (f != null && f.equalsIgnoreCase("true")) { //$NON-NLS-1$
-			fFragment = true;
-		}
-		String unpack = getNodeAttribute(node, "unpack"); //$NON-NLS-1$
-		if (unpack != null && unpack.equalsIgnoreCase("false")) { //$NON-NLS-1$
-			fUnpack = false;
-		}
 	}
 
 	public void loadFrom(IPluginBase plugin) {
 		id = plugin.getId();
 		label = plugin.getTranslatedName();
 		fVersion = plugin.getVersion();
-		fFragment = plugin instanceof IFragment;
 	}
 
 	@Override
@@ -149,16 +108,7 @@ public class FeaturePlugin extends FeatureData implements IFeaturePlugin {
 			writer.println();
 			writer.print(indent2 + "version=\"" + getVersion() + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		if (isFragment()) {
-			writer.println();
-			writer.print(indent2 + "fragment=\"true\""); //$NON-NLS-1$
-		}
-		if (!isUnpack()) {
-			writer.println();
-			writer.print(indent2 + "unpack=\"false\""); //$NON-NLS-1$
-		}
 		writer.println("/>"); //$NON-NLS-1$
-		//writer.println(indent + "</plugin>");
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeatureEntry.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeatureEntry.java
@@ -26,24 +26,11 @@ public interface IFeatureEntry extends IFeatureObject, IIdentifiable, IEnvironme
 	String P_NL = "p_nl"; //$NON-NLS-1$
 	String P_ARCH = "p_arch"; //$NON-NLS-1$
 	String P_FILTER = "p_filter"; //$NON-NLS-1$
-	String P_DOWNLOAD_SIZE = "p_download_size"; //$NON-NLS-1$
-	String P_INSTALL_SIZE = "p_install_size"; //$NON-NLS-1$
 
 	/**
 	 * Returns an LDAP filter that must be satisfied for this entry
 	 */
 	String getFilter();
-
-	/**
-	 * 	Returns estimated download size of this plug-in.
-	 */
-	long getDownloadSize();
-
-	/**
-	 * Returns estimated size of this plug-in when installed.
-	 */
-	long getInstallSize();
-
 	/**
 	 * Sets an LDAP filter on this plugin
 	 */
@@ -52,10 +39,4 @@ public interface IFeatureEntry extends IFeatureObject, IIdentifiable, IEnvironme
 	/**
 	 * 	Sets the estimated download size of this plug-in.
 	 */
-	void setDownloadSize(long size) throws CoreException;
-
-	/**
-	 * Sets the estimated size of this plug-in when installed.
-	 */
-	void setInstallSize(long size) throws CoreException;
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeaturePlugin.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeaturePlugin.java
@@ -13,25 +13,13 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.ifeature;
 
-import org.eclipse.core.runtime.CoreException;
-
 /**
  * A base class for plug-in and data entires
  */
 public interface IFeaturePlugin extends IFeatureObject, IVersionable, IFeatureEntry {
 	/**
-	 * A property that will be carried by the change event
-	 * if 'unpack' field of this object is changed.
-	 */
-	public static final String P_UNPACK = "unpack"; //$NON-NLS-1$
-
-	/**
 	 * Returns whether this is a reference to a fragment.
 	 * @return <samp>true</samp> if this is a fragment, <samp>false</samp> otherwise.
 	 */
-	public boolean isFragment();
-
-	public boolean isUnpack();
-
-	public void setUnpack(boolean unpack) throws CoreException;
+	boolean isFragment();
 }

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/feature/FeatureDataTestCase.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/feature/FeatureDataTestCase.java
@@ -41,10 +41,7 @@ public class FeatureDataTestCase {
 	public void testSerialization() throws Exception {
 		String expected = String.format("<data%n" +
 				FEATURE_INDENT + "id=\"id.1\"%n" + FEATURE_INDENT + "os=\"win32\"%n" + FEATURE_INDENT
-				+ "arch=\"x86_64\"%n" + FEATURE_INDENT
-				+ "download-size=\"1000\"%n" +
-				FEATURE_INDENT + "install-size=\"0\"/>%n"
-				);
+				+ "arch=\"x86_64\"/>%n");
 		FeatureData data = newFeatureData();
 		String actual = toXml(data);
 		assertEquals(expected, actual);
@@ -54,16 +51,13 @@ public class FeatureDataTestCase {
 		assertEquals(data.getOS(), data2.getOS());
 		assertEquals(data.getArch(), data2.getArch());
 		assertEquals(data.getFilter(), data2.getFilter());
-		assertEquals(data.getDownloadSize(), data2.getDownloadSize());
 	}
 
 	@Test
 	public void testSerializationWithLdapFilter() throws CoreException {
 		String expected = String.format("<data%n" + FEATURE_INDENT + "id=\"id.1\"%n" + FEATURE_INDENT + "os=\"win32\"%n"
 				+ FEATURE_INDENT + "arch=\"x86_64\"%n" + FEATURE_INDENT
-				+ "filter=\"(&amp; (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86))\"%n" + FEATURE_INDENT
-				+ "download-size=\"1000\"%n" + FEATURE_INDENT
-				+ "install-size=\"0\"/>%n");
+				+ "filter=\"(&amp; (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86))\"/>%n");
 		FeatureData data = newFeatureData();
 		data.setFilter("(& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86))");
 		String actual = toXml(data);
@@ -79,7 +73,6 @@ public class FeatureDataTestCase {
 		data.setLabel("Feature1");
 		data.setArch("x86_64");
 		data.setOS("win32");
-		data.setDownloadSize(1000);
 		return data;
 	}
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/ProjectUtils.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/ProjectUtils.java
@@ -369,7 +369,6 @@ public class ProjectUtils {
 		IFeaturePlugin featurePlugin = feature.getModel().getFactory().createPlugin();
 		featurePlugin.setId(id);
 		featurePlugin.setVersion(version);
-		featurePlugin.setUnpack(false);
 		feature.addPlugins(new IFeaturePlugin[] { featurePlugin });
 		return featurePlugin;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -850,9 +850,6 @@ public class PDEUIMessages extends NLS {
 	public static String SiteEditor_PluginDetailsSection_title;
 	public static String SiteEditor_PluginDetailsSection_desc;
 	public static String SiteEditor_PluginDetailsSection_pluginLabel;
-	public static String SiteEditor_PluginDetailsSection_downloadSize;
-	public static String SiteEditor_PluginDetailsSection_installSize;
-	public static String SiteEditor_PluginDetailsSection_unpack;
 
 	public static String FeatureEditor_DataDetailsSection_title;
 	public static String FeatureEditor_DataDetailsSection_desc;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/PluginDetailsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/PluginDetailsSection.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.feature;
 
-import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -30,7 +28,6 @@ import org.eclipse.pde.internal.ui.editor.PDESection;
 import org.eclipse.pde.internal.ui.parts.FormEntry;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.IFormPart;
 import org.eclipse.ui.forms.IManagedForm;
@@ -44,14 +41,6 @@ public class PluginDetailsSection extends PDESection implements IPartSelectionLi
 	private FormEntry fNameText;
 
 	private FormEntry fVersionText;
-
-	private FormEntry fdownloadSizeText;
-
-	private FormEntry fInstallSizeText;
-
-	private Button fUnpackButton;
-
-	private boolean fBlockNotification;
 
 	public PluginDetailsSection(PDEFormPage page, Composite parent) {
 		this(page, parent, PDEUIMessages.SiteEditor_PluginDetailsSection_title, PDEUIMessages.SiteEditor_PluginDetailsSection_desc, SWT.NULL);
@@ -67,16 +56,12 @@ public class PluginDetailsSection extends PDESection implements IPartSelectionLi
 	@Override
 	public void cancelEdit() {
 		fVersionText.cancelEdit();
-		fdownloadSizeText.cancelEdit();
-		fInstallSizeText.cancelEdit();
 		super.cancelEdit();
 	}
 
 	@Override
 	public void commit(boolean onSave) {
 		fVersionText.commit();
-		fdownloadSizeText.commit();
-		fInstallSizeText.commit();
 		super.commit(onSave);
 	}
 
@@ -110,52 +95,6 @@ public class PluginDetailsSection extends PDESection implements IPartSelectionLi
 		});
 		limitTextWidth(fVersionText);
 		fVersionText.setEditable(isEditable());
-
-		fdownloadSizeText = new FormEntry(container, toolkit, PDEUIMessages.SiteEditor_PluginDetailsSection_downloadSize, null, false);
-		fdownloadSizeText.setFormEntryListener(new FormEntryAdapter(this) {
-
-			@Override
-			public void textValueChanged(FormEntry text) {
-				if (fInput != null)
-					try {
-						fInput.setDownloadSize(getLong(text.getValue()));
-					} catch (CoreException e) {
-						PDEPlugin.logException(e);
-					}
-			}
-		});
-		limitTextWidth(fdownloadSizeText);
-		fdownloadSizeText.setEditable(isEditable());
-
-		fInstallSizeText = new FormEntry(container, toolkit, PDEUIMessages.SiteEditor_PluginDetailsSection_installSize, null, false);
-		fInstallSizeText.setFormEntryListener(new FormEntryAdapter(this) {
-
-			@Override
-			public void textValueChanged(FormEntry text) {
-				if (fInput != null)
-					try {
-						fInput.setInstallSize(getLong(text.getValue()));
-					} catch (CoreException e) {
-						PDEPlugin.logException(e);
-					}
-			}
-		});
-		limitTextWidth(fInstallSizeText);
-		fInstallSizeText.setEditable(isEditable());
-
-		fUnpackButton = toolkit.createButton(container, PDEUIMessages.SiteEditor_PluginDetailsSection_unpack, SWT.CHECK);
-		GridData gd = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
-		gd.horizontalSpan = 2;
-		fUnpackButton.setLayoutData(gd);
-		fUnpackButton.addSelectionListener(widgetSelectedAdapter(e -> {
-			try {
-				if (!fBlockNotification)
-					fInput.setUnpack(fUnpackButton.getSelection());
-			} catch (CoreException ex) {
-				PDEPlugin.logException(ex);
-			}
-		}));
-
 		toolkit.paintBordersFor(container);
 		section.setClient(container);
 	}
@@ -207,45 +146,16 @@ public class PluginDetailsSection extends PDESection implements IPartSelectionLi
 		update();
 	}
 
-	@Override
-	public void setFocus() {
-		if (fdownloadSizeText != null)
-			fdownloadSizeText.getText().setFocus();
-	}
-
 	private void update() {
 		if (fInput != null) {
 			fNameText.setValue(fInput.getLabel());
 			fVersionText.setValue(fInput.getVersion(), true);
-			fdownloadSizeText.setValue(fInput.getDownloadSize() >= 0 ? "" + fInput.getDownloadSize() : null, true); //$NON-NLS-1$
-			fInstallSizeText.setValue(fInput.getInstallSize() >= 0 ? "" + fInput.getInstallSize() : null, true); //$NON-NLS-1$
-			fBlockNotification = true;
-			fUnpackButton.setSelection(fInput.isUnpack());
-			fBlockNotification = false;
 
 		} else {
 			fNameText.setValue(null);
 			fVersionText.setValue(null, true);
-			fdownloadSizeText.setValue(null, true);
-			fInstallSizeText.setValue(null, true);
-			fBlockNotification = true;
-			fUnpackButton.setSelection(true);
-			fBlockNotification = false;
 		}
 		boolean editable = fInput != null && isEditable();
 		fVersionText.setEditable(editable);
-		fdownloadSizeText.setEditable(editable);
-		fInstallSizeText.setEditable(editable);
-		fUnpackButton.setEnabled(editable);
-	}
-
-	private long getLong(String svalue) {
-		if (svalue == null)
-			return 0;
-		try {
-			return Long.parseLong(svalue);
-		} catch (NumberFormatException e) {
-			return 0;
-		}
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/PluginSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/PluginSection.java
@@ -45,7 +45,6 @@ import org.eclipse.pde.internal.core.feature.FeaturePlugin;
 import org.eclipse.pde.internal.core.ifeature.IFeature;
 import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
 import org.eclipse.pde.internal.core.ifeature.IFeaturePlugin;
-import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.dialogs.PluginSelectionDialog;
@@ -221,7 +220,6 @@ public class PluginSection extends TableSection implements IPluginModelListener 
 			FeaturePlugin fplugin = (FeaturePlugin) model.getFactory().createPlugin();
 			fplugin.loadFrom(candidate.getPluginBase());
 			fplugin.setVersion(ICoreConstants.DEFAULT_VERSION);
-			fplugin.setUnpack(CoreUtility.guessUnpack(candidate.getBundleDescription()));
 			added[i] = fplugin;
 		}
 		feature.addPlugins(added);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -231,9 +231,6 @@ Leave blank if the plug-in does not contain platform-specific code.
 SiteEditor_PluginDetailsSection_title = Plug-in Details
 SiteEditor_PluginDetailsSection_desc = Specify installation details for the selected plug-in.
 SiteEditor_PluginDetailsSection_pluginLabel = Name:
-SiteEditor_PluginDetailsSection_downloadSize = Download Size (kB):
-SiteEditor_PluginDetailsSection_installSize = Installation Size (kB):
-SiteEditor_PluginDetailsSection_unpack = Unpack the plug-in archive after the installation
 
 FeatureEditor_DataDetailsSection_title = Data Archive Environments
 FeatureEditor_DataDetailsSection_desc = Specify environment combinations in which the selected archive can be installed. \

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/feature/CreateFeatureProjectOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/feature/CreateFeatureProjectOperation.java
@@ -23,7 +23,6 @@ import org.eclipse.pde.internal.core.feature.FeaturePlugin;
 import org.eclipse.pde.internal.core.feature.WorkspaceFeatureModel;
 import org.eclipse.pde.internal.core.ifeature.IFeature;
 import org.eclipse.pde.internal.core.ifeature.IFeaturePlugin;
-import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.swt.widgets.Shell;
 
 public class CreateFeatureProjectOperation extends AbstractCreateFeatureOperation {
@@ -43,7 +42,6 @@ public class CreateFeatureProjectOperation extends AbstractCreateFeatureOperatio
 			FeaturePlugin fplugin = (FeaturePlugin) model.getFactory().createPlugin();
 			fplugin.loadFrom(plugin);
 			fplugin.setVersion(ICoreConstants.DEFAULT_VERSION);
-			fplugin.setUnpack(CoreUtility.guessUnpack(plugin.getPluginModel().getBundleDescription()));
 			added[i] = fplugin;
 		}
 		feature.addPlugins(added);


### PR DESCRIPTION
This commit removes some of the unused attributes of plugin element, which are redundant and are never read from a feature.xml file: install-size, download size and unpack attributes.


Fixes: [730](https://github.com/eclipse-pde/eclipse.pde/issues/730) 