### PR TITLE
Enable Javadoc generation in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,9 @@ pipeline {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
 					sh '''
 						mvn clean verify --batch-mode -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						-Pbree-libs -Papi-check \
+						-Pbree-libs \
+						-Papi-check \
+						-Pjavadoc \
 						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
 					'''
 				}


### PR DESCRIPTION
Currently javadoc is not generated as part of the build making javadoc errors hard to discover.