### PR TITLE
Adding a category for the layout spy

### DIFF
--- a/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.tools.layout.spy;singleton:=true
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jface.databinding;bundle-version="1.9.0",

--- a/ui/org.eclipse.tools.layout.spy/plugin.xml
+++ b/ui/org.eclipse.tools.layout.spy/plugin.xml
@@ -19,6 +19,10 @@
 <!-- Extensions -->
    <extension
          point="org.eclipse.ui.commands">
+      <category
+            id="org.eclipse.pde.runtime.spy.commands.category"
+            name="%spy-category.name">
+      </category>
       <command
             categoryId="org.eclipse.pde.runtime.spy.commands.category"
             description="%spy-layout-command.description"


### PR DESCRIPTION
core and ui define this org.eclipse.pde.runtime.spy.commands.category category for their command. Copying over the solution for the layout spy.

Fixes #856