### PR TITLE
Use ExtensionBasedTextEditor as the base instead of TextEditor

### DIFF
--- a/ds/org.eclipse.pde.ds.ui/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.30.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.24.200,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)",
  org.eclipse.jdt.ui;bundle-version="[3.31.0,4.0.0)",
- org.eclipse.core.filesystem;bundle-version="[1.10.200,2.0.0)"
+ org.eclipse.core.filesystem;bundle-version="[1.10.200,2.0.0)",
+ org.eclipse.ui.genericeditor;bundle-version="[1.3.200,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.pde.internal.ds.ui;x-internal:=true,

--- a/ua/org.eclipse.pde.ua.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.pde.ua.ui/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.205.0,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.100,4.0.0)",
  org.eclipse.search;bundle-version="[3.16.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.9.2,4.0.0)",
- org.eclipse.core.filesystem;bundle-version="[1.10.200,2.0.0)"
+ org.eclipse.core.filesystem;bundle-version="[1.10.200,2.0.0)",
+ org.eclipse.ui.genericeditor;bundle-version="[1.3.200,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.pde.internal.ua.ui;x-internal:=true,

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDESourcePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDESourcePage.java
@@ -60,7 +60,6 @@ import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.editors.text.EditorsUI;
-import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.IFormPage;
@@ -73,7 +72,9 @@ import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 import org.eclipse.ui.texteditor.ResourceAction;
 import org.eclipse.ui.texteditor.TextOperationAction;
 
-public abstract class PDESourcePage extends TextEditor implements IFormPage, IGotoMarker, ISelectionChangedListener, IOutlineContentCreator, IOutlineSelectionHandler {
+@SuppressWarnings("restriction")
+public abstract class PDESourcePage extends org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor
+		implements IFormPage, IGotoMarker, ISelectionChangedListener, IOutlineContentCreator, IOutlineSelectionHandler {
 
 	private static String RES_BUNDLE_LOCATION = "org.eclipse.pde.internal.ui.editor.text.ConstructedPDEEditorMessages"; //$NON-NLS-1$
 	private static ResourceBundle fgBundleForConstructedKeys = ResourceBundle.getBundle(RES_BUNDLE_LOCATION);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndSourcePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/bnd/BndSourcePage.java
@@ -13,101 +13,12 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.bnd;
 
-import org.eclipse.core.resources.IMarker;
-import org.eclipse.pde.internal.ui.IHelpContextIds;
+import org.eclipse.pde.internal.ui.editor.GenericSourcePage;
 import org.eclipse.pde.internal.ui.editor.PDEFormEditor;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.forms.IManagedForm;
-import org.eclipse.ui.forms.editor.FormEditor;
-import org.eclipse.ui.forms.editor.IFormPage;
-import org.eclipse.ui.ide.IDE;
 
-@SuppressWarnings("restriction")
-public class BndSourcePage extends org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor implements IFormPage {
-
-	private FormEditor editor;
-	private boolean active;
-	private int index;
-	private String id;
-	private Control fControl;
+public class BndSourcePage extends GenericSourcePage {
 
 	public BndSourcePage(PDEFormEditor editor, String id, String title) {
-		this.id = id;
+		super(editor, id, title);
 	}
-
-	@Override
-	public void initialize(FormEditor editor) {
-		this.editor = editor;
-	}
-
-	@Override
-	public FormEditor getEditor() {
-		return editor;
-	}
-
-	@Override
-	public IManagedForm getManagedForm() {
-		return null;
-	}
-
-	@Override
-	public void setActive(boolean active) {
-		this.active = active;
-	}
-
-	@Override
-	public boolean isActive() {
-		return active;
-	}
-
-	@Override
-	public boolean canLeaveThePage() {
-		return true;
-	}
-
-	@Override
-	public Control getPartControl() {
-		return fControl;
-	}
-
-	@Override
-	public void createPartControl(Composite parent) {
-		super.createPartControl(parent);
-		Control[] children = parent.getChildren();
-		fControl = children[children.length - 1];
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(fControl, IHelpContextIds.MANIFEST_SOURCE_PAGE);
-	}
-
-	@Override
-	public String getId() {
-		return id;
-	}
-
-	@Override
-	public int getIndex() {
-		return index;
-	}
-
-	@Override
-	public void setIndex(int index) {
-		this.index = index;
-	}
-
-	@Override
-	public boolean isEditor() {
-		return true;
-	}
-
-	@Override
-	public boolean selectReveal(Object object) {
-		if (object instanceof IMarker) {
-			IDE.gotoMarker(this, (IMarker) object);
-			return true;
-		}
-		return false;
-	}
-
-
 }


### PR DESCRIPTION
Actually all PDE source pages can benefit from Generic Editor also some functionality relies on the PDESourcePage as a base.

This makes the PDESourcePage extend the ExtensionBasedTextEditor to account for this.