### PR TITLE
Unify creation of WizardElements

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/AddBundleContainerSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/AddBundleContainerSelectionPage.java
@@ -350,20 +350,7 @@ public class AddBundleContainerSelectionPage extends WizardSelectionPage {
 	 * @return new wizard element
 	 */
 	protected WizardElement createWizardElement(IConfigurationElement config) {
-		String name = config.getAttribute(WizardElement.ATT_NAME);
-		String id = config.getAttribute(WizardElement.ATT_ID);
-		if (name == null || id == null)
-			return null;
-		WizardElement element = new WizardElement(config);
-
-		String imageName = config.getAttribute(WizardElement.ATT_ICON);
-		Image image = null;
-		if (imageName != null) {
-			String pluginID = config.getNamespaceIdentifier();
-			image = PDEPlugin.getDefault().getLabelProvider().getImageFromPlugin(pluginID, imageName);
-		}
-		element.setImage(image);
-		return element;
+		return WizardElement.create(config, WizardElement.ATT_NAME, WizardElement.ATT_ID);
 	}
 
 	/**

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/WizardElement.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/WizardElement.java
@@ -42,7 +42,7 @@ public class WizardElement extends NamedElement implements IPluginContribution {
 	protected IConfigurationElement configurationElement;
 	private IConfigurationElement template;
 
-	public WizardElement(IConfigurationElement config) {
+	WizardElement(IConfigurationElement config) {
 		super(config.getAttribute(ATT_NAME));
 		this.configurationElement = config;
 	}
@@ -167,12 +167,12 @@ public class WizardElement extends NamedElement implements IPluginContribution {
 		return null;
 	}
 
-	public static WizardElement create(IConfigurationElement config) {
-		String name = config.getAttribute(ATT_NAME);
-		String id = config.getAttribute(ATT_ID);
-		String className = config.getAttribute(ATT_CLASS);
-		if (name == null || id == null || className == null)
-			return null;
+	public static WizardElement create(IConfigurationElement config, String... requiredAttributes) {
+		for (String required : requiredAttributes) {
+			if (config.getAttribute(required) == null) {
+				return null;
+			}
+		}
 		WizardElement element = new WizardElement(config);
 		String imageName = config.getAttribute(ATT_ICON);
 		if (imageName != null) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/extension/NewExtensionRegistryReader.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/extension/NewExtensionRegistryReader.java
@@ -21,13 +21,11 @@ import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.elements.ElementList;
 import org.eclipse.pde.internal.ui.wizards.Category;
 import org.eclipse.pde.internal.ui.wizards.WizardCollectionElement;
 import org.eclipse.pde.internal.ui.wizards.WizardElement;
-import org.eclipse.swt.graphics.Image;
 
 public class NewExtensionRegistryReader {
 	public static final String TAG_WIZARD = "wizard"; //$NON-NLS-1$
@@ -61,41 +59,17 @@ public class NewExtensionRegistryReader {
 	}
 
 	protected WizardElement createWizardElement(IConfigurationElement config) {
-		String name = config.getAttribute(WizardElement.ATT_NAME);
-		String id = config.getAttribute(WizardElement.ATT_ID);
 		String className = config.getAttribute(WizardElement.ATT_CLASS);
 		String template = config.getAttribute(WizardElement.ATT_TEMPLATE);
-		if (name == null || id == null)
+		if (className == null && template == null) {
 			return null;
-		if (className == null && template == null)
-			return null;
-		WizardElement element = new WizardElement(config);
-		String imageName = config.getAttribute(WizardElement.ATT_ICON);
-		if (imageName != null) {
-			String pluginID = config.getNamespaceIdentifier();
-			Image image = PDEPlugin.getDefault().getLabelProvider().getImageFromPlugin(pluginID, imageName);
-			element.setImage(image);
 		}
-		return element;
+		return WizardElement.create(config, WizardElement.ATT_NAME, WizardElement.ATT_ID);
 	}
 
 	protected WizardElement createEditorWizardElement(IConfigurationElement config) {
-		String name = config.getAttribute(WizardElement.ATT_NAME);
-		String id = config.getAttribute(WizardElement.ATT_ID);
-		String className = config.getAttribute(WizardElement.ATT_CLASS);
-		String point = config.getAttribute(WizardElement.ATT_POINT);
-		if (name == null || id == null || className == null)
-			return null;
-		if (point == null)
-			return null;
-		WizardElement element = new WizardElement(config);
-		String imageName = config.getAttribute(WizardElement.ATT_ICON);
-		if (imageName != null) {
-			String pluginID = config.getNamespaceIdentifier();
-			Image image = PDEPlugin.getDefault().getLabelProvider().getImageFromPlugin(pluginID, imageName);
-			element.setImage(image);
-		}
-		return element;
+		return WizardElement.create(config, WizardElement.ATT_NAME, WizardElement.ATT_ID, WizardElement.ATT_CLASS,
+				WizardElement.ATT_POINT);
 	}
 
 	protected String getCategoryStringFor(IConfigurationElement config) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewLibraryPluginProjectWizard.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewLibraryPluginProjectWizard.java
@@ -31,7 +31,6 @@ import org.eclipse.pde.internal.ui.wizards.NewWizard;
 import org.eclipse.pde.internal.ui.wizards.WizardElement;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkingSet;
@@ -107,19 +106,7 @@ public class NewLibraryPluginProjectWizard extends NewWizard implements IExecuta
 	}
 
 	protected WizardElement createWizardElement(IConfigurationElement config) {
-		String name = config.getAttribute(WizardElement.ATT_NAME);
-		String id = config.getAttribute(WizardElement.ATT_ID);
-		String className = config.getAttribute(WizardElement.ATT_CLASS);
-		if (name == null || id == null || className == null)
-			return null;
-		WizardElement element = new WizardElement(config);
-		String imageName = config.getAttribute(WizardElement.ATT_ICON);
-		if (imageName != null) {
-			String pluginID = config.getNamespaceIdentifier();
-			Image image = PDEPlugin.getDefault().getLabelProvider().getImageFromPlugin(pluginID, imageName);
-			element.setImage(image);
-		}
-		return element;
+		return WizardElement.create(config, WizardElement.ATT_NAME, WizardElement.ATT_ID, WizardElement.ATT_CLASS);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewPluginProjectWizard.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewPluginProjectWizard.java
@@ -35,7 +35,6 @@ import org.eclipse.pde.internal.ui.wizards.IProjectProvider;
 import org.eclipse.pde.internal.ui.wizards.NewWizard;
 import org.eclipse.pde.internal.ui.wizards.WizardElement;
 import org.eclipse.pde.ui.IPluginContentWizard;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
 
@@ -157,19 +156,7 @@ public class NewPluginProjectWizard extends NewWizard implements IExecutableExte
 	}
 
 	protected WizardElement createWizardElement(IConfigurationElement config) {
-		String name = config.getAttribute(WizardElement.ATT_NAME);
-		String id = config.getAttribute(WizardElement.ATT_ID);
-		String className = config.getAttribute(WizardElement.ATT_CLASS);
-		if (name == null || id == null || className == null)
-			return null;
-		WizardElement element = new WizardElement(config);
-		String imageName = config.getAttribute(WizardElement.ATT_ICON);
-		if (imageName != null) {
-			String pluginID = config.getNamespaceIdentifier();
-			Image image = PDEPlugin.getDefault().getLabelProvider().getImageFromPlugin(pluginID, imageName);
-			element.setImage(image);
-		}
-		return element;
+		return WizardElement.create(config, WizardElement.ATT_NAME, WizardElement.ATT_ID, WizardElement.ATT_CLASS);
 	}
 
 	public ElementList getAvailableCodegenWizards() {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/templates/NewPluginProjectFromTemplateWizard.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/templates/NewPluginProjectFromTemplateWizard.java
@@ -231,7 +231,8 @@ public abstract class NewPluginProjectFromTemplateWizard extends NewWizard imple
 			for (IConfigurationElement element : elements) {
 				if (element.getName().equals(TAG_WIZARD)) {
 					if (templateID.equals(element.getAttribute(WizardElement.ATT_ID))) {
-						return WizardElement.create(element);
+						return WizardElement.create(element, WizardElement.ATT_NAME, WizardElement.ATT_ID,
+								WizardElement.ATT_CLASS);
 					}
 				}
 			}


### PR DESCRIPTION
Currently WizardElement are created based on slightly different precondition checks, beside that, there is even one factory method but only used in one place.

This unify the access to always using the factory method and instead passing the required attributes to check as parameters.