### PR TITLE
Discover URIs from referenced target locations

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetReferenceBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetReferenceBundleContainer.java
@@ -86,7 +86,7 @@ public class TargetReferenceBundleContainer extends AbstractBundleContainer {
 		return uri;
 	}
 
-	private synchronized ITargetDefinition getTargetDefinition() throws CoreException {
+	synchronized ITargetDefinition getTargetDefinition() throws CoreException {
 		// only synchronize here, we just want to make sure not two threads are
 		// loading the target in parallel but not block the targetDefinition or
 		// reload operation as these might be called from the UI


### PR DESCRIPTION
Currently URIs are not discovered when they are defined in a referenced target location.

This now also look into referenced target for locations that are suitable to supply additional URIs.

This relates to https://github.com/eclipse-pde/eclipse.pde/issues/207