### PR TITLE
Disposes fSiteBundleImage in CategoryLabelProvider

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryLabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryLabelProvider.java
@@ -35,7 +35,7 @@ class CategoryLabelProvider extends LabelProvider {
 
 	private Image fSiteFeatureImage;
 	private Image fMissingSiteFeatureImage;
-	private final Image fSiteBundleImage;
+	private Image fSiteBundleImage;
 	private final Image fMissingSiteBundleImage;
 	private Image fPageImage;
 	private Image fCatDefImage;
@@ -106,6 +106,10 @@ class CategoryLabelProvider extends LabelProvider {
 		if ((fSiteFeatureImage != null) && (fSiteFeatureImage.isDisposed() == false)) {
 			fSiteFeatureImage.dispose();
 			fSiteFeatureImage = null;
+		}
+		if ((fSiteBundleImage != null) && (fSiteBundleImage.isDisposed() == false)) {
+			fSiteBundleImage.dispose();
+			fSiteBundleImage = null;
 		}
 		if ((fMissingSiteFeatureImage != null) && (fMissingSiteFeatureImage.isDisposed() == false)) {
 			fMissingSiteFeatureImage.dispose();


### PR DESCRIPTION
Fixes the following error which I see in my error log

java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:605)
	at org.eclipse.jface.resource.URLImageDescriptor.createImage(URLImageDescriptor.java:300)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:289)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:267)
	at org.eclipse.pde.internal.ui.editor.category.CategoryLabelProvider.<init>(CategoryLabelProvider.java:46)
	at org.eclipse.pde.internal.ui.editor.category.CategorySection.createClient(CategorySection.java:214)
	at org.eclipse.pde.internal.ui.editor.StructuredViewerSection.<init>(StructuredViewerSection.java:58)
	at org.eclipse.pde.internal.ui.editor.StructuredViewerSection.<init>(StructuredViewerSection.java:47)
	at org.eclipse.pde.internal.ui.editor.TreeSection.<init>(TreeSection.java:75)