### PR TITLE
Revert "Postpone long-running operations to the activation of the "Tracing" tab."

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TracingOptionsManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TracingOptionsManager.java
@@ -24,16 +24,16 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 
@@ -44,8 +44,8 @@ public class TracingOptionsManager {
 		super();
 	}
 
-	public Map<String, String> getTemplateTable(String pluginId, IProgressMonitor monitor) {
-		Map<String, String> tracingTemplate = getTracingTemplate(monitor);
+	public Map<String, String> getTemplateTable(String pluginId) {
+		Map<String, String> tracingTemplate = getTracingTemplate();
 		Map<String, String> defaults = new HashMap<>();
 		tracingTemplate.forEach((key, value) -> {
 			if (belongsTo(key, pluginId)) {
@@ -60,9 +60,9 @@ public class TracingOptionsManager {
 		return pluginId.equalsIgnoreCase(firstSegment);
 	}
 
-	public Map<String, String> getTracingOptions(Map<String, String> storedOptions, IProgressMonitor monitor) {
+	public Map<String, String> getTracingOptions(Map<String, String> storedOptions) {
 		// Start with the fresh template from plugins
-		Map<String, String> defaults = getTracingTemplateCopy(monitor);
+		Map<String, String> defaults = getTracingTemplateCopy();
 		if (storedOptions != null) {
 			// Load stored values, but only for existing keys
 			storedOptions.forEach((key, value) -> {
@@ -74,29 +74,21 @@ public class TracingOptionsManager {
 		return defaults;
 	}
 
-	public Map<String, String> getTracingTemplateCopy(IProgressMonitor monitor) {
-		return new HashMap<>(getTracingTemplate(monitor));
+	public Map<String, String> getTracingTemplateCopy() {
+		return new HashMap<>(getTracingTemplate());
 	}
 
-	private synchronized Map<String, String> getTracingTemplate(IProgressMonitor monitor) {
-		if (template != null) {
-			return template;
-		}
-
-		Map<String, String> temp = new HashMap<>();
-		IPluginModelBase[] models = PluginRegistry.getAllModels();
-		SubMonitor subMonitor = SubMonitor.convert(monitor, models.length);
-
-		for (IPluginModelBase model : models) {
-			subMonitor.split(1);
-			Properties options = TracingOptionsManager.getOptions(model);
-			if (options != null) {
+	private synchronized Map<String, String> getTracingTemplate() {
+		if (template == null) {
+			Map<String, String> temp = new HashMap<>();
+			IPluginModelBase[] models = PluginRegistry.getAllModels();
+			Arrays.stream(models).map(TracingOptionsManager::getOptions).filter(Objects::nonNull).forEach(p -> {
 				@SuppressWarnings({ "rawtypes", "unchecked" })
-				Map<String, String> entries = (Map) options;
+				Map<String, String> entries = (Map) p;
 				temp.putAll(entries); // All entries are of String/String
-			}
+			});
+			template = temp;
 		}
-		template = temp;
 		return template;
 	}
 
@@ -137,7 +129,7 @@ public class TracingOptionsManager {
 	}
 
 	public void save(Path file, Map<String, String> map, Set<String> selected) {
-		Map<String, String> properties = getTracingOptions(map, null);
+		Map<String, String> properties = getTracingOptions(map);
 		properties.keySet().removeIf(key -> {
 			IPath path = IPath.fromOSString(key);
 			return path.segmentCount() < 1 || !selected.contains(path.segment(0));
@@ -146,7 +138,7 @@ public class TracingOptionsManager {
 	}
 
 	public void save(Path file, Map<String, String> map) {
-		saveOptions(file, getTracingOptions(map, null));
+		saveOptions(file, getTracingOptions(map));
 	}
 
 	private static Properties getOptions(IPluginModelBase model) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1092,7 +1092,6 @@ public class PDEUIMessages extends NLS {
 	public static String TracingTab_AttributeLabel_TracingChecked;
 	public static String TracingTab_AttributeLabel_TracingNone;
 
-	public static String TracingBlock_initializing_tracing_options;
 	public static String TracingBlock_restore_default;
 	public static String TracingBlock_restore_default_selected;
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/TracingBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/TracingBlock.java
@@ -18,21 +18,16 @@ package org.eclipse.pde.internal.ui.launcher;
 
 import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BiFunction;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jface.dialogs.IDialogSettings;
-import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -63,53 +58,6 @@ import org.eclipse.ui.forms.widgets.ScrolledPageBook;
 
 public class TracingBlock {
 
-	/**
-	 * This class encapsulates all calls to the tracing options manager and runs
-	 * them using a progress monitor.
-	 */
-	private static record TracingOptionsManagerDelegate(IRunnableContext fRunnableContext) {
-
-		Map<String, String> getTracingTemplateCopy() {
-			return runShowingProgress(
-					(tracingOptionsManager, monitor) -> tracingOptionsManager.getTracingTemplateCopy(monitor));
-		}
-
-		public Map<String, String> getTracingOptions(Map<String, String> options) {
-			return runShowingProgress(
-					(tracingOptionsManager, monitor) -> tracingOptionsManager.getTracingOptions(options, monitor));
-		}
-
-		public Map<String, String> getTemplateTable(String pluginId) {
-			return runShowingProgress(
-					(tracingOptionsManager, monitor) -> tracingOptionsManager.getTemplateTable(pluginId, monitor));
-		}
-
-		private Map<String, String> runShowingProgress(
-				BiFunction<TracingOptionsManager, IProgressMonitor, Map<String, String>> task) {
-			try {
-				String taskName = PDEUIMessages.TracingBlock_initializing_tracing_options;
-				final Map<String, String> result = new HashMap<>();
-
-				// due to a bug
-				// (https://github.com/eclipse-platform/eclipse.platform/issues/769),
-				// the task needs to be forked otherwise the UI
-				// does not show the progress indicator
-				fRunnableContext.run(true, false, monitor -> {
-					SubMonitor subMonitor = SubMonitor.convert(monitor, taskName, 1);
-					result.putAll(task.apply(PDECore.getDefault().getTracingOptionsManager(), subMonitor.split(1)));
-				});
-
-				return result;
-			} catch (InvocationTargetException e) {
-				throw new IllegalStateException(e);
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				throw new IllegalStateException(e);
-			}
-		}
-	}
-
-	private TracingOptionsManagerDelegate fTracingOptionsManagerDelegate;
 	private final TracingTab fTab;
 	private Button fTracingCheck;
 	private CheckboxTableViewer fPluginViewer;
@@ -253,7 +201,8 @@ public class TracingBlock {
 			if (selec.getFirstElement() instanceof IPluginModelBase model) {
 				String modelName = model.getBundleDescription().getSymbolicName();
 				if (modelName != null) {
-					Map<String, String> properties = fTracingOptionsManagerDelegate.getTracingTemplateCopy();
+					Map<String, String> properties = PDECore.getDefault().getTracingOptionsManager()
+							.getTracingTemplateCopy();
 					properties.forEach((key, value) -> {
 						if (key.startsWith(modelName + '/')) {
 							fMasterOptions.put(key, value);
@@ -273,7 +222,7 @@ public class TracingBlock {
 		fRestoreDefaultButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
 			disposePropertySources();
 			fMasterOptions.clear();
-			fMasterOptions.putAll(fTracingOptionsManagerDelegate.getTracingTemplateCopy());
+			fMasterOptions.putAll(PDECore.getDefault().getTracingOptionsManager().getTracingTemplateCopy());
 			Object[] elements = fPluginViewer.getCheckedElements();
 			for (Object element : elements) {
 				if (element instanceof IPluginModelBase model) {
@@ -316,17 +265,14 @@ public class TracingBlock {
 		return style == SWT.NULL ? 2 : 0;
 	}
 
-	private void activateInternal(ILaunchConfiguration config) {
+	public void initializeFrom(ILaunchConfiguration config) {
 		fMasterOptions.clear();
 		disposePropertySources();
 		try {
 			fTracingCheck.setSelection(config.getAttribute(IPDELauncherConstants.TRACING, false));
 			Map<String, String> options = config.getAttribute(IPDELauncherConstants.TRACING_OPTIONS, (Map<String, String>) null);
-
-			fMasterOptions.putAll(options == null //
-					? fTracingOptionsManagerDelegate.getTracingTemplateCopy() //
-					: fTracingOptionsManagerDelegate.getTracingOptions(options));
-
+			TracingOptionsManager mgr = PDECore.getDefault().getTracingOptionsManager();
+			fMasterOptions.putAll(options == null ? mgr.getTracingTemplateCopy() : mgr.getTracingOptions(options));
 			masterCheckChanged();
 			String checked = config.getAttribute(IPDELauncherConstants.TRACING_CHECKED, (String) null);
 			if (checked == null) {
@@ -354,10 +300,6 @@ public class TracingBlock {
 		} catch (CoreException e) {
 			PDEPlugin.logException(e);
 		}
-	}
-
-	public void setRunnableContext(IRunnableContext runnableContext) {
-		fTracingOptionsManagerDelegate = new TracingOptionsManagerDelegate(runnableContext);
 	}
 
 	public void performApply(ILaunchConfigurationWorkingCopy config) {
@@ -406,7 +348,6 @@ public class TracingBlock {
 	}
 
 	public void activated(ILaunchConfigurationWorkingCopy workingCopy) {
-		activateInternal(workingCopy);
 		fPageBook.getParent().getParent().layout(true);
 	}
 
@@ -494,7 +435,7 @@ public class TracingBlock {
 			return null;
 		return fPropertySources.computeIfAbsent(model, m -> {
 			String id = m.getPluginBase().getId();
-			Map<String, String> defaults = fTracingOptionsManagerDelegate.getTemplateTable(id);
+			Map<String, String> defaults = PDECore.getDefault().getTracingOptionsManager().getTemplateTable(id);
 			TracingPropertySource source = new TracingPropertySource(m, fMasterOptions, defaults, this);
 			source.setChanged(true);
 			return source;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -596,7 +596,6 @@ TracingTab_AttributeLabel_TracingOptions=Tracing options
 TracingTab_AttributeLabel_TracingChecked=Tracing select all
 TracingTab_AttributeLabel_TracingNone=Tracing select none
 
-TracingBlock_initializing_tracing_options=Initializing tracing options
 TracingBlock_restore_default=Restore &All to Defaults
 TracingBlock_restore_default_selected=Restore &Selected to Defaults
 TracingLauncherTab_name = Trac&ing

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/TracingTab.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/TracingTab.java
@@ -16,7 +16,6 @@ package org.eclipse.pde.ui.launcher;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPlugin;
@@ -82,13 +81,7 @@ public class TracingTab extends AbstractLauncherTab {
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration config) {
-		// the heavy lifting occurs in #activated(...)
-	}
-
-	@Override
-	public void setLaunchConfigurationDialog(ILaunchConfigurationDialog dialog) {
-		super.setLaunchConfigurationDialog(dialog);
-		fTracingBlock.setRunnableContext(dialog);
+		fTracingBlock.initializeFrom(config);
 	}
 
 	@Override


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform/issues/859 and in particular https://github.com/eclipse-platform/eclipse.platform/issues/859#issuecomment-1814650741.

This reverts commit 7c1f0ed1479916ffe425a87e2fae689dbb72975a from #674. The change introduced a regression causing Tracing tabs not to be initialized properly in specific situation. It requires an update to the Eclipse platform, which will not be integrated into the upcoming release anymore. Therefore, the change is reverted for the release to be reapplied after the next release.

The effect of reverting the change will be a loss of the performance improvement in the launch configurations dialog that was gained by the change.