### PR TITLE
ClasspathUpdaterTests fail on Java 21

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -35,6 +35,7 @@
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
+          <argLine>-DDetectVMInstallationsJob.disabled=true</argLine>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
           <dependencies>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/classpathupdater/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/classpathupdater/.classpath
@@ -8,7 +8,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>


### PR DESCRIPTION
Don't hard code JRE version in test expectations. The test only wants to know if the classpath entries are there and in the right order, independently which JRE is used to run Eclipse / be on classpath.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/764