### PR TITLE
Fixes PDE preference page template

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/templates_3.1/preferences/java/$pageClassName$.java
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.1/preferences/java/$pageClassName$.java
@@ -1,9 +1,11 @@
 package $packageName$;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.*;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.IWorkbench;
-import $pluginClass$;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class represents a preference page that
@@ -31,7 +33,8 @@ public class $pageClassName$
 
 	public $pageClassName$() {
 		super(GRID);
-		setPreferenceStore($activator$.getDefault().getPreferenceStore());
+		ScopedPreferenceStore scopedPreferenceStore = new ScopedPreferenceStore(InstanceScope.INSTANCE, String.valueOf(FrameworkUtil.getBundle(getClass()).getBundleId()));
+		setPreferenceStore(scopedPreferenceStore);
 		setDescription("A demonstration of a preference page implementation");
 	}
 	
@@ -61,9 +64,7 @@ public class $pageClassName$
 			new StringFieldEditor(PreferenceConstants.P_STRING, "A &text preference:", getFieldEditorParent()));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
-	 */
+	@Override
 	public void init(IWorkbench workbench) {
 	}
 	

--- a/ui/org.eclipse.pde.ui.templates/templates_3.1/preferences/java/PreferenceInitializer.java
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.1/preferences/java/PreferenceInitializer.java
@@ -1,22 +1,20 @@
 package $packageName$;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
-import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.osgi.framework.FrameworkUtil;
 
-import $pluginClass$;
 
 /**
  * Class used to initialize default preference values.
  */
 public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
-	 */
+	@Override
 	public void initializeDefaultPreferences() {
-		IPreferenceStore store = $activator$.getDefault().getPreferenceStore();
+		ScopedPreferenceStore store = new ScopedPreferenceStore(InstanceScope.INSTANCE, String.valueOf(FrameworkUtil.getBundle(getClass()).getBundleId()));
+
 		store.setDefault(PreferenceConstants.P_BOOLEAN, true);
 		store.setDefault(PreferenceConstants.P_CHOICE, "choice2");
 		store.setDefault(PreferenceConstants.P_STRING,


### PR DESCRIPTION
The current template assumes that the plug-in has an activator. As we do not use activators anymore in the default plug-in template, we should also adjust this template.

Plus getting rid of NON-Javadoc