### PR TITLE
Support names for Updates repositories in product definition

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IRepositoryInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IRepositoryInfo.java
@@ -23,4 +23,8 @@ public interface IRepositoryInfo extends IProductObject {
 
 	void setURL(String url);
 
+	String getName();
+
+	void setName(String name);
+
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/isite/IRepositoryReference.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/isite/IRepositoryReference.java
@@ -25,4 +25,8 @@ public interface IRepositoryReference extends ISiteObject {
 
 	void setURL(String url) throws CoreException;
 
+	String getName();
+
+	void setName(String name) throws CoreException;
+
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/RepositoryInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/RepositoryInfo.java
@@ -26,9 +26,11 @@ public class RepositoryInfo extends ProductObject implements IRepositoryInfo {
 	private static final long serialVersionUID = 1L;
 
 	public static final String P_LOCATION = "location"; //$NON-NLS-1$
+	public static final String P_NAME = "name"; //$NON-NLS-1$
 	public static final String P_ENABLED = "enabled"; //$NON-NLS-1$
 
 	private String fURL;
+	private String fName;
 	private boolean fEnabled = true; // enabled unless specified otherwise
 
 	public RepositoryInfo(IProductModel model) {
@@ -50,6 +52,20 @@ public class RepositoryInfo extends ProductObject implements IRepositoryInfo {
 	}
 
 	@Override
+	public String getName() {
+		return fName;
+	}
+
+	@Override
+	public void setName(String name) {
+		String old = fName;
+		fName = name;
+		if (isEditable()) {
+			firePropertyChanged(P_NAME, old, fName);
+		}
+	}
+
+	@Override
 	public boolean getEnabled() {
 		return fEnabled;
 	}
@@ -58,7 +74,7 @@ public class RepositoryInfo extends ProductObject implements IRepositoryInfo {
 	public void setEnabled(boolean enabled) {
 		boolean old = fEnabled;
 		fEnabled = enabled;
-		if (isEditable()) {
+		if (isEditable() && old != fEnabled) {
 			firePropertyChanged(P_ENABLED, old, fEnabled);
 		}
 	}
@@ -68,15 +84,18 @@ public class RepositoryInfo extends ProductObject implements IRepositoryInfo {
 		if (node.getNodeType() == Node.ELEMENT_NODE) {
 			Element element = (Element) node;
 			fURL = element.getAttribute("location"); //$NON-NLS-1$
+			fName = element.getAttribute("name"); //$NON-NLS-1$
 			fEnabled = Boolean.parseBoolean(element.getAttribute(P_ENABLED));
 		}
 	}
-
 
 	@Override
 	public void write(String indent, PrintWriter writer) {
 		if (isURLDefined()) {
 			writer.print(indent + "<repository location=\"" + fURL + "\""); //$NON-NLS-1$ //$NON-NLS-2$
+			if (fName != null) {
+				writer.print(" name=\"" + fName + "\""); //$NON-NLS-1$//$NON-NLS-2$
+			}
 			writer.print(" enabled=\"" + fEnabled + "\""); //$NON-NLS-1$//$NON-NLS-2$
 			writer.println(" />"); //$NON-NLS-1$
 		}
@@ -99,7 +118,7 @@ public class RepositoryInfo extends ProductObject implements IRepositoryInfo {
 		if (!(obj instanceof RepositoryInfo other)) {
 			return false;
 		}
-		return Objects.equals(fURL, other.fURL);
+		return Objects.equals(fURL, other.fURL) && Objects.equals(fName, other.fName);
 	}
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/site/RepositoryReference.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/site/RepositoryReference.java
@@ -25,9 +25,11 @@ public class RepositoryReference extends SiteObject implements IRepositoryRefere
 	private static final long serialVersionUID = 1L;
 
 	public static final String P_LOCATION = "location"; //$NON-NLS-1$
+	public static final String P_NAME = "name"; //$NON-NLS-1$
 	public static final String P_ENABLED = "enabled"; //$NON-NLS-1$
 
 	private String fURL;
+	private String fName;
 	private boolean fEnabled = true; // enabled unless specified otherwise
 
 	public RepositoryReference() {
@@ -48,6 +50,19 @@ public class RepositoryReference extends SiteObject implements IRepositoryRefere
 	}
 
 	@Override
+	public String getName() {
+		return fName;
+	}
+
+	@Override
+	public void setName(String name) throws CoreException {
+		String old = fName;
+		fName = name;
+		ensureModelEditable();
+		firePropertyChanged(P_NAME, old, fName);
+	}
+
+	@Override
 	public boolean getEnabled() {
 		return fEnabled;
 	}
@@ -65,6 +80,7 @@ public class RepositoryReference extends SiteObject implements IRepositoryRefere
 		if (node.getNodeType() == Node.ELEMENT_NODE) {
 			Element element = (Element) node;
 			fURL = element.getAttribute("location"); //$NON-NLS-1$
+			fName = element.getAttribute("name"); //$NON-NLS-1$
 			fEnabled = Boolean.parseBoolean(element.getAttribute(P_ENABLED));
 		}
 	}
@@ -73,6 +89,9 @@ public class RepositoryReference extends SiteObject implements IRepositoryRefere
 	public void write(String indent, PrintWriter writer) {
 		if (isURLDefined()) {
 			writer.print(indent + "<repository-reference location=\"" + fURL + "\""); //$NON-NLS-1$ //$NON-NLS-2$
+			if (fName != null) {
+				writer.print(" name=\"" + fName + "\""); //$NON-NLS-1$//$NON-NLS-2$
+			}
 			writer.print(" enabled=\"" + fEnabled + "\""); //$NON-NLS-1$//$NON-NLS-2$
 			writer.println(" />"); //$NON-NLS-1$
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3071,12 +3071,15 @@ public class PDEUIMessages extends NLS {
 	public static String UpdatesSection_description;
 	public static String UpdatesSection_RepositoryDialogTitle;
 	public static String UpdatesSection_Location;
+	public static String UpdatesSection_Name;
 	public static String UpdatesSection_ErrorLocationNoName;
 	public static String UpdatesSection_ErrorInvalidURL;
 	public static String UpdatesSection_LocationColumn;
 
 	public static String UpdatesSection_LocationMessage;
 	public static String UpdatesSection_EnabledColumn;
+
+	public static String UpdatesSection_NameColumn;
 
 	public static String CustomizationPage_title;
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2568,11 +2568,13 @@ UpdatesSection_description=Specify the repository locations for product updates.
 Enabled repositories are always contacted for updates. Disabled repositories are added to the preference list but must be explicitly enabled by the user in order to be contacted.
 UpdatesSection_RepositoryDialogTitle=Repository Location
 UpdatesSection_Location=Enter a URL:
+UpdatesSection_Name=Enter a name:
 UpdatesSection_ErrorLocationNoName=You must specify a URL for the repository location.
 UpdatesSection_ErrorInvalidURL=The location specified for the repository is not a valid URL.
 UpdatesSection_LocationColumn=Location
 UpdatesSection_LocationMessage=A valid http://, https://, or file:/ URL
 UpdatesSection_EnabledColumn=Enabled
+UpdatesSection_NameColumn=Name
 
 CustomizationPage_title=Customization
 PreferencesSection_title=Default Preferences


### PR DESCRIPTION
2 editors are changed: product file editor and then the repository section but also the category editor which uses the same stuff (code is very simular)

UI part for https://github.com/eclipse-equinox/p2/issues/345