### PR TITLE
Deploy PDE artifacts to maven

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+def deployBranch = 'master'
+
 pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
@@ -12,12 +14,15 @@ pipeline {
 		maven 'apache-maven-latest'
 		jdk 'temurin-jdk17-latest'
 	}
+	environment {
+		MVN_GOALS = getMavenGoals()
+	}
 	stages {
 		stage('Build') {
 			steps {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
 					sh '''
-						mvn clean verify --batch-mode -Dmaven.repo.local=$WORKSPACE/.m2/repository \
+						mvn clean ${MVN_GOALS} --batch-mode -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs \
 						-Papi-check \
 						-Pjavadoc \
@@ -38,4 +43,11 @@ pipeline {
 			}
 		}
 	}
+}
+
+def getMavenGoals() {
+	//if(env.BRANCH_NAME == deployBranch) {
+		return "deploy -DdeployAtEnd=true"
+	//}
+	//	return "verify"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,19 @@
     <module>features</module>
     <module>org.eclipse.pde.doc.user</module>
   </modules>
+  
+  <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>PDE - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/pde/</url>
+        </repository>
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>PDE - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/pde-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 
   <!--
     To build individual bundles, we specify a repository where to find parent pom,
@@ -103,7 +116,16 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>3.1.1</version>
+          </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+            </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
As an alternative to
- https://github.com/eclipse-pde/eclipse.pde/pull/826

I think we maybe better should go the path of deploy PDE directly to the maven where we can consume than with maven target locations instead of create a new update site.

This has the following benefits:

1. No need to setup a download space and if we later decide its not good at all the snapshots get deleted after a while automatically
2. We can get more experience with this way of deployment and how it works out so PDE can become a blueprint for other projects to do so as well
3. This could be a first step to make it possible to release artifacts to central without the help of global deploy script
4. It would allow to see how deploying features to a maven repository works out

If this is in place, we can start to iron out the produced poms and start trying to strip PDE form the aggregator and instead consume it from the target.


FYI @HannesWell @akurtakov @mickaelistria @vogella 


