### PR TITLE
Add a requirement to the org.eclipse.osgi.compatibility.state fragment

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/p2.inf
+++ b/ui/org.eclipse.pde.core/META-INF/p2.inf
@@ -1,0 +1,2 @@
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.osgi.compatibility.state


### PR DESCRIPTION
PDE effectively requires the org.eclipse.osgi.compatibility.state fragment but has no way to declare this requirement in a provisioned install setup so it must be given manually or by a feature.

This adds a p2.inf to ensure it is always included when installing pde.core bundle.