### PR TITLE
Add syntax highlight from adapted from bnd-tools

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -120,6 +120,7 @@ Require-Bundle:
  org.eclipse.equinox.security;bundle-version="[1.4.100,2.0.0)"
 Import-Package: aQute.bnd.build.model;version="[4.2.0,5.0.0)",
  aQute.bnd.header;version="[2.5.0,3.0.0)",
+ aQute.bnd.help;version="2.0.0",
  aQute.bnd.osgi;version="[5.6.0,8.0.0)",
  aQute.bnd.osgi.repository;version="[3.0.0,4.0.0)",
  aQute.bnd.osgi.resource;version="[4.3.0,6.0.0)",

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -2478,8 +2478,22 @@
       <extension
             point="org.eclipse.ui.genericeditor.contentAssistProcessors">
          <contentAssistProcessor
-               class="org.eclipse.pde.internal.ui.editor.bnd.BndAutoCompleteProcessor"
+               class="org.eclipse.pde.internal.ui.editor.bnd.BndBuildPathAutoCompleteProcessor"
                contentType="org.eclipse.pde.bndInstructions">
          </contentAssistProcessor>
+      </extension>
+      <extension
+            point="org.eclipse.ui.genericeditor.contentAssistProcessors">
+         <contentAssistProcessor
+               class="org.eclipse.pde.internal.ui.bndtools.BndCompletionProcessor"
+               contentType="org.eclipse.pde.bndInstructions">
+         </contentAssistProcessor>
+      </extension>
+      <extension
+            point="org.eclipse.ui.genericeditor.presentationReconcilers">
+         <presentationReconciler
+               class="org.eclipse.pde.internal.ui.editor.bnd.BNDPresentationReconciler"
+               contentType="org.eclipse.pde.bndInstructions">
+         </presentationReconciler>
       </extension>
 </plugin>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndCompletionProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndCompletionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 bndtools project.
+ * Copyright (c) 2011, 2023 bndtools project and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,9 @@
  *     Ferry Huberts <ferry.huberts@pelagic.nl> - ongoing enhancements
  *     Neil Bartlett <njbartlett@gmail.com> - ongoing enhancements
  *     BJ Hargrave <bj@bjhargrave.com> - ongoing enhancements
+ *     Christoph Läubrich - adjust to coding conventions, fix missing completions on empty lines
  *******************************************************************************/
-package bndtools.editor.completion;
+package org.eclipse.pde.internal.ui.bndtools;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,6 +23,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.CompletionProposal;
 import org.eclipse.jface.text.contentassist.ContextInformation;
