### PR TITLE
Use the generic editor as the source editor for bnd instructions

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -2475,4 +2475,11 @@
 			</enablement>
          </commonWizard>
       </extension>
+      <extension
+            point="org.eclipse.ui.genericeditor.contentAssistProcessors">
+         <contentAssistProcessor
+               class="org.eclipse.pde.internal.ui.editor.bnd.BndAutoCompleteProcessor"
+               contentType="org.eclipse.pde.bndInstructions">
+         </contentAssistProcessor>
+      </extension>
 </plugin>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/MultiSourceEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/MultiSourceEditor.java
@@ -15,6 +15,7 @@ package org.eclipse.pde.internal.ui.editor;
 
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.editor.context.InputContext;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.forms.editor.IFormPage;
 
@@ -23,12 +24,14 @@ public abstract class MultiSourceEditor extends PDEFormEditor {
 		InputContext context = fInputContextManager.findContext(contextId);
 		if (context == null)
 			return;
-		PDESourcePage sourcePage;
+		IEditorPart sourcePage;
 		// Don't duplicate
 		if (findPage(contextId) != null)
 			return;
 		sourcePage = createSourcePage(this, contextId, context.getInput().getName(), context.getId());
-		sourcePage.setInputContext(context);
+		if (sourcePage instanceof PDESourcePage pdeSourcePage) {
+			pdeSourcePage.setInputContext(context);
+		}
 		try {
 			addPage(sourcePage, context.getInput());
 		} catch (PartInitException e) {
@@ -49,7 +52,7 @@ public abstract class MultiSourceEditor extends PDEFormEditor {
 		}
 	}
 
-	protected PDESourcePage createSourcePage(PDEFormEditor editor, String title, String name, String contextId) {
+	protected IEditorPart createSourcePage(PDEFormEditor editor, String title, String name, String contextId) {
 		return new GenericSourcePage(editor, title, name);
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndSourcePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndSourcePage.java
@@ -13,62 +13,101 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.bnd;
 
-import org.eclipse.jface.text.DefaultInformationControl;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.contentassist.ContentAssistant;
-import org.eclipse.jface.text.contentassist.IContentAssistant;
-import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.jface.text.source.SourceViewerConfiguration;
-import org.eclipse.jface.viewers.ILabelProvider;
-import org.eclipse.jface.viewers.ITreeContentProvider;
-import org.eclipse.pde.internal.ui.PDEPluginImages;
-import org.eclipse.pde.internal.ui.editor.GenericSourcePage;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.editor.PDEFormEditor;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.forms.IManagedForm;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.IFormPage;
+import org.eclipse.ui.ide.IDE;
 
-public class BndSourcePage extends GenericSourcePage {
+@SuppressWarnings("restriction")
+public class BndSourcePage extends org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor implements IFormPage {
+
+	private FormEditor editor;
+	private boolean active;
+	private int index;
+	private String id;
+	private Control fControl;
 
 	public BndSourcePage(PDEFormEditor editor, String id, String title) {
-		super(editor, id, title);
-		setSourceViewerConfiguration(new SourceViewerConfiguration() {
-			private ContentAssistant fContentAssistant;
-
-			@Override
-			public IContentAssistant getContentAssistant(ISourceViewer sourceViewer) {
-				if (isEditable()) {
-					if (fContentAssistant == null) {
-						// Initialize in SWT thread before using in background
-						// thread:
-						PDEPluginImages.get(null);
-						fContentAssistant = new ContentAssistant(true);
-						fContentAssistant.setDocumentPartitioning(getConfiguredDocumentPartitioning(sourceViewer));
-						fContentAssistant.setContentAssistProcessor(new BndAutoCompleteProcessor(),
-								IDocument.DEFAULT_CONTENT_TYPE);
-						fContentAssistant.enableAutoInsert(true);
-						fContentAssistant
-								.setInformationControlCreator(parent -> new DefaultInformationControl(parent, false));
-						fContentAssistant.setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_ABOVE);
-						fContentAssistant.enableAutoActivation(true);
-					}
-					return fContentAssistant;
-				}
-				return null;
-			}
-		});
+		this.id = id;
 	}
 
 	@Override
-	public ILabelProvider createOutlineLabelProvider() {
+	public void initialize(FormEditor editor) {
+		this.editor = editor;
+	}
+
+	@Override
+	public FormEditor getEditor() {
+		return editor;
+	}
+
+	@Override
+	public IManagedForm getManagedForm() {
 		return null;
 	}
 
 	@Override
-	public ITreeContentProvider createOutlineContentProvider() {
-		return null;
+	public void setActive(boolean active) {
+		this.active = active;
 	}
 
 	@Override
-	public void updateSelection(Object object) {
-
+	public boolean isActive() {
+		return active;
 	}
+
+	@Override
+	public boolean canLeaveThePage() {
+		return true;
+	}
+
+	@Override
+	public Control getPartControl() {
+		return fControl;
+	}
+
+	@Override
+	public void createPartControl(Composite parent) {
+		super.createPartControl(parent);
+		Control[] children = parent.getChildren();
+		fControl = children[children.length - 1];
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(fControl, IHelpContextIds.MANIFEST_SOURCE_PAGE);
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public int getIndex() {
+		return index;
+	}
+
+	@Override
+	public void setIndex(int index) {
+		this.index = index;
+	}
+
+	@Override
+	public boolean isEditor() {
+		return true;
+	}
+
+	@Override
+	public boolean selectReveal(Object object) {
+		if (object instanceof IMarker) {
+			IDE.gotoMarker(this, (IMarker) object);
+			return true;
+		}
+		return false;
+	}
+
 
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/feature/FeatureEditor.java
@@ -47,7 +47,6 @@ import org.eclipse.pde.internal.ui.editor.ISortableContentOutlinePage;
 import org.eclipse.pde.internal.ui.editor.MultiSourceEditor;
 import org.eclipse.pde.internal.ui.editor.PDEFormEditor;
 import org.eclipse.pde.internal.ui.editor.PDEFormPage;
-import org.eclipse.pde.internal.ui.editor.PDESourcePage;
 import org.eclipse.pde.internal.ui.editor.build.BuildInputContext;
 import org.eclipse.pde.internal.ui.editor.build.BuildPage;
 import org.eclipse.pde.internal.ui.editor.build.BuildSourcePage;
@@ -312,7 +311,7 @@ public class FeatureEditor extends MultiSourceEditor implements IShowEditorInput
 	}
 
 	@Override
-	protected PDESourcePage createSourcePage(PDEFormEditor editor, String title, String name, String contextId) {
+	protected IEditorPart createSourcePage(PDEFormEditor editor, String title, String name, String contextId) {
 		if (contextId.equals(FeatureInputContext.CONTEXT_ID))
 			return new FeatureSourcePage(editor, title, name);
 		if (contextId.equals(BuildInputContext.CONTEXT_ID))

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
@@ -75,7 +75,6 @@ import org.eclipse.pde.internal.ui.editor.JarEntryEditorInput;
 import org.eclipse.pde.internal.ui.editor.JarEntryFile;
 import org.eclipse.pde.internal.ui.editor.PDEFormEditor;
 import org.eclipse.pde.internal.ui.editor.PDELauncherFormEditor;
-import org.eclipse.pde.internal.ui.editor.PDESourcePage;
 import org.eclipse.pde.internal.ui.editor.bnd.BndInputContext;
 import org.eclipse.pde.internal.ui.editor.bnd.BndSourcePage;
 import org.eclipse.pde.internal.ui.editor.build.BuildInputContext;
@@ -656,7 +655,7 @@ public class ManifestEditor extends PDELauncherFormEditor implements IShowEditor
 	}
 
 	@Override
-	protected PDESourcePage createSourcePage(PDEFormEditor editor, String title, String name, String contextId) {
+	protected IEditorPart createSourcePage(PDEFormEditor editor, String title, String name, String contextId) {
 		if (contextId.equals(PluginInputContext.CONTEXT_ID))
 			return new ManifestSourcePage(editor, title, name);
 		if (contextId.equals(BuildInputContext.CONTEXT_ID))


### PR DESCRIPTION
Currently a plain TextEditor is used, but the ExtensionBasedTextEditor is much more powerful.

@mickaelistria I was able  to use `ExtensionBasedTextEditor` now and register the completion proposals via extension registry so it seems to work at the basics, can you take a look if it looks sane or I'm doing anything wrong here/not recommended?

Relates to https://github.com/eclipse-pde/eclipse.pde/issues/701