### PR TITLE
The pde.ua.tests requires org.eclipse.ui.genericeditor

### DIFF
--- a/ua/org.eclipse.pde.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.pde.ua.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.ua.tests
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-ClassPath: tests.jar
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.pde.ua.core;bundle-version="[1.0.0,2.0.0)",
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.search;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.ui.workbench.texteditor;bundle-version="[3.6.0,4.0.0)"
+ org.eclipse.ui.workbench.texteditor;bundle-version="[3.6.0,4.0.0)",
+ org.eclipse.ui.genericeditor;bundle-version="[1.3.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/ua/org.eclipse.pde.ua.tests/pom.xml
+++ b/ua/org.eclipse.pde.ua.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.pde</groupId>
   <artifactId>org.eclipse.pde.ua.tests</artifactId>
-  <version>1.3.100-SNAPSHOT</version>
+  <version>1.3.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Without this, there is a compile error calling PDESourcePage.getDocumentProvider.