### PR TITLE
Remove unnecessary 'fragment' attribute of plugin-elements in products

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IProductPlugin.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IProductPlugin.java
@@ -23,17 +23,4 @@ public interface IProductPlugin extends IProductObject {
 	String getVersion();
 
 	void setVersion(String version);
-
-	/**
-	 * @return whether this product plug-in is a fragment. <code>false</code> by default.
-	 * @see #setFragment(boolean)
-	 */
-	boolean isFragment();
-
-	/**
-	 * Sets whether this product plug-in is a fragment. <code>false</code> by default.
-	 * @param isFragment whether this product is a fragment
-	 * @see #isFragment()
-	 */
-	void setFragment(boolean isFragment);
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ProductPlugin.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ProductPlugin.java
@@ -18,8 +18,6 @@ package org.eclipse.pde.internal.core.product;
 
 import java.io.PrintWriter;
 
-import org.eclipse.pde.core.plugin.IFragmentModel;
-import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.iproduct.IProductModel;
 import org.eclipse.pde.internal.core.iproduct.IProductPlugin;
@@ -32,12 +30,6 @@ public class ProductPlugin extends ProductObject implements IProductPlugin {
 	private String fId;
 	private String fVersion;
 
-	/**
-	 * Used to cache the fragment attribute value internally in order to not lose it in case the current
-	 * plugin/fragment is not in the target platform anymore (see bug 264462)
-	 */
-	private boolean fFragment;
-
 	public ProductPlugin(IProductModel model) {
 		super(model);
 	}
@@ -48,8 +40,6 @@ public class ProductPlugin extends ProductObject implements IProductPlugin {
 			Element element = (Element) node;
 			fId = element.getAttribute("id"); //$NON-NLS-1$
 			fVersion = element.getAttribute("version"); //$NON-NLS-1$
-			String fragment = element.getAttribute("fragment"); //$NON-NLS-1$
-			fFragment = Boolean.parseBoolean(fragment);
 		}
 	}
 
@@ -59,16 +49,6 @@ public class ProductPlugin extends ProductObject implements IProductPlugin {
 		if (fVersion != null && fVersion.length() > 0 && !fVersion.equals(ICoreConstants.DEFAULT_VERSION)) {
 			writer.print(" version=\"" + fVersion + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-
-		// If the plugin is a known fragment or has a cached fragment setting, mark it as a fragment
-		if (PluginRegistry.findModel(fId) != null) {
-			if (PluginRegistry.findModel(fId) instanceof IFragmentModel) {
-				writer.print(" fragment=\"" + Boolean.TRUE + "\""); //$NON-NLS-1$ //$NON-NLS-2$
-			}
-		} else if (fFragment) {
-			writer.print(" fragment=\"" + Boolean.TRUE + "\""); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-
 		writer.println("/>"); //$NON-NLS-1$
 	}
 
@@ -94,16 +74,6 @@ public class ProductPlugin extends ProductObject implements IProductPlugin {
 		if (isEditable()) {
 			firePropertyChanged("version", old, fVersion); //$NON-NLS-1$
 		}
-	}
-
-	@Override
-	public boolean isFragment() {
-		return fFragment;
-	}
-
-	@Override
-	public void setFragment(boolean isFragment) {
-		fFragment = isFragment;
 	}
 
 }


### PR DESCRIPTION
The PDE Product Editor used to add a `fragment` attribute to plugin elements in `*.product` files, but the attribute is unused for a long time.

Relates to https://github.com/eclipse-equinox/p2/pull/378