### PR TITLE
Disable workspace export action for mixed products

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -340,6 +340,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String ProductEditor_exportTooltip;
 
+	public static String ProductEditor_exportTooltip_mixed;
+
 	public static String ProductEditor_launchFailed;
 
 	public static String RemoveSplashHandlerBindingAction_msgProgressRemoveProductBindings;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductEditor.java
@@ -172,21 +172,33 @@ public class ProductEditor extends PDELauncherFormEditor {
 	public void contributeToToolbar(IToolBarManager manager) {
 		contributeLaunchersToToolbar(manager);
 		manager.add(getExportAction());
-		IBaseModel model = getAggregateModel();
-		if (model == null) {
-			return;
+		if (getAggregateModel() instanceof IProductModel productModel) {
+			productModel.addModelChangedListener(e -> {
+				if (IProduct.P_TYPE.equals(e.getChangedProperty())) {
+					setExportActionState();
+				}
+			});
+			manager.add(new ProductValidateAction(productModel.getProduct()));
 		}
-		IProduct product = ((IProductModel) model).getProduct();
-		manager.add(new ProductValidateAction(product));
 	}
 
 	private ProductExportAction getExportAction() {
 		if (fExportAction == null) {
 			fExportAction = new ProductExportAction(this);
-			fExportAction.setToolTipText(PDEUIMessages.ProductEditor_exportTooltip);
 			fExportAction.setImageDescriptor(PDEPluginImages.DESC_EXPORT_PRODUCT_TOOL);
+			setExportActionState();
 		}
 		return fExportAction;
+	}
+
+	private void setExportActionState() {
+		if (getAggregateModel() instanceof IProductModel productModel) {
+			boolean isMixed = productModel.getProduct().getType() == ProductType.MIXED;
+			fExportAction.setEnabled(!isMixed);
+			fExportAction.setToolTipText(isMixed //
+					? PDEUIMessages.ProductEditor_exportTooltip_mixed
+					: PDEUIMessages.ProductEditor_exportTooltip);
+		}
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2091,6 +2091,7 @@ ProductExportWizardPage_wrongExtension=A product configuration file name must ha
 ProductExportWizardPage_fileSelection=File Selection
 ProductIntroWizardPage_invalidIntroId=Invalid Intro ID.  Legal characters are: a-z A-Z 0-9 .
 ProductEditor_exportTooltip=Export an Eclipse product
+ProductEditor_exportTooltip_mixed=Export a mixed Eclipse product is not (yet) supported
 ProductEditor_launchFailed=Failed to launch product from Editor
 ProductExportWizardPage_productSelection=Select a product configuration
 ProductExportWizardPage_exportOptionsGroup=Export Options


### PR DESCRIPTION
Mixed products can not be exported from the workspace (at the moment).
In order to avoid later errors, disable the export action in the Product-Editor for mixed products.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/825