### PR TITLE
Validation dialog - Edit launch configuration link

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/AllLauncherTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/AllLauncherTests.java
@@ -28,6 +28,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	LaunchConfigurationHelperTestCase.class, //
 	LaunchConfigurationMigrationTest.class, //
 	ProductEditorLaunchingTest.class, //
+	ValidationDialogTest.class, //
 })
 public class AllLauncherTests {
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/ValidationDialogTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/ValidationDialogTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ETAS GmbH and others, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.pde.ui.tests.launcher;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.jface.window.IShellProvider;
+import org.eclipse.pde.internal.ui.launcher.PluginStatusDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.ui.PlatformUI;
+import org.junit.Test;
+
+public class ValidationDialogTest {
+	PluginStatusDialog dialog;
+
+	@Test
+	public void editLaunchConfigLink() {
+		Display.getDefault().syncExec(() -> {
+			IShellProvider shellProvider = PlatformUI.getWorkbench().getModalDialogShellProvider();
+			dialog = new PluginStatusDialog(shellProvider.getShell());
+			dialog.showLink(true);
+			dialog.showCancelButton(true);
+			// To make the dialogue close immediately
+			dialog.setBlockOnOpen(false);
+			dialog.open();
+			Control[] children = dialog.buttonBar.getParent().getChildren();
+			checkEditConfigurationLink(children);
+			dialog.close();
+		});
+
+	}
+
+	private void checkEditConfigurationLink(Control[] element) {
+		for (Control control : element) {
+			if (control instanceof Composite) {
+				Control[] children = ((Composite) control).getChildren();
+				checkEditConfigurationLink(children);
+			} else if ((control instanceof Link)) {
+				isEditLaunchConfigurationLinkAvilable(element, control);
+				break;
+			}
+		}
+	}
+
+	private void isEditLaunchConfigurationLinkAvilable(Control[] element, Control control) {
+		Control editConfigLink = element[0];
+		((Link) control).notifyListeners(SWT.Selection, new Event());
+		assertNotNull(editConfigLink.isVisible());
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1791,6 +1791,7 @@ public class PDEUIMessages extends NLS {
 	public static String PluginWorkingSet_deselectAll_toolTip;
 	public static String PluginWorkingSet_noPluginsChecked;
 	public static String PluginStatusDialog_pluginValidation;
+	public static String PluginStatusDialog_validationLink;
 	public static String PluginsView_openWith;
 	public static String PluginsView_import;
 	public static String PluginsView_select;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginValidationStatusHandler.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginValidationStatusHandler.java
@@ -57,6 +57,7 @@ public class PluginValidationStatusHandler implements IStatusHandler {
 		display.syncExec(() -> {
 			IShellProvider shellProvider = PlatformUI.getWorkbench().getModalDialogShellProvider();
 			PluginStatusDialog dialog = new PluginStatusDialog(shellProvider.getShell());
+			dialog.showLink(true);
 			dialog.showCancelButton(true);
 			dialog.setInput(op.getInput());
 			result[0] = dialog.open();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1513,6 +1513,7 @@ PluginListPage_initializeFromPlugins=&Initialize from the plug-ins list:
 PluginEditor_exportTooltip=Export deployable plug-ins and fragments
 PluginWorkingSet_noPluginsChecked=At least one plug-in must be checked
 PluginStatusDialog_pluginValidation=Validation
+PluginStatusDialog_validationLink=<A>Edit Launch Configuration</A>
 PluginsView_openWith=Open &With
 PluginsView_import=I&mport As
 PluginsView_select=Se&lect


### PR DESCRIPTION
Introduced a new link in validation dialog to open the current launch configuration.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/305