### PR TITLE
Run some pde.build tests with Tycho (second attempt)

### DIFF
--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.ant,
  org.eclipse.debug.core,
  org.eclipse.equinox.p2.publisher;bundle-version="1.1.0",
- org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0"
+ org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0",
+ org.eclipse.equinox.p2.repository.tools
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.equinox.frameworkadmin;version="2.0.0",
  org.eclipse.equinox.internal.p2.artifact.repository,

--- a/build/org.eclipse.pde.build.tests/META-INF/p2.inf
+++ b/build/org.eclipse.pde.build.tests/META-INF/p2.inf
@@ -1,0 +1,2 @@
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.osgi.compatibility.state

--- a/build/org.eclipse.pde.build.tests/build.properties
+++ b/build/org.eclipse.pde.build.tests/build.properties
@@ -20,5 +20,4 @@ bin.includes = META-INF/,\
                test.xml
 src.includes = about.html
 jars.compile.order = .
-pom.model.property.skipTests = true
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.pde</groupId>
+		<artifactId>eclipse.pde.build</artifactId>
+		<version>4.30.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>org.eclipse.pde.build.tests</artifactId>
+	<version>1.4.200-SNAPSHOT</version>
+	<packaging>eclipse-test-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<requirement>
+								<!-- The product -->
+								<type>p2-installable-unit</type>
+								<id>org.eclipse.sdk.ide</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<configuration>
+					<product>org.eclipse.sdk.ide</product>
+					<testRuntime>p2Installed</testRuntime>
+					<testClass>org.eclipse.pde.build.tests.PDEBuildTestSuite</testClass>
+					<systemProperties>
+						<pde.build.includeP2>false</pde.build.includeP2>
+					</systemProperties>
+				</configuration>
+				<executions>
+					<execution>
+						<id>p2-tests</id>
+						<goals><goal>test</goal></goals>
+						<configuration>
+							<testClass>org.eclipse.pde.build.tests.P2TestSuite</testClass>
+							<systemProperties/>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>org.eclipse.pde</groupId>
 		<artifactId>eclipse.pde.build</artifactId>
-		<version>4.30.0-SNAPSHOT</version>
+		<version>4.31.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.pde.build.tests</artifactId>
-	<version>1.4.200-SNAPSHOT</version>
+	<version>1.4.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/Utils.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/Utils.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.build.internal.tests;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -377,7 +379,10 @@ public class Utils {
 			// Eclipse.app/Contents/Eclipse).
 			baseLocation = baseLocation.getParentFile().getParentFile();
 		}
-		executableLocation = findExecutable(new File(baseLocation.getParent(), "deltapack/eclipse"));
+		File fallback = new File(baseLocation.getParent(), "deltapack/eclipse");
+		executableLocation = findExecutable(fallback);
+		assumeTrue("All attempts to find the executable failed including fallback to " + fallback.getAbsolutePath(),
+				executableLocation != null);
 		return executableLocation;
 	}
 


### PR DESCRIPTION
This is a fresh attempt based on

- https://github.com/eclipse-pde/eclipse.pde/pull/927

with some progress made here
- https://github.com/eclipse-pde/eclipse.pde/pull/933

but that was a dead end I think instead one should try to add a `category.xml` with another execution that mirrors into the "deltapack folder" so if the test executes in `target/work` the goal would be to have a folder `target/deltapack/eclipse` that mirrors everything needed as the "deltapack".
