### PR TITLE
Delete orphan files that are copied/generated by bnd automatic manifest

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/FileResource.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/FileResource.java
@@ -112,7 +112,7 @@ public class FileResource implements Resource {
 			return;
 		}
 		for (IResource resource : container.members()) {
-			if (filter == null || filter.test(container)) {
+			if (filter == null || filter.test(resource)) {
 				if (resource instanceof IFile) {
 					IPath projectRelativePath = resource.getProjectRelativePath();
 					String relativePath = projectRelativePath.toString();


### PR DESCRIPTION
Currently we copy everything that would normally go to the jar into the output folder, but if on the next build the resource is not put anymore we have some orphan files.

This records what resources are created as part of the project build and finally deletes any orphans on close.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/587