### PR TITLE
Support setting the bundleroot for manifest generated projects

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
@@ -68,13 +68,10 @@ public class PDEProject {
 			}
 		}
 		if (BndProject.isBndProject(project)) {
-
 			try {
-				if (project.hasNature(JavaCore.NATURE_ID)) {
-					IJavaProject javaProject = JavaCore.create(project);
-					IPath outputLocation = javaProject.getOutputLocation();
-					IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
-					return workspaceRoot.getFolder(outputLocation);
+				IFolder outputFolder = getJavaOutputFolder(project);
+				if (outputFolder != null) {
+					return outputFolder;
 				}
 			} catch (CoreException e) {
 				// can't determine the bundle root then from java settings!
@@ -82,6 +79,16 @@ public class PDEProject {
 			}
 		}
 		return project;
+	}
+
+	public static IFolder getJavaOutputFolder(IProject project) throws CoreException {
+		if (project.hasNature(JavaCore.NATURE_ID)) {
+			IJavaProject javaProject = JavaCore.create(project);
+			IPath outputLocation = javaProject.getOutputLocation();
+			IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
+			return workspaceRoot.getFolder(outputLocation);
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Currently we have only the option to set the bundleroot to a different folder (what the will become the outputfolder). In some cases one might want to set the bundle root also to the project root.

This now adds special handling for the case where bundle root != output folder.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/803

@merks if you like to try this out do the follwoing:

1. Create a project with automatic manifest generation:  https://newsroom.eclipse.org/eclipse-newsletter/2023/june/notable-improvements-eclipse-ide#Support-for-Automatic-Manifest-Generation
2. Now goto `.settings/org.eclipse.jdt.core.prefs`
3. Add the follwoing line: `BUNDLE_ROOT_PATH=`
4. You should now see the `META-INF/MANIFEST.MF` created at the root of the project for your for your convenience and comfort

Please note that currently there is no UI and I would not recomment such setup but it should address your concerns and allow a soft migration path.