### PR TITLE
Fixing broken code tags in Javadoc

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/ApiPlugin.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/ApiPlugin.java
@@ -65,7 +65,7 @@ public class ApiPlugin extends Plugin implements ISaveParticipant, DebugOptionsL
 
 	/**
 	 * Constant representing the expected name for an execution environment
-	 * description fragment Value is <code>org.eclipse.pde.api.tools.ee"
+	 * description fragment Value is <code>"org.eclipse.pde.api.tools.ee"</code>
 	 */
 	private static final String EE_DESCRIPTION_PREFIX = "org.eclipse.pde.api.tools.ee"; //$NON-NLS-1$
 	/**

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/ISessionManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/ISessionManager.java
@@ -71,7 +71,7 @@ public interface ISessionManager {
 	/**
 	 * Returns the active session or <code>null</code> if there is no session.
 	 *
-	 * @return active session or <code>null</null>
+	 * @return active session or <code>null</code>
 	 */
 	public ISession getActiveSession();
 

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/problems/IApiProblem.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/problems/IApiProblem.java
@@ -742,12 +742,12 @@ public interface IApiProblem {
 	public String[] getExtraMarkerAttributeIds();
 
 	/**
-	 * Returns the respective values for the extra marker attributes associated
-	 * to this problem when persisted into a marker by the JavaBuilder. Each
-	 * value must correspond to a matching attribute name, as defined by
-	 * {@link #getExtraMarkerAttributeIds()}. The values must be eligible for
-	 * marker creation, as defined by
-	 * <code> IMarker#setAttributes(String[], Object[])}.
+	 * Returns the respective values for the extra marker attributes associated to
+	 * this problem when persisted into a marker by the JavaBuilder. Each value must
+	 * correspond to a matching attribute name, as defined by
+	 * {@link #getExtraMarkerAttributeIds()}. The values must be eligible for marker
+	 * creation, as defined by
+	 * <code> IMarker#setAttributes(String[], Object[])}</code>.
 	 *
 	 * @return the values of the corresponding extra marker attributes
 	 */

--- a/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/APIToolsAnalysisTask.java
+++ b/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/APIToolsAnalysisTask.java
@@ -512,10 +512,10 @@ public class APIToolsAnalysisTask extends CommonUtilsTask {
 	}
 
 	/**
-	 * Returns <code>true</code if the given component should be filtered from
+	 * Returns <code>true</code> if the given component should be filtered from
 	 * results of this task. This may be because the name is a match or partial
-	 * match to the exlude list or the name is not a match to the include list.
-	 * If no include or exclude list is provided, no filtering is done and
+	 * match to the exlude list or the name is not a match to the include list. If
+	 * no include or exclude list is provided, no filtering is done and
 	 * <code>false</code> is returned.
 	 *
 	 * @param componentID name of the api component (symbolic name of a bundle)

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
@@ -1131,7 +1131,8 @@ public class P2TargetUtils {
 	}
 
 	/**
-	 * @return the phase set to execute, includes the configuration phase if {@link #getIncludeConfigurePhase()} is <code>true<code>
+	 * @return the phase set to execute, includes the configuration phase if
+	 *         {@link #getIncludeConfigurePhase()} is <code>true</code>
 	 */
 	@SuppressWarnings("restriction")
 	private IPhaseSet createPhaseSet() {

--- a/ui/org.eclipse.pde.core/src_ant/org/eclipse/pde/internal/core/ant/ConvertSchemaToHTML.java
+++ b/ui/org.eclipse.pde.core/src_ant/org/eclipse/pde/internal/core/ant/ConvertSchemaToHTML.java
@@ -80,24 +80,25 @@ public class ConvertSchemaToHTML extends Task {
 	}
 
 	/**
-	 * Optional attribute providing a comma <code>','</code> delimited
-	 * list of file paths to search for plug-ins that provide schema
-	 * files included by the schema files being converted.
+	 * Optional attribute providing a comma <code>','</code> delimited list of
+	 * file paths to search for plug-ins that provide schema files included by
+	 * the schema files being converted.
 	 * <p>
-	 * When a schema file includes another, the html will include the
-	 * element definitions from the included schema if it is available.
-	 * If the schema does not exist in the same plug-in, the task will
-	 * assume the schema url is of the form
-	 * <code>schema://<pluginID>/<schemaPath>. It will extract the plug-in
-	 * ID and look for a folder of that name in the same directory as the
-	 * parent schema's host plug-in. If the plug-ins are not all in the same
-	 * directory, this attribute can be used to locate them.
-	 * </p><p>
-	 * The paths can be absolute file paths or paths relative to the ant
-	 * base directory <code>${basedir}</code>.
+	 * When a schema file includes another, the html will include the element
+	 * definitions from the included schema if it is available. If the schema
+	 * does not exist in the same plug-in, the task will assume the schema url
+	 * is of the form <code>schema://<pluginID>/<schemaPath></code>. It will
+	 * extract the plug-in ID and look for a folder of that name in the same
+	 * directory as the parent schema's host plug-in. If the plug-ins are not
+	 * all in the same directory, this attribute can be used to locate them.
+	 * </p>
+	 * <p>
+	 * The paths can be absolute file paths or paths relative to the ant base
+	 * directory <code>${basedir}</code>.
 	 * </p>
 	 *
-	 * @param additionalSearchPaths comma delimited list of search paths
+	 * @param additionalSearchPaths
+	 *            comma delimited list of search paths
 	 */
 	public void setAdditionalSearchPaths(String additionalSearchPaths) {
 		this.additionalSearchPaths = additionalSearchPaths;


### PR DESCRIPTION
The commit attempts to fix the broken code tags in Javadocs across various files in eclipse.pde.

Inspired by: #928 