### PR TITLE
Strip micro-version and add upper bound when adding package imports

### DIFF
--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
@@ -32,9 +32,11 @@ public class ImportPackageObject extends PackageObject {
 	private static final long serialVersionUID = 1L;
 
 	private static String getVersion(ExportPackageDescription desc) {
-		String version = desc.getVersion().toString();
-		if (!version.equals(Version.emptyVersion.toString())) {
-			return desc.getVersion().toString();
+		Version version = desc.getVersion();
+		if (version != null && !Version.emptyVersion.equals(version)) {
+			return new VersionRange(
+					"[" + version.getMajor() + "." + version.getMinor() + "," + (version.getMajor() + 1) + "]") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$//$NON-NLS-4$
+							.toString();
 		}
 		return null;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
@@ -49,7 +49,6 @@ import org.eclipse.pde.internal.core.text.bundle.ExportPackageHeader;
 import org.eclipse.pde.internal.core.text.bundle.ExportPackageObject;
 import org.eclipse.pde.internal.core.text.bundle.ImportPackageHeader;
 import org.eclipse.pde.internal.core.text.bundle.ImportPackageObject;
-import org.eclipse.pde.internal.core.text.bundle.ManifestHeader;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
@@ -321,14 +320,17 @@ public class JavaResolutionFactory {
 					if (!(model instanceof IBundlePluginModelBase base))
 						return;
 					IBundle bundle = base.getBundleModel().getBundle();
-					String pkgId = ((ExportPackageDescription) getChangeObject()).getName();
+					ExportPackageDescription desc = (ExportPackageDescription) getChangeObject();
+					String pkgId = desc.getName();
 					IManifestHeader header = bundle.getManifestHeader(Constants.IMPORT_PACKAGE);
 					if (header == null) {
-						bundle.setHeader(Constants.IMPORT_PACKAGE, pkgId);
-					} else if (header instanceof ImportPackageHeader ipHeader) {
-						int manifestVersion = BundlePluginBase.getBundleManifestVersion(bundle);
-						String versionAttr = (manifestVersion < 2) ? ICoreConstants.PACKAGE_SPECIFICATION_VERSION : Constants.VERSION_ATTRIBUTE;
-						ImportPackageObject impObject = new ImportPackageObject((ManifestHeader) header, (ExportPackageDescription) getChangeObject(), versionAttr);
+						header = bundle.getModel().getFactory().createHeader(Constants.IMPORT_PACKAGE, pkgId);
+					}
+					if (header instanceof ImportPackageHeader ipHeader) {
+						String versionAttr = (BundlePluginBase.getBundleManifestVersion(bundle) < 2)
+								? ICoreConstants.PACKAGE_SPECIFICATION_VERSION
+								: Constants.VERSION_ATTRIBUTE;
+						ImportPackageObject impObject = new ImportPackageObject(ipHeader, desc, versionAttr);
 						if (!isUndo()) {
 							ipHeader.addPackage(impObject);
 						} else {


### PR DESCRIPTION
 This commit resets the micro-version to ‘0’ while importing packages as part of quick fix, as it is not relevant. 

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/401