### PR TITLE
List OSGI plugins in the export list

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/PluginExportWizardPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/PluginExportWizardPage.java
@@ -27,6 +27,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
+import org.eclipse.pde.internal.core.bnd.BndProjectManager;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.util.PersistablePluginObject;
@@ -53,7 +54,8 @@ public class PluginExportWizardPage extends BaseExportWizardPage {
 		for (int i = 0; i < projects.length; i++) {
 			if (!WorkspaceModelManager.isBinaryProject(projects[i]) && WorkspaceModelManager.isPluginProject(projects[i])) {
 				IModel model = PluginRegistry.findModel(projects[i]);
-				if (model != null && isValidModel(model) && hasBuildProperties((IPluginModelBase) model)) {
+				if (model != null && isValidModel(model) && (hasBuildProperties((IPluginModelBase) model)
+						|| hasPdeBndDescriptor(projects[i]))) {
 					result.add(model);
 				}
 			}
@@ -69,6 +71,15 @@ public class PluginExportWizardPage extends BaseExportWizardPage {
 	private boolean hasBuildProperties(IPluginModelBase model) {
 		File file = new File(model.getInstallLocation(), ICoreConstants.BUILD_FILENAME_DESCRIPTOR);
 		return file.exists();
+	}
+
+	private boolean hasPdeBndDescriptor(IProject project) {
+		try {
+			return BndProjectManager.getBndProject(project).isPresent();
+		} catch (Exception e) {
+			return false;
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
The commit fixes OSGi plugins (that have been created using standard OSGi framework with 'Generate OSGi metadata automatically' feature) not being displayed in the export dialog box. This happens because an OSGi project has a pde.bnd file, unlike the eclipse plugins, which has build.properties. Therefore the previous behaviour was to check for the presence of a build.properties file for validating a plugin project. This assumption breaks with the new type.

The commit relies on the following assumptions in case of OSGi template projects:
 - The location of the pde.bnd file is always under the root folder of the plugin project
 - The filename is always constant, namely, pde.bnd.
 
Fixes: #600 

