### PR TITLE
Add Bnd Workspace ServiceFactory

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -40,6 +40,7 @@ import org.eclipse.pde.core.project.IBundleProjectService;
 import org.eclipse.pde.core.target.ITargetDefinition;
 import org.eclipse.pde.core.target.ITargetPlatformService;
 import org.eclipse.pde.internal.core.bnd.BndResourceChangeListener;
+import org.eclipse.pde.internal.core.bnd.BndWorkspaceServiceFactory;
 import org.eclipse.pde.internal.core.builders.FeatureRebuilder;
 import org.eclipse.pde.internal.core.builders.PluginRebuilder;
 import org.eclipse.pde.internal.core.project.BundleProjectService;
@@ -47,8 +48,12 @@ import org.eclipse.pde.internal.core.schema.SchemaRegistry;
 import org.eclipse.pde.internal.core.target.P2TargetUtils;
 import org.eclipse.pde.internal.core.target.TargetPlatformService;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
+
+import aQute.bnd.build.Workspace;
 
 public class PDECore extends Plugin implements DebugOptionsListener {
 	public static final String PLUGIN_ID = "org.eclipse.pde.core"; //$NON-NLS-1$
@@ -347,6 +352,8 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		});
 		bndResourceChangeListener = new BndResourceChangeListener();
 		workspace.addResourceChangeListener(bndResourceChangeListener);
+		fBundleContext.registerService(Workspace.class, new BndWorkspaceServiceFactory(),
+				FrameworkUtil.asDictionary(Map.of(Constants.SERVICE_RANKING, -10)));
 	}
 
 	public BundleContext getBundleContext() {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndWorkspaceServiceFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndWorkspaceServiceFactory.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.bnd;
+
+import org.eclipse.core.runtime.ILog;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceRegistration;
+
+import aQute.bnd.build.Workspace;
+
+public class BndWorkspaceServiceFactory implements ServiceFactory<Workspace> {
+
+	@Override
+	public Workspace getService(Bundle bundle, ServiceRegistration<Workspace> registration) {
+		try {
+			return BndProjectManager.getWorkspace();
+		} catch (Exception e) {
+			ILog.get().error("Creating Bnd Workspace Service failed!", e); //$NON-NLS-1$
+			return null;
+		}
+	}
+
+	@Override
+	public void ungetService(Bundle bundle, ServiceRegistration<Workspace> registration, Workspace service) {
+	}
+
+}


### PR DESCRIPTION
Some shared component want to discover the available workspace and do so by searching for Workspace in the service registry.

This adds a service factory that supply the PDE Bnd Workspace in case it is requested by a component.