### PR TITLE
Show only single editor when open plain BND files

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/model/xml/ManifestEditorSpellCheckTestCase.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/model/xml/ManifestEditorSpellCheckTestCase.java
@@ -31,6 +31,7 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -44,6 +45,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.internal.ErrorEditorPart;
 import org.eclipse.ui.texteditor.spelling.SpellingAnnotation;
 import org.junit.Before;
 import org.junit.Test;
@@ -137,7 +139,17 @@ public class ManifestEditorSpellCheckTestCase extends XMLModelTestCase {
 			Thread.sleep(5000);
 		} catch (InterruptedException e) {
 		}
-
+		if (fEditor instanceof ErrorEditorPart errorpart) {
+			IStatus error = errorpart.getError();
+			if (error == null) {
+				fail("failed to open editor");
+			}
+			Throwable exception = error.getException();
+			if (exception != null) {
+				throw new AssertionError("fail to open editor", exception);
+			}
+			fail(error.toString());
+		}
 		PDEFormEditor editor = (PDEFormEditor) fEditor;
 		editor.setActivePage(PluginInputContext.CONTEXT_ID);
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormEditor.java
@@ -776,23 +776,21 @@ public abstract class PDEFormEditor extends FormEditor implements IInputContextL
 	protected void performGlobalAction(String id) {
 		// preserve selection
 		ISelection selection = getSelection();
-		boolean handled = ((PDEFormPage) getActivePageInstance()).performGlobalAction(id);
-		if (!handled) {
-			IFormPage page = getActivePageInstance();
-			if (page instanceof PDEFormPage) {
-				if (id.equals(ActionFactory.UNDO.getId())) {
-					fInputContextManager.undo();
-					return;
-				}
-				if (id.equals(ActionFactory.REDO.getId())) {
-					fInputContextManager.redo();
-					return;
-				}
-				if (id.equals(ActionFactory.CUT.getId()) || id.equals(ActionFactory.COPY.getId())) {
-					copyToClipboard(selection);
-					return;
-				}
-			}
+		IFormPage page = getActivePageInstance();
+		if (PDEFormPage.performGlobalAction(id, page)) {
+			return;
+		}
+		if (id.equals(ActionFactory.UNDO.getId())) {
+			fInputContextManager.undo();
+			return;
+		}
+		if (id.equals(ActionFactory.REDO.getId())) {
+			fInputContextManager.redo();
+			return;
+		}
+		if (id.equals(ActionFactory.CUT.getId()) || id.equals(ActionFactory.COPY.getId())) {
+			copyToClipboard(selection);
+			return;
 		}
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormPage.java
@@ -59,6 +59,7 @@ import org.eclipse.ui.forms.IFormPart;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.FormPage;
+import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -156,8 +157,8 @@ public abstract class PDEFormPage extends FormPage {
 	public void contextMenuAboutToShow(IMenuManager menu) {
 	}
 
-	protected Control getFocusControl() {
-		IManagedForm form = getManagedForm();
+	protected static Control getFocusControl(IFormPage page) {
+		IManagedForm form = page.getManagedForm();
 		if (form == null)
 			return null;
 		Control control = form.getForm();
@@ -170,14 +171,14 @@ public abstract class PDEFormPage extends FormPage {
 		return focusControl;
 	}
 
-	public boolean performGlobalAction(String actionId) {
-		Control focusControl = getFocusControl();
+	public static boolean performGlobalAction(String actionId, IFormPage formPage) {
+		Control focusControl = getFocusControl(formPage);
 		if (focusControl == null)
 			return false;
 
 		if (canPerformDirectly(actionId, focusControl))
 			return true;
-		AbstractFormPart focusPart = getFocusSection();
+		AbstractFormPart focusPart = getFocusSection(formPage);
 		if (focusPart != null) {
 			if (focusPart instanceof PDESection)
 				return ((PDESection) focusPart).doGlobalAction(actionId);
@@ -188,7 +189,7 @@ public abstract class PDEFormPage extends FormPage {
 	}
 
 	public boolean canPaste(Clipboard clipboard) {
-		AbstractFormPart focusPart = getFocusSection();
+		AbstractFormPart focusPart = getFocusSection(this);
 		if (focusPart != null) {
 			if (focusPart instanceof PDESection) {
 				return ((PDESection) focusPart).canPaste(clipboard);
@@ -201,7 +202,7 @@ public abstract class PDEFormPage extends FormPage {
 	}
 
 	public boolean canCopy(ISelection selection) {
-		AbstractFormPart focusPart = getFocusSection();
+		AbstractFormPart focusPart = getFocusSection(this);
 		if (focusPart != null) {
 			if (focusPart instanceof PDESection) {
 				return ((PDESection) focusPart).canCopy(selection);
@@ -214,7 +215,7 @@ public abstract class PDEFormPage extends FormPage {
 	}
 
 	public boolean canCut(ISelection selection) {
-		AbstractFormPart focusPart = getFocusSection();
+		AbstractFormPart focusPart = getFocusSection(this);
 		if (focusPart != null) {
 			if (focusPart instanceof PDESection) {
 				return ((PDESection) focusPart).canCut(selection);
@@ -226,8 +227,8 @@ public abstract class PDEFormPage extends FormPage {
 		return false;
 	}
 
-	private AbstractFormPart getFocusSection() {
-		Control focusControl = getFocusControl();
+	private static AbstractFormPart getFocusSection(IFormPage page) {
+		Control focusControl = getFocusControl(page);
 		if (focusControl == null)
 			return null;
 		Composite parent = focusControl.getParent();
@@ -243,7 +244,15 @@ public abstract class PDEFormPage extends FormPage {
 		return targetPart;
 	}
 
-	protected boolean canPerformDirectly(String id, Control control) {
+	protected static boolean canPerformDirectly(String id, IFormPage page) {
+		Control focusControl = getFocusControl(page);
+		if (focusControl == null) {
+			return false;
+		}
+		return canPerformDirectly(id, focusControl);
+	}
+
+	protected static boolean canPerformDirectly(String id, Control control) {
 		if (control instanceof Text text) {
 			if (id.equals(ActionFactory.CUT.getId())) {
 				text.cut();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/context/InputContextManager.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/context/InputContextManager.java
@@ -201,6 +201,9 @@ public abstract class InputContextManager implements IResourceChangeListener {
 	}
 
 	public void monitorFile(IFile file) {
+		if (file == null) {
+			return;
+		}
 		monitoredFiles.add(file);
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/OverviewPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/OverviewPage.java
@@ -375,7 +375,7 @@ public class OverviewPage extends LaunchShortcutOverviewPage {
 			return;
 		try {
 			ManifestEditor manifestEditor = (ManifestEditor) getEditor();
-			manifestEditor.addExtensionTabs();
+			manifestEditor.addExtensionTabs(3);
 			manifestEditor.setShowExtensions(true);
 			manifestEditor.setActivePage(activePageId);
 		} catch (PartInitException | BackingStoreException e) {


### PR DESCRIPTION
Currently the manifest editor shows an error when one opens a plain bnd file. This is because no "manifest first" parts are found and the bnd form page is only added for pde.bnd files.

This now fixes the issue by making manifest-first files completely optional and show a plain bnd editor instead in case of only a bnd file.