### PR TITLE
Touch bundles affected by changed compiler generation for switch

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/forceQualifierUpdate.txt
+++ b/apitools/org.eclipse.pde.api.tools/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ Comparator errors in I20220902-1100
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 Comparator errors in I20230906-0400
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/ua/org.eclipse.pde.ua.core/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.pde.ua.core/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/ui/org.eclipse.pde.core/forceQualifierUpdate.txt
+++ b/ui/org.eclipse.pde.core/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/ui/org.eclipse.pde.ui/forceQualifierUpdate.txt
+++ b/ui/org.eclipse.pde.ui/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 567095 - Comparator errors in I20200917-1800
 Bug 572892 - 4.20 I-Build: I20210415-1800 - Comparator Errors Found
 #383: Eclipse 4.26.0 Integration Build: I20221106-2230 Unstable! 
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686