### PR TITLE
Consider the BND Buildpath/Testpath as extra items in the container

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -58,6 +58,7 @@ import org.eclipse.pde.internal.build.IBuildPropertiesConstants;
 import org.eclipse.pde.internal.core.bnd.BndProjectManager;
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
 
+import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 
 public class RequiredPluginsClasspathContainer extends PDEClasspathContainer implements IClasspathContainer {
@@ -204,6 +205,7 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 			if (fBuild != null) {
 				addSecondaryDependencies(desc, added, entries);
 			}
+			addBndClasspath(desc, added, entries);
 
 			// add Import-Package
 			// sort by symbolicName_version to get a consistent order
@@ -227,6 +229,22 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 		} catch (CoreException e) {
 		}
 		return entries;
+	}
+
+	private void addBndClasspath(BundleDescription desc, Set<BundleDescription> added, List<IClasspathEntry> entries) {
+		try {
+			Optional<Project> bndProject = BndProjectManager.getBndProject(project);
+			if (bndProject.isPresent()) {
+				for (Container container : bndProject.get().getBuildpath()) {
+					addExtraModel(desc, added, entries, container.getBundleSymbolicName());
+				}
+				for (Container container : bndProject.get().getTestpath()) {
+					addExtraModel(desc, added, entries, container.getBundleSymbolicName());
+				}
+			}
+		} catch (Exception e) {
+			PDECore.logException(e, "Can't set classpath from bnd!"); //$NON-NLS-1$
+		}
 	}
 
 	/**
@@ -538,21 +556,27 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 			if (entry != null) {
 				String[] tokens = entry.getTokens();
 				for (String pluginId : tokens) {
-					// Get PluginModelBase first to resolve system.bundle entry if it exists
-					IPluginModelBase model = PluginRegistry.findModel(pluginId);
-					if (model != null) {
-						BundleDescription bundleDesc = model.getBundleDescription();
-						if (added.contains(bundleDesc)) {
-							continue;
-						}
-						Map<BundleDescription, List<Rule>> rules = new HashMap<>();
-						findExportedPackages(bundleDesc, desc, rules);
-						addDependency(bundleDesc, added, rules, entries, true);
-					}
+					// Get PluginModelBase first to resolve system.bundle entry
+					// if it exists
+					addExtraModel(desc, added, entries, pluginId);
 				}
 			}
 		} catch (CoreException e) {
 			return;
+		}
+	}
+
+	private void addExtraModel(BundleDescription desc, Set<BundleDescription> added, List<IClasspathEntry> entries,
+			String pluginId) throws CoreException {
+		IPluginModelBase model = PluginRegistry.findModel(pluginId);
+		if (model != null) {
+			BundleDescription bundleDesc = model.getBundleDescription();
+			if (added.contains(bundleDesc)) {
+				return;
+			}
+			Map<BundleDescription, List<Rule>> rules = new HashMap<>();
+			findExportedPackages(bundleDesc, desc, rules);
+			addDependency(bundleDesc, added, rules, entries, true);
 		}
 	}
 
@@ -572,7 +596,8 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 				}
 				map.put(bdesc, rules);
 
-				// Look at re-exported Require-Bundles for any other exported packages
+				// Look at re-exported Require-Bundles for any other exported
+				// packages
 				BundleSpecification[] requiredBundles = bdesc.getRequiredBundles();
 				for (BundleSpecification requiredBundle : requiredBundles) {
 					if (requiredBundle.isExported()) {


### PR DESCRIPTION
Currently we rely on the Manifest to discover all required items but that do not work for items that are not referenced inside the manifest.

This handles the BND Buildpath/Testpath as if it was part of the traditional Secondary Dependencies.