### PR TITLE
Toggle OSGi and Eclipse plugin creation options appropriately

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationPage.java
@@ -167,6 +167,7 @@ public class NewProjectCreationPage extends WizardNewProjectCreationPage {
 	private void updateRuntimeDependency() {
 		boolean depends = fEclipseButton.getSelection();
 		fOSGiCombo.setEnabled(!depends);
+		useAutomaticMetadata.setSelection(!depends);
 		useAutomaticMetadata.setEnabled(!depends);
 	}
 


### PR DESCRIPTION
 If one creates plugins using the automatic manifest generation feature,
subsequent plugin projects created with Eclipse as the target is throwing errors, due to the 'Generate OSGi metadata automatically' button not being unchecked. This commit tries to resolve this issue by unchecking the feature whwnever an Eclipse plugin project using templates is created.

Fixes: #798 