### PR TITLE
Recreate #674: Postpone long-running operations to the activation of the "Tracing" tab.

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1092,6 +1092,7 @@ public class PDEUIMessages extends NLS {
 	public static String TracingTab_AttributeLabel_TracingChecked;
 	public static String TracingTab_AttributeLabel_TracingNone;
 
+	public static String TracingBlock_initializing_tracing_options;
 	public static String TracingBlock_restore_default;
 	public static String TracingBlock_restore_default_selected;
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -596,6 +596,7 @@ TracingTab_AttributeLabel_TracingOptions=Tracing options
 TracingTab_AttributeLabel_TracingChecked=Tracing select all
 TracingTab_AttributeLabel_TracingNone=Tracing select none
 
+TracingBlock_initializing_tracing_options=Initializing tracing options
 TracingBlock_restore_default=Restore &All to Defaults
 TracingBlock_restore_default_selected=Restore &Selected to Defaults
 TracingLauncherTab_name = Trac&ing

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/TracingTab.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/TracingTab.java
@@ -16,6 +16,7 @@ package org.eclipse.pde.ui.launcher;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPlugin;
@@ -80,7 +81,13 @@ public class TracingTab extends AbstractLauncherTab {
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration config) {
-		fTracingBlock.initializeFrom(config);
+		// the heavy lifting occurs in #activated(...)
+	}
+
+	@Override
+	public void setLaunchConfigurationDialog(ILaunchConfigurationDialog dialog) {
+		super.setLaunchConfigurationDialog(dialog);
+		fTracingBlock.setRunnableContext(dialog);
 	}
 
 	@Override


### PR DESCRIPTION
Recreate #674 which was reverted in #925.

Needs:
* [x] https://github.com/eclipse-platform/eclipse.platform/pull/860

Fixes to https://github.com/eclipse-pde/eclipse.pde/issues/679