### PR TITLE
Gitignore test classes directory

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/.gitignore
+++ b/ds/org.eclipse.pde.ds.annotations/.gitignore
@@ -1,1 +1,2 @@
 /bin
+/bin_test/


### PR DESCRIPTION
pde.ds.annotations has main and test sources, which have 2 separate bin directories. The second bin directory should be gitignored.