### PR TITLE
Separate the license checks in a check and and review part

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
   check-merge-commits:
     if: github.event_name == 'pull_request'
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
+  check-dash-licenses:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: eclipse.pde
+    secrets:
+      gitlabAPIToken: ${{ secrets.PDE_GITLAB_API_TOKEN }}
   build:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@master
 

--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,14 +1,6 @@
-name: License vetting status check
+name: Request license-review
 
 on:
-  push:
-    branches: 
-      - 'master'
-      - 'tycho-*'
-  pull_request:
-    branches: 
-     - 'master'
-     - 'tycho-*'
   issue_comment:
     types: [created]
 
@@ -18,6 +10,6 @@ jobs:
       pull-requests: write
     uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
-      projectId: technology.tycho
+      projectId: eclipse.pde
     secrets:
       gitlabAPIToken: ${{ secrets.PDE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
and fix project id...

the review part needs to be merged to master to be fully tested.

![grafik](https://github.com/eclipse-pde/eclipse.pde/assets/1331477/3470aff4-224f-46c6-a2ee-33452c127a55)

now it nicely integrates with the other checks.