### PR TITLE
Abstract the lookup of included schemas

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/PathSchemaProvider.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/PathSchemaProvider.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *  Copyright (c) 2000, 2023 IBM Corporation and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - extract to schema provider
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.schema;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.pde.internal.core.ischema.ISchema;
+import org.eclipse.pde.internal.core.ischema.ISchemaDescriptor;
+
+public class PathSchemaProvider implements SchemaProvider {
+
+	private List<IPath> searchPath;
+
+	public PathSchemaProvider(List<IPath> searchPath) {
+		this.searchPath = searchPath;
+	}
+
+	@Override
+	public ISchema createSchema(ISchemaDescriptor descriptor, String location) {
+
+		try {
+			URL schemaURL = IncludedSchemaDescriptor.computeURL(descriptor, location, searchPath);
+			if (schemaURL == null) {
+				return null;
+			}
+			Schema ischema = new Schema(null, schemaURL, false);
+			ischema.load();
+			return ischema;
+		} catch (MalformedURLException e) {
+			return null;
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/Schema.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/Schema.java
@@ -23,13 +23,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Vector;
 
 import javax.xml.parsers.SAXParser;
 
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.pde.core.IModelChangedEvent;
@@ -100,7 +98,7 @@ public class Schema extends PlatformObject implements ISchema {
 
 	private final boolean fAbbreviated;
 
-	private List<IPath> fSearchPath;
+	private SchemaProvider schemaProvider;
 
 	public Schema(String pluginId, String pointId, String name, boolean abbreviated) {
 		fPluginID = pluginId;
@@ -865,7 +863,7 @@ public class Schema extends PlatformObject implements ISchema {
 
 	private void processInclude(Node node) {
 		String location = getAttribute(node, "schemaLocation"); //$NON-NLS-1$
-		SchemaInclude include = new SchemaInclude(this, location, fAbbreviated, fSearchPath);
+		SchemaInclude include = new SchemaInclude(this, location, fAbbreviated, schemaProvider);
 		if (fIncludes == null) {
 			fIncludes = new Vector<>();
 		}
@@ -1010,14 +1008,13 @@ public class Schema extends PlatformObject implements ISchema {
 	}
 
 	/**
-	 * Sets a list of additional schema relative or absolute paths to search when
-	 * trying to find an included schema.  Must be set before {@link #load()} is
+	 * Sets a provider of additional schema to search when trying to find an included schema.  Must be set before {@link #load()} is
 	 * called.
 	 *
-	 * @param searchPath the list of paths to search for included schema or <code>null</code> for no additional paths
+	 * @param provider the list of paths to search for included schema or <code>null</code> for no additional paths
 	 */
-	public void setSearchPath(List<IPath> searchPath) {
-		fSearchPath = searchPath;
+	public void setSchemaProvider(SchemaProvider provider) {
+		schemaProvider = provider;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaDescriptor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaDescriptor.java
@@ -16,10 +16,8 @@ package org.eclipse.pde.internal.core.schema;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.pde.internal.core.ischema.ISchema;
 import org.eclipse.pde.internal.core.ischema.ISchemaDescriptor;
 
@@ -30,7 +28,7 @@ public class SchemaDescriptor implements ISchemaDescriptor {
 	private Schema fSchema;
 	private long fLastModified;
 	private boolean fEditable;
-	private List<IPath> fSearchPath;
+	private SchemaProvider schemaProvider;
 
 	public SchemaDescriptor(String extPointID, URL schemaURL) {
 		this(extPointID, schemaURL, null);
@@ -42,9 +40,9 @@ public class SchemaDescriptor implements ISchemaDescriptor {
 	 *
 	 * @param extPointID the extension point the schema describes
 	 * @param schemaURL the url location of the schema
-	 * @param searchPath list of absolute or schema relative paths to search for included schemas, may be <code>null</code>
+	 * @param provider list of absolute or schema relative paths to search for included schemas, may be <code>null</code>
 	 */
-	public SchemaDescriptor(String extPointID, URL schemaURL, List<IPath> searchPath) {
+	public SchemaDescriptor(String extPointID, URL schemaURL, SchemaProvider provider) {
 		fPoint = extPointID;
 		fSchemaURL = schemaURL;
 		if (fSchemaURL != null) {
@@ -53,7 +51,7 @@ public class SchemaDescriptor implements ISchemaDescriptor {
 				fLastModified = file.lastModified();
 			}
 		}
-		fSearchPath = searchPath;
+		schemaProvider = provider;
 	}
 
 	public SchemaDescriptor(IFile file, boolean editable) {
@@ -87,7 +85,7 @@ public class SchemaDescriptor implements ISchemaDescriptor {
 			} else {
 				fSchema = new Schema(this, fSchemaURL, abbreviated);
 			}
-			fSchema.setSearchPath(fSearchPath);
+			fSchema.setSchemaProvider(schemaProvider);
 			fSchema.load();
 		}
 		return fSchema;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaInclude.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaInclude.java
@@ -14,12 +14,8 @@
 package org.eclipse.pde.internal.core.schema;
 
 import java.io.PrintWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.ischema.ISchema;
 import org.eclipse.pde.internal.core.ischema.ISchemaDescriptor;
@@ -36,7 +32,7 @@ public class SchemaInclude extends SchemaObject implements ISchemaInclude {
 
 	private final boolean fAbbreviated;
 
-	private final List<IPath> fSearchPath;
+	private final SchemaProvider schemaProvider;
 
 	public SchemaInclude(ISchemaObject parent, String location, boolean abbreviated) {
 		this(parent, location, abbreviated, null);
@@ -51,11 +47,11 @@ public class SchemaInclude extends SchemaObject implements ISchemaInclude {
 	 * @param abbreviated whether the schema is following the abbreviated syntax
 	 * @param searchPath list of schema relative or absolute paths to look for the included schema, may be <code>null</code>
 	 */
-	public SchemaInclude(ISchemaObject parent, String location, boolean abbreviated, List<IPath> searchPath) {
+	public SchemaInclude(ISchemaObject parent, String location, boolean abbreviated, SchemaProvider schemaProvider) {
 		super(parent, location);
 		fLocation = location;
 		fAbbreviated = abbreviated;
-		fSearchPath = searchPath;
+		this.schemaProvider = schemaProvider;
 	}
 
 	/**
@@ -97,23 +93,9 @@ public class SchemaInclude extends SchemaObject implements ISchemaInclude {
 			SchemaRegistry registry = PDECore.getDefault().getSchemaRegistry();
 			fIncludedSchema = registry.getIncludedSchema(descriptor, fLocation);
 		} else if (fIncludedSchema == null) {
-			fIncludedSchema = createInternalSchema(descriptor, fLocation);
+			fIncludedSchema = schemaProvider.createSchema(descriptor, fLocation);
 		}
 		return fIncludedSchema;
-	}
-
-	private ISchema createInternalSchema(ISchemaDescriptor desc, String location) {
-		try {
-			URL schemaURL = IncludedSchemaDescriptor.computeURL(desc, location, fSearchPath);
-			if (schemaURL == null) {
-				return null;
-			}
-			Schema ischema = new Schema(null, schemaURL, fAbbreviated);
-			ischema.load();
-			return ischema;
-		} catch (MalformedURLException e) {
-			return null;
-		}
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaProvider.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaProvider.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.schema;
+
+import org.eclipse.pde.internal.core.ischema.ISchema;
+import org.eclipse.pde.internal.core.ischema.ISchemaDescriptor;
+
+public interface SchemaProvider {
+
+	ISchema createSchema(ISchemaDescriptor descriptor, String location);
+
+}

--- a/ui/org.eclipse.pde.core/src_ant/org/eclipse/pde/internal/core/ant/ConvertSchemaToHTML.java
+++ b/ui/org.eclipse.pde.core/src_ant/org/eclipse/pde/internal/core/ant/ConvertSchemaToHTML.java
@@ -45,6 +45,7 @@ import org.eclipse.pde.internal.core.ischema.ISchemaInclude;
 import org.eclipse.pde.internal.core.plugin.ExternalFragmentModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModelBase;
+import org.eclipse.pde.internal.core.schema.PathSchemaProvider;
 import org.eclipse.pde.internal.core.schema.Schema;
 import org.eclipse.pde.internal.core.schema.SchemaDescriptor;
 import org.eclipse.pde.internal.core.util.HeaderMap;
@@ -101,7 +102,8 @@ public class ConvertSchemaToHTML extends Task {
 				org.eclipse.core.internal.runtime.XmlProcessorFactory.createSAXParserWithErrorOnDOCTYPE()
 						.parse(schemaFile, handler);
 				URL url = schemaFile.toURL();
-				SchemaDescriptor desc = new SchemaDescriptor(extPoint.getFullId(), url, searchPaths);
+				SchemaDescriptor desc = new SchemaDescriptor(extPoint.getFullId(), url,
+						new PathSchemaProvider(searchPaths));
 				schema = (Schema) desc.getSchema(false);
 
 				// Check that all included schemas are available


### PR DESCRIPTION
Currently the lookup of additional schemas is hardcoded to use a list of absolute pathes. this has the drawback that other ways are not supported (e.g. schemas from a jar file or whatever source).

This adds an abstraction for the lookup that can be used to plugin additional strategies.