### PR TITLE
Setting BUNDLE_ROOT_PATH preference to an empty string gives an error

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PDEProject.java
@@ -60,6 +60,9 @@ public class PDEProject {
 		if (node != null) {
 			String string = node.get(BUNDLE_ROOT_PATH, null);
 			if (string != null) {
+				if (string.isBlank()) {
+					return project;
+				}
 				IPath path = IPath.fromPortableString(string);
 				return project.getFolder(path);
 			}


### PR DESCRIPTION
Currently one must either specify a folder or delete the preference BUNDLE_ROOT_PATH or PDE gives an error message.

Instead we should interpret an empty BUNDLE_ROOT_PATH as the explicit intend of the user to use the project as a bundle root.