### PR TITLE
Async update in product editor to prevent deadlock

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
@@ -409,7 +409,7 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 		if (applicationDeltas.length + productDeltas.length == 0) {
 			return;
 		}
-		Display.getDefault().syncExec(() -> {
+		Display.getDefault().asyncExec(() -> {
 			fAppCombo.handleExtensionDelta(applicationDeltas);
 			fProductCombo.handleExtensionDelta(productDeltas);
 		});
@@ -427,7 +427,7 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 		System.arraycopy(apps, 0, finalApps, 0, apps.length);
 		finalApps[apps.length] = ""; //$NON-NLS-1$
 
-		Display.getDefault().syncExec(() -> {
+		Display.getDefault().asyncExec(() -> {
 			fAppCombo.reload(finalApps);
 			fProductCombo.reload(finalProducts);
 		});


### PR DESCRIPTION
Reported in #907 that loading of target platform and de-selecting it in the preference can lead to a deadlock. With this change the update of the ProductInfoSection happens with async.