### PR TITLE
New PDE test fails since I20231105-1800

### DIFF
--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/AssembleTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/AssembleTests.java
@@ -201,13 +201,13 @@ public class AssembleTests extends PDETestCase {
 
 		Set<String> entries = new HashSet<>();
 		entries.add("eclipse/plugins/A_1.0.0.jar");
-		entries.add("eclipse/plugins/B_1.0.0/META-INF/MANIFEST.MF");
+		entries.add("eclipse/plugins/B_1.0.0.jar:META-INF/MANIFEST.MF");
 		assertZipContents(buildFolder, "I.TestBuild/F-TestBuild.zip", entries);
 
 		buildProperties.put("archivesFormat", "*,*,*-folder");
 		Utils.storeBuildProperties(buildFolder, buildProperties);
 		runBuild(buildFolder);
 		assertResourceFile(buildFolder, "tmp/e4/plugins/A_1.0.0.jar");
-		assertResourceFile(buildFolder, "tmp/e4/plugins/B_1.0.0/META-INF/MANIFEST.MF");
+		assertResourceFile(buildFolder, "tmp/e4/plugins/B_1.0.0.jar:META-INF/MANIFEST.MF");
 	}
 }

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ProductTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ProductTests.java
@@ -565,11 +565,11 @@ public class ProductTests extends PDETestCase {
 		assertLogContainsLine(config, "osgi.bundles.defaultStartLevel=3");
 		assertLogContainsLine(config, "osgi.bundles=org.eclipse.equinox.simpleconfigurator@1:start");
 		assertLogContainsLine(info,
-				"org.eclipse.core.runtime_" + versions.get("org.eclipse.core.runtime") + ",3,false");
-		assertLogContainsLine(info, "org.eclipse.equinox.app_" + versions.get("org.eclipse.equinox.app") + ",3,false"); // bug
+				"org.eclipse.core.runtime_" + versions.get("org.eclipse.core.runtime") + ".jar,3,false");
+		assertLogContainsLine(info, "org.eclipse.equinox.app_" + versions.get("org.eclipse.equinox.app") + ".jar,3,false"); // bug
 																														// 274901
 		assertLogContainsLine(info,
-				"org.eclipse.equinox.common_" + versions.get("org.eclipse.equinox.common") + ",1,true");
+				"org.eclipse.equinox.common_" + versions.get("org.eclipse.equinox.common") + ".jar,1,true");
 	}
 
 	@Test

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
@@ -23,6 +23,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.Enumeration;
@@ -41,6 +42,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.RuntimeConfigurable;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
+import org.apache.tools.ant.filters.StringInputStream;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.taskdefs.Javac;
 import org.apache.tools.ant.taskdefs.Parallel;
@@ -1788,14 +1790,23 @@ public class ScriptGenerationTests extends PDETestCase {
 		properties.put("generateSourceReferences", "true");
 		Utils.storeBuildProperties(buildFolder, properties);
 		runBuild(buildFolder);
-
-		Manifest m = Utils.loadManifest(buildFolder.getFile("tmp/eclipse/plugins/A_1.0.0/META-INF/MANIFEST.MF"));
-		assertEquals(m.getMainAttributes().getValue(IPDEBuildConstants.ECLIPSE_SOURCE_REF), a_source);
-		m = Utils.loadManifest(buildFolder.getFile("tmp/eclipse/plugins/B_1.0.0/META-INF/MANIFEST.MF"));
-		assertEquals(m.getMainAttributes().getValue(IPDEBuildConstants.ECLIPSE_SOURCE_REF),
+		
+		String manifestFile = readEntryFromZip(buildFolder.getFile("tmp/eclipse/plugins/A_1.0.0.jar"), "META-INF/MANIFEST.MF");
+		try (InputStream contents = new StringInputStream(manifestFile)) {
+			Manifest m = new Manifest(contents);
+			assertEquals(m.getMainAttributes().getValue(IPDEBuildConstants.ECLIPSE_SOURCE_REF), a_source);
+		}
+		manifestFile = readEntryFromZip(buildFolder.getFile("tmp/eclipse/plugins/B_1.0.0.jar"), "META-INF/MANIFEST.MF");
+		try (InputStream contents = new StringInputStream(manifestFile)) {
+			Manifest m = new Manifest(contents);
+			assertEquals(m.getMainAttributes().getValue(IPDEBuildConstants.ECLIPSE_SOURCE_REF),
 				"B's source,foo.bar;type:=\"mine\"");
-		m = Utils.loadManifest(buildFolder.getFile("tmp/eclipse/plugins/C_1.0.0/META-INF/MANIFEST.MF"));
-		assertEquals(m.getMainAttributes().getValue(IPDEBuildConstants.ECLIPSE_SOURCE_REF), "foo.bar;type:=mine");
+		}
+		manifestFile = readEntryFromZip(buildFolder.getFile("tmp/eclipse/plugins/C_1.0.0.jar"), "META-INF/MANIFEST.MF");
+		try (InputStream contents = new StringInputStream(manifestFile)) {
+			Manifest m = new Manifest(contents);
+			assertEquals(m.getMainAttributes().getValue(IPDEBuildConstants.ECLIPSE_SOURCE_REF), "foo.bar;type:=mine");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Adopted test expectations to changes made in
1765416677a731a710a9eb43524b4bd88f89b752, where PDE exports bundles as jars by default (unless "Eclipse-BundleShape: dir" is specified in manifest or other preconditions force bundle to be a directory).

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/884