### PR TITLE
FeatureErrorReporter.validatePluginExists should recognized fragments

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/FeatureErrorReporter.java
@@ -408,7 +408,7 @@ public class FeatureErrorReporter extends ManifestErrorReporter {
 		int severity = CompilerFlags.getFlag(fProject, CompilerFlags.F_UNRESOLVED_PLUGINS);
 		if (severity != CompilerFlags.IGNORE) {
 			IPluginModelBase model = PluginRegistry.findModel(id);
-			if (model == null || !model.isEnabled() || model.isFragmentModel()) {
+			if (model == null || !model.isEnabled()) {
 				VirtualMarker marker = report(NLS.bind(PDECoreMessages.Builders_Feature_reference, id), getLine(element, attr.getName()), severity, PDEMarkerFactory.CAT_OTHER);
 				addMarkerAttribute(marker, PDEMarkerFactory.compilerKey,  CompilerFlags.F_UNRESOLVED_PLUGINS);
 			}


### PR DESCRIPTION
The validator currently produces an error when it find the referenced plugin but the plugin is a fragment. This is wrong behavior for the latest implementation that makes no distinction between plugins versus fragments.

https://github.com/eclipse-pde/eclipse.pde/issues/915