### PR TITLE
Make BaseApiAnalyzer#getJavaProject protected

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
@@ -185,7 +185,7 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 	public void analyzeComponent(final BuildState state, final IApiFilterStore filterStore, final Properties preferences, final IApiBaseline baseline, final IApiComponent component, final IBuildContext context, IProgressMonitor monitor) {
 		SubMonitor localMonitor = SubMonitor.convert(monitor, BuilderMessages.BaseApiAnalyzer_analyzing_api, 6);
 		try {
-			fJavaProject = getJavaProject(component);
+			this.fJavaProject = getJavaProject(component);
 			this.fFilterStore = filterStore;
 			this.fPreferences = preferences;
 			if (!ignoreUnusedProblemFilterCheck()) {
@@ -2665,7 +2665,7 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 	 * @param component API component
 	 * @return Java project or <code>null</code>
 	 */
-	private IJavaProject getJavaProject(IApiComponent component) {
+	protected IJavaProject getJavaProject(IApiComponent component) {
 		if (component instanceof ProjectComponent pp) {
 			return pp.getJavaProject();
 		}


### PR DESCRIPTION
Currently there is no way to pass the project to the analyzer without having an project ProjectComponent, but users of BaseApiAnalyzer might have other means to find the project in question.

This makes the BaseApiAnalyzer#getJavaProject() protected so implementors can override this (e.g. Tycho).

This relates to
- https://github.com/eclipse-pde/eclipse.pde/issues/785