@@ -34,24 +37,27 @@ import aQute.bnd.help.Syntax;
 
 public class BndCompletionProcessor implements IContentAssistProcessor {
 
-	private static final Pattern PREFIX_PATTERN = Pattern.compile("(\\S+)$");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(\\S+)$"); //$NON-NLS-1$
 
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
 		try {
-			String pre = viewer.getDocument()
-				.get(0, offset);
-			Matcher matcher = PREFIX_PATTERN.matcher(pre);
-			if (matcher.find()) {
-				String prefix = matcher.group(1);
-				ICompletionProposal[] found = proposals(prefix, offset);
-				if (found.length == 1) {
-					found[0].apply(viewer.getDocument());
-					viewer.setSelectedRange(offset + (found[0].getDisplayString()
-						.length() - prefix.length() + 2), 0);
-					return new ICompletionProposal[0];
+			IDocument document = viewer.getDocument();
+			IRegion lineInfo = document.getLineInformationOfOffset(offset);
+			if (lineInfo.getOffset() != offset) {
+				String pre = document.get(0, offset);
+				Matcher matcher = PREFIX_PATTERN.matcher(pre);
+				if (matcher.find()) {
+					String prefix = matcher.group(1);
+					ICompletionProposal[] found = proposals(prefix, offset);
+					if (found.length == 1) {
+						found[0].apply(document);
+						viewer.setSelectedRange(offset + (found[0].getDisplayString().length() - prefix.length() + 2),
+								0);
+						return new ICompletionProposal[0];
+					}
+					return found;
 				}
-				return found;
 			}
 			return proposals(null, offset);
 		} catch (BadLocationException e) {
@@ -79,7 +85,6 @@ public class BndCompletionProcessor implements IContentAssistProcessor {
 
 	@Override
 	public IContextInformation[] computeContextInformation(ITextViewer viewer, int offset) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -99,13 +104,11 @@ public class BndCompletionProcessor implements IContentAssistProcessor {
 
 	@Override
 	public IContextInformationValidator getContextInformationValidator() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public String getErrorMessage() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndCompletionProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndCompletionProcessor.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2022 bndtools project.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     David Savage <davemssavage@gmail.com> - initial API and implementation
+ *     Ferry Huberts <ferry.huberts@pelagic.nl> - ongoing enhancements
+ *     Neil Bartlett <njbartlett@gmail.com> - ongoing enhancements
+ *     BJ Hargrave <bj@bjhargrave.com> - ongoing enhancements
+ *******************************************************************************/
+package bndtools.editor.completion;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.contentassist.CompletionProposal;
+import org.eclipse.jface.text.contentassist.ContextInformation;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.jface.text.contentassist.IContextInformationValidator;
+
+import aQute.bnd.help.Syntax;
+
+public class BndCompletionProcessor implements IContentAssistProcessor {
+
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(\\S+)$");
+
+	@Override
+	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
+		try {
+			String pre = viewer.getDocument()
+				.get(0, offset);
+			Matcher matcher = PREFIX_PATTERN.matcher(pre);
+			if (matcher.find()) {
+				String prefix = matcher.group(1);
+				ICompletionProposal[] found = proposals(prefix, offset);
+				if (found.length == 1) {
+					found[0].apply(viewer.getDocument());
+					viewer.setSelectedRange(offset + (found[0].getDisplayString()
+						.length() - prefix.length() + 2), 0);
+					return new ICompletionProposal[0];
+				}
+				return found;
+			}
+			return proposals(null, offset);
+		} catch (BadLocationException e) {
+			return proposals(null, offset);
+		}
+	}
+
+	private static ICompletionProposal[] proposals(String prefix, int offset) {
+		ArrayList<ICompletionProposal> results = new ArrayList<>(Syntax.HELP.size());
+		for (Syntax s : Syntax.HELP.values()) {
+			if (prefix == null || s.getHeader()
+				.startsWith(prefix)) {
+				IContextInformation info = new ContextInformation(s.getHeader(), s.getHeader());
+				String text = prefix == null ? s.getHeader()
+					: s.getHeader()
+						.substring(prefix.length());
+				results.add(new CompletionProposal(text + ": ", offset, 0, text.length() + 2, null, s.getHeader(), info, //$NON-NLS-1$
+					s.getLead()));
+			}
+		}
+		Collections.sort(results, (p1, p2) -> p1.getDisplayString()
+			.compareTo(p2.getDisplayString()));
+		return results.toArray(new ICompletionProposal[0]);
+	}
+
+	@Override
+	public IContextInformation[] computeContextInformation(ITextViewer viewer, int offset) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public char[] getCompletionProposalAutoActivationCharacters() {
+		return new char[] {
+			'-'
+		};
+	}
+
+	@Override
+	public char[] getContextInformationAutoActivationCharacters() {
+		return new char[] {
+			'-'
+		};
+	}
+
+	@Override
+	public IContextInformationValidator getContextInformationValidator() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getErrorMessage() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndScanner.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndScanner.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2023 bndtools project.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     David Savage <davemssavage@gmail.com> - initial API and implementation
+ *     Neil Bartlett <njbartlett@gmail.com> - ongoing enhancements
+ *     Ferry Huberts <ferry.huberts@pelagic.nl> - ongoing enhancements
+ *     BJ Hargrave <bj@bjhargrave.com> - ongoing enhancements
+ *     Amit Kumar Mondal <admin@amitinside.com> - ongoing enhancements
+ *     Peter Kriens <Peter.Kriens@aQute.biz> - ongoing enhancements
+ *******************************************************************************/
+package bndtools.editor.completion;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.text.rules.ICharacterScanner;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.RuleBasedScanner;
+import org.eclipse.jface.text.rules.Token;
+
+import aQute.bnd.help.Syntax;
+import aQute.bnd.osgi.Constants;
+
+public class BndScanner extends RuleBasedScanner {
+	BndSourceViewerConfiguration	bsvc;
+	final Set<String>				instructions;
+	final Set<String>				directives	= new HashSet<>();
+
+	public BndScanner(BndSourceViewerConfiguration manager) {
+		bsvc = manager;
+		instructions = Syntax.HELP.values()
+			.stream()
+			.map(Syntax::getHeader)
+			.collect(Collectors.toSet());
+
+		directives.addAll(Constants.directives);
+		directives.addAll(Constants.COMPONENT_DIRECTIVES);
+		directives.addAll(Constants.COMPONENT_DIRECTIVES_1_1);
+		directives.addAll(Constants.COMPONENT_DIRECTIVES_1_2);
+
+		IRule[] rules = new IRule[] {
+			this::comment, //
+			this::keyword, //
+			this::error,
+		};
+
+		setRules(rules);
+		setDefaultReturnToken(bsvc.T_DEFAULT);
+	}
+
+	IToken comment(ICharacterScanner scanner) {
+		if (scanner.getColumn() != 0)
+			return Token.UNDEFINED;
+
+		int c;
+		int n = 0;
+		while (true) {
+			do {
+				c = scanner.read();
+				n++;
+			} while ((c == ' ' || c == '\t'));
+
+			if (c == '#' || c == '!') {
+				while (true) {
+					c = scanner.read();
+					n++;
+
+					if (c == '\n' || c == '\r' || c == ICharacterScanner.EOF)
+						return bsvc.T_COMMENT;
+				}
+			} else {
+				while (n-- > 0)
+					scanner.unread();
+				return Token.UNDEFINED;
+			}
+		}
+	}
+
+	IToken keyword(ICharacterScanner scanner) {
+		if (scanner.getColumn() != 0)
+			return Token.UNDEFINED;
+
+		int c;
+		int n = 0;
+		c = scanner.read();
+		n++;
+
+		StringBuilder sb = new StringBuilder();
+		while (!(c == ' ' || c == '\t' || c == ':' || c == '=' || c == ICharacterScanner.EOF)) {
+
+			if (c == '\\') {
+				c = scanner.read();
+				n++;
+				if (c == ICharacterScanner.EOF) {
+					break;
+				}
+			}
+
+			sb.append((char) c);
+			c = scanner.read();
+			n++;
+		}
+
+		if (sb.isEmpty()) {
+
+			while (n-- > 0)
+				scanner.unread();
+
+			return Token.UNDEFINED;
+		}
+
+		scanner.unread();
+
+		String key = sb.toString();
+
+		if (Constants.options.contains(key)) {
+			return bsvc.T_OPTION;
+		}
+
+		if (instructions.contains(key)) {
+			return bsvc.T_INSTRUCTION;
+		}
+
+		return bsvc.T_KEY;
+	}
+
+	IToken error(ICharacterScanner scanner) {
+		int c = scanner.read();
+		int n = 1;
+		if (c == '\\') {
+			c = scanner.read();
+			n++;
+			if (c == ' ' || c == '\t') {
+				while (c == ' ' || c == '\t') {
+					c = scanner.read();
+				}
+				scanner.unread();
+				return bsvc.T_ERROR;
+			}
+		}
+		while (n-- > 0)
+			scanner.unread();
+		return Token.UNDEFINED;
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/MacroRule.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/MacroRule.java
@@ -13,7 +13,7 @@
  *     Neil Bartlett <njbartlett@gmail.com> - ongoing enhancements
  *     BJ Hargrave <bj@bjhargrave.com> - ongoing enhancements
  *******************************************************************************/
-package bndtools.editor.completion;
+package org.eclipse.pde.internal.ui.bndtools;
 
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IRule;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/MacroRule.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/MacroRule.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2019 bndtools project.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     David Savage <davemssavage@gmail.com> - initial API and implementation
+ *     Neil Bartlett <njbartlett@gmail.com> - ongoing enhancements
+ *     BJ Hargrave <bj@bjhargrave.com> - ongoing enhancements
+ *******************************************************************************/
+package bndtools.editor.completion;
+
+import org.eclipse.jface.text.rules.ICharacterScanner;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.Token;
+
+import aQute.bnd.osgi.Macro;
+
+public class MacroRule implements IRule {
+
+	private final StringBuffer	buffer	= new StringBuffer();
+	private final IToken		token;
+
+	public MacroRule(IToken token) {
+		this.token = token;
+	}
+
+	@Override
+	public IToken evaluate(ICharacterScanner scanner) {
+		int c = scanner.read();
+		if (c == '$') {
+			buffer.setLength(0);
+			buffer.append('$');
+			if (scan(scanner, buffer))
+				return token;
+		}
+		scanner.unread();
+		return Token.UNDEFINED;
+
+	}
+
+	boolean scan(ICharacterScanner scanner, StringBuffer buffer) {
+		int c = scanner.read();
+		if (c == ICharacterScanner.EOF)
+			return false;
+		int terminator = Macro.getTerminator((char) c);
+
+		if (terminator == 0)
+			return false;
+
+		while (true) {
+			c = scanner.read();
+			buffer.append((char) c);
+			if (c == terminator)
+				return true;
+			else if (c == '$') {
+				if (!scan(scanner, buffer))
+					return false;
+			} else if (c == '\\') {
+				c = scanner.read();
+				if (c == ICharacterScanner.EOF)
+					return false;
+				buffer.append((char) c);
+			}
+		}
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BNDPresentationReconciler.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BNDPresentationReconciler.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.bnd;
+
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.presentation.PresentationReconciler;
+import org.eclipse.jface.text.rules.DefaultDamagerRepairer;
+import org.eclipse.pde.internal.ui.bndtools.BndScanner;
+
+public class BNDPresentationReconciler extends PresentationReconciler {
+	public BNDPresentationReconciler() {
+		BndScanner scanner = new BndScanner(JavaUI.getColorManager());
+		DefaultDamagerRepairer dr = new DefaultDamagerRepairer(scanner);
+		this.setDamager(dr, IDocument.DEFAULT_CONTENT_TYPE);
+		this.setRepairer(dr, IDocument.DEFAULT_CONTENT_TYPE);
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndBuildPathAutoCompleteProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndBuildPathAutoCompleteProcessor.java
@@ -33,7 +33,7 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.properties.LineType;
 import aQute.bnd.properties.PropertiesLineReader;
 
-public class BndAutoCompleteProcessor implements IContentAssistProcessor {
+public class BndBuildPathAutoCompleteProcessor implements IContentAssistProcessor {
 
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {


### PR DESCRIPTION
Currently there is no syntax-highlight when PDE shows the bnd instruction files.

This connects the highlight/code completion form the bndtools project with the source page to provide completion and syntax coloring.

This is how this looks like:
![grafik](https://github.com/eclipse-pde/eclipse.pde/assets/1331477/63e5fa4d-079d-4c2e-90dc-d6d9f3e543f5)

Fix https://github.com/eclipse-pde/eclipse.pde/issues/701

I'll open an CQ now to get further assistance on if/how we can (temporary) copy/use the code from bndtools.