### PR TITLE
Consider Require-Capability when validating BREE

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
@@ -587,7 +587,8 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 							IPath currentPath = entry.getPath();
 							if (JavaRuntime.newDefaultJREContainerPath().matchingFirstSegments(currentPath) > 0) {
 								String eeId = JavaRuntime.getExecutionEnvironmentId(currentPath);
-								if (eeId != null) {
+								IHeader header = getHeader(Constants.REQUIRE_CAPABILITY);
+								if (eeId != null && header == null) {
 									VirtualMarker marker = report(PDECoreMessages.BundleErrorReporter_noExecutionEnvironmentSet, 1, sev, PDEMarkerFactory.M_EXECUTION_ENVIRONMENT_NOT_SET, PDEMarkerFactory.CAT_EE);
 									addMarkerAttribute(marker, "ee_id", eeId); //$NON-NLS-1$
 									addMarkerAttribute(marker,PDEMarkerFactory.compilerKey,	CompilerFlags.P_INCOMPATIBLE_ENV);
@@ -615,7 +616,8 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 			if (vm != null) {
 				for (IExecutionEnvironment systemEnv : systemEnvs) {
 					// Get strictly compatible EE for the default VM
-					if (systemEnv.isStrictlyCompatible(vm)) {
+					IHeader header = getHeader(Constants.REQUIRE_CAPABILITY);
+					if (systemEnv.isStrictlyCompatible(vm) && header == null) {
 						VirtualMarker marker = report(PDECoreMessages.BundleErrorReporter_noExecutionEnvironmentSet, 1, sev, PDEMarkerFactory.M_EXECUTION_ENVIRONMENT_NOT_SET, PDEMarkerFactory.CAT_EE);
 						addMarkerAttribute(marker, "ee_id", systemEnv.getId()); //$NON-NLS-1$
 						addMarkerAttribute(marker,PDEMarkerFactory.compilerKey, CompilerFlags.P_INCOMPATIBLE_ENV);


### PR DESCRIPTION
Presence of osgi.ee capability ‘Require-Capability’ should mitigate absence of BREE headers in the manifest. The current parser has no awareness of Require-Capability header. In future the parser should consider this header too while evaluating BREE header. 

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/140