### PR TITLE
Correctly determine if automatic manifest option is valid

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewProjectCreationOperation.java
@@ -465,7 +465,9 @@ public class NewProjectCreationOperation extends WorkspaceModifyOperation {
 
 	private boolean isAutomaticMetadata() {
 		if (fData instanceof PluginFieldData d) {
-			return d.isAutomaticMetadataGeneration();
+
+			String framework = d.getOSGiFramework();
+			return d.isAutomaticMetadataGeneration() && framework != null && !ICoreConstants.EQUINOX.equals(framework);
 		}
 		return false;
 	}


### PR DESCRIPTION
Currently if the "generate automatic manifest" is checked it still creates one if a user later choose to create a traditional one.

This enhance the check in the wizard to make sure it is actually a valid choice.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/798