### PR TITLE
Assume bundle shape as jar by default

### DIFF
--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: org.eclipse.pde.build.tests;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Activator: org.eclipse.pde.build.tests.Activator
 Export-Package: org.eclipse.pde.build.internal.tests;x-internal:=true,
  org.eclipse.pde.build.internal.tests.ant;x-internal:=true,

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/P2Tests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/P2Tests.java
@@ -629,8 +629,8 @@ public class P2Tests extends P2TestCase {
 		IFolder b = Utils.createFolder(buildFolder, "plugins/b");
 		IFolder c = Utils.createFolder(buildFolder, "plugins/c");
 
-		Utils.generateFeature(buildFolder, "F", null, new String[] { "a;unpack=false", "b;unpack=false;os=linux",
-				"b;unpack=false;os=win32", "c;unpack=false" });
+		Utils.generateFeature(buildFolder, "F", null, new String[] { "a", "b;os=linux",
+				"b;os=win32", "c" });
 		Properties featureProperties = new Properties();
 		featureProperties.put("bin.includes", "feature.xml");
 		Utils.storeProperties(buildFolder.getFile("features/F/build.properties"), featureProperties);
@@ -685,7 +685,7 @@ public class P2Tests extends P2TestCase {
 
 		// now change A and recompile
 		Utils.generateFeature(buildFolder, "F", null,
-				new String[] { "a;unpack=true", "b;os=linux;optional=true", "c;unpack=false" });
+				new String[] { "a", "b;os=linux;optional=true", "c" });
 		Utils.storeProperties(buildFolder.getFile("features/F/build.properties"), featureProperties);
 
 		code = new StringBuffer();
@@ -762,8 +762,7 @@ public class P2Tests extends P2TestCase {
 		assertLogContainsLines(buildFolder.getFile("compare.log"),
 				new String[] { "canonical: org.eclipse.update.feature,F,1.0.0",
 						"The feature has a different number of entries",
-						"The entry \"Plugin: a 1.0.0.v2\" is not present in both features",
-						"The entry \"Plugin: b 1.0.0\" has different unpack attribute values" });
+						"The entry \"Plugin: a 1.0.0.v2\" is not present in both features", });
 		assertLogContainsLines(buildFolder.getFile("compare.log"),
 				new String[] { "canonical: osgi.bundle,b,1.0.0", "The class B.class is different." });
 		boolean failed = true;

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/tests/PDETestCase.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/tests/PDETestCase.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.pde.build.tests;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,11 +26,15 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.helper.AntXMLContext;
@@ -324,9 +328,11 @@ public abstract class PDETestCase {
 		assertTrue(logFile.length() > 0);
 
 		int idx = 0;
+		List<String> logContent = new ArrayList<>();
 		try (BufferedReader reader = new BufferedReader(new FileReader(logFile))) {
 			while (reader.ready()) {
 				String line = reader.readLine();
+				logContent.add(line);
 				if (line.indexOf(lines[idx]) >= 0) {
 					if (++idx >= lines.length) {
 						reader.close();
@@ -335,7 +341,11 @@ public abstract class PDETestCase {
 				}
 			}
 		}
-		fail();
+
+		// Will always fail here (expected)
+		String expected = Stream.of(lines).map(x -> x.trim()).collect(Collectors.joining("\n"));
+		String actual = logContent.stream().map(x -> x.trim()).collect(Collectors.joining("\n"));
+		assertEquals("Not found given lines in given order", expected, actual);
 	}
 
 	/**

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/FeatureGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/FeatureGenerator.java
@@ -425,7 +425,7 @@ public class FeatureGenerator extends AbstractScriptGenerator {
 					Entry entry = listIter.next();
 					String name = entry.getId();
 					String bundleVersion = entry.getVersion();
-					boolean guessedUnpack = true;
+					boolean guessedUnpack = false;
 					boolean writeBundle = !verify;
 					if (verify) {
 						BundleDescription bundle = state.getResolvedBundle(name, bundleVersion);

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ShapeAdvisor.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ShapeAdvisor.java
@@ -113,6 +113,6 @@ public class ShapeAdvisor implements IPDEBuildConstants {
 			}
 		}
 
-		return true; //don't know, return the default
+		return false; //don't know, return the default
 	}
 }

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/Utils.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/Utils.java
@@ -777,7 +777,7 @@ public final class Utils implements IPDEBuildConstants, IBuildPropertiesConstant
 
 		results.put(EXTRA_ID, tokenizer.nextToken());
 		results.put(EXTRA_VERSION, Version.emptyVersion);
-		results.put(EXTRA_UNPACK, Boolean.TRUE);
+		results.put(EXTRA_UNPACK, Boolean.FALSE);
 
 		while (tokenizer.hasMoreTokens()) {
 			String token = tokenizer.nextToken();


### PR DESCRIPTION
- set PDE generator to assume "unpack" attribute from bundles to be "false" by default.
- additionally adopted testBug263272() to ignore "unpack=false" instructions from the feature.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/884