### PR TITLE
Skip target bundles with invalid manifest during IU generation #996

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/InstallableUnitGenerator.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/InstallableUnitGenerator.java
@@ -81,11 +81,14 @@ public class InstallableUnitGenerator {
 					PublisherInfo publisherInfo = new PublisherInfo();
 					publisherInfo.setArtifactOptions(IPublisherInfo.A_INDEX);
 					BundleDescription bundleDescription = BundlesAction.createBundleDescription(headers, null);
-					IInstallableUnit iu = BundlesAction.createBundleIU(bundleDescription,
-							BundlesAction.createBundleArtifactKey(bundleDescription.getSymbolicName(),
-									bundleDescription.getVersion().toString()),
-							publisherInfo);
-					return Stream.of(iu);
+					// null if bundle contains invalid manifest headers
+					if (bundleDescription != null) {
+						IInstallableUnit iu = BundlesAction.createBundleIU(bundleDescription,
+								BundlesAction.createBundleArtifactKey(bundleDescription.getSymbolicName(),
+										bundleDescription.getVersion().toString()),
+								publisherInfo);
+						return Stream.of(iu);
+					}
 				} catch (IOException e) {
 					// can't use it then...
 				}


### PR DESCRIPTION
A call to BundlesAction.createBundleDescription() returns null, if the manifest of the current bundle contains invalid headers (e.g. the same package is imported twice).

If left unchecked, this causes an unhandled NullPointerException a few lines further down. Add an explicit null, in order to simply skip this invalid bundle.