### PR TITLE
Throw exception in MinimalState::addBundle if the model wasn't installed

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
@@ -105,6 +105,14 @@ public class MinimalState {
 		BundleDescription desc = model.getBundleDescription();
 		long bundleId = desc == null || !update ? -1 : desc.getBundleId();
 		try {
+			if (model.getInstallLocation() == null) {
+				// This exception should help diagnosing the problem. If this
+				// exception wasn't thrown then the code would throw a NPE in
+				// the next line anyway.
+				throw new IllegalArgumentException(
+						"The plugin '" + model + "' was not created from a resource in the file system"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+
 			File bundleLocation = new File(model.getInstallLocation());
 			BundleDescription newDesc = addBundle(bundleLocation, bundleId,
 					loadWorkspaceBundleManifest(bundleLocation, model.getUnderlyingResource()));


### PR DESCRIPTION
The exception is an attempt to shed some light in the real cause of the problem that's causing some tests fail and it simply replaces an obscure NPE that's happening anyway. It logs the name of the model for which the method would have failed with a NPE.

This PR does **not** solve the underlying problem, it merely helps identifying it.

Contributes to https://github.com/eclipse-pde/eclipse.pde/issues/554

## A last remark
FWIW by looking at the rest of the code in the class, I'm pretty sure it should be safe to simply skip such plug-ins by changing the `if` statement at the beginning of the method to 
```java
if (model == null || model.getInstallLocation() == null) {
     return;
}
```
... what do you guys think?