### PR TITLE
Use a default schema provider without path in case none is supplied

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaInclude.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaInclude.java
@@ -14,6 +14,7 @@
 package org.eclipse.pde.internal.core.schema;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.pde.internal.core.PDECore;
@@ -23,6 +24,8 @@ import org.eclipse.pde.internal.core.ischema.ISchemaInclude;
 import org.eclipse.pde.internal.core.ischema.ISchemaObject;
 
 public class SchemaInclude extends SchemaObject implements ISchemaInclude {
+
+	private static final PathSchemaProvider DEFAULT_SCHEMA_PROVIDER = new PathSchemaProvider(null);
 
 	private static final long serialVersionUID = 1L;
 
@@ -57,7 +60,7 @@ public class SchemaInclude extends SchemaObject implements ISchemaInclude {
 		super(parent, location);
 		fLocation = location;
 		fAbbreviated = abbreviated;
-		this.schemaProvider = schemaProvider;
+		this.schemaProvider = Objects.requireNonNullElse(schemaProvider, DEFAULT_SCHEMA_PROVIDER);
 	}
 
 	/**
@@ -98,7 +101,7 @@ public class SchemaInclude extends SchemaObject implements ISchemaInclude {
 		if (fAbbreviated) {
 			SchemaRegistry registry = PDECore.getDefault().getSchemaRegistry();
 			fIncludedSchema = registry.getIncludedSchema(descriptor, fLocation);
-		} else if (fIncludedSchema == null && schemaProvider != null) {
+		} else if (fIncludedSchema == null) {
 			fIncludedSchema = schemaProvider.createSchema(descriptor, fLocation);
 		}
 		return fIncludedSchema;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/schema/SchemaEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/schema/SchemaEditor.java
@@ -187,10 +187,17 @@ public class SchemaEditor extends MultiSourceEditor {
 
 	public static boolean openSchema(IPath path) {
 		String pluginId = path.segment(0);
+		int remove;
+		if ("schema:".equals(pluginId)) { //$NON-NLS-1$
+			pluginId = path.segment(1);
+			remove = 2;
+		} else {
+			remove = 1;
+		}
 		IPluginModelBase model = PluginRegistry.findModel(pluginId);
 		if (model != null && model.getUnderlyingResource() != null) {
 			IProject project = model.getUnderlyingResource().getProject();
-			IFile file = project.getFile(path.removeFirstSegments(1));
+			IFile file = project.getFile(path.removeFirstSegments(remove));
 			return openSchema(file);
 		}
 		return false;


### PR DESCRIPTION
Even though no search path is provided we need to decode the URL and see if we can find the schema in the current workspace.

Also fixes an issue where schema can't be opened by double click on linux.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/890