### PR TITLE
Wait for jobs to complete and perform up to three retries

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleMergeSplitTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleMergeSplitTests.java
@@ -343,11 +343,7 @@ public class BundleMergeSplitTests extends ApiBuilderTest {
 		// create the API baseline
 		IProject[] projects = getEnv().getWorkspace().getRoot().getProjects();
 		IPath baselineLocation = ApiTestsPlugin.getDefault().getStateLocation().append(referenceBaselineLocation);
-		for (IProject currentProject : projects) {
-			IApiComponent component = manager.getWorkspaceComponent(currentProject.getName());
-			assertNotNull("The project was not found in the workspace baseline: " + currentProject.getName(), component); //$NON-NLS-1$
-			exportApiComponent(currentProject, component, baselineLocation);
-		}
+		exportProjects(manager, projects, baselineLocation);
 		this.baseline = ApiModelFactory.newApiBaseline(API_BASELINE);
 		int length = projects.length;
 		IApiComponent[] components = new IApiComponent[length];

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleVersionTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/BundleVersionTests.java
@@ -154,12 +154,7 @@ public class BundleVersionTests extends ApiBuilderTest {
 		IProject[] projects = getEnv().getWorkspace().getRoot().getProjects();
 		int length = projects.length;
 		IPath baselineLocation = ApiTestsPlugin.getDefault().getStateLocation().append(referenceBaselineLocation);
-		for (int i = 0; i < length; i++) {
-			IProject currentProject = projects[i];
-			IApiComponent apiComponent = manager.getWorkspaceComponent(currentProject.getName());
-			assertNotNull("The project was not found in the workspace baseline: " + currentProject.getName(), apiComponent); //$NON-NLS-1$
-			exportApiComponent(currentProject, apiComponent, baselineLocation);
-		}
+		exportProjects(manager, projects, baselineLocation);
 		this.baseline = ApiModelFactory.newApiBaseline(API_BASELINE);
 		IApiComponent[] components = new IApiComponent[length];
 		for (int i = 0; i < length; i++) {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/CompatibilityTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/CompatibilityTest.java
@@ -153,12 +153,7 @@ public abstract class CompatibilityTest extends ApiBuilderTest {
 			// create the API baseline
 			projects = getEnv().getWorkspace().getRoot().getProjects();
 			IPath baselineLocation = ApiTestsPlugin.getDefault().getStateLocation().append(BASELINE);
-			IApiComponent component = null;
-			for (IProject project : projects) {
-				component = manager.getWorkspaceComponent(project.getName());
-				assertNotNull("The project was not found in the workspace baseline: " + project.getName(), component); //$NON-NLS-1$
-				exportApiComponent(project, component, baselineLocation);
-			}
+			exportProjects(manager, projects, baselineLocation);
 			baseline = ApiModelFactory.newApiBaseline("API-baseline"); //$NON-NLS-1$
 			IApiComponent[] components = new IApiComponent[projects.length];
 			for (int i = 0; i < projects.length; i++) {


### PR DESCRIPTION
Currently exporting the API description sometimes fails because there could be a race between a resource change event and disposal of the api component.

This changes the following things:
- the API description is performed as the very first step
- if generation fails wait until all running jobs are done
- then retry up to three times

This should fix https://github.com/eclipse-pde/eclipse.pde/issues/553