### PR TITLE
Fixup IU location update handling

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IULocationFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IULocationFactory.java
@@ -101,8 +101,8 @@ public class IULocationFactory implements ITargetLocationFactory {
 			flags |= Boolean.parseBoolean(includeAllPlatforms) ? IUBundleContainer.INCLUDE_ALL_ENVIRONMENTS : 0;
 			flags |= Boolean.parseBoolean(includeSource) ? IUBundleContainer.INCLUDE_SOURCE : 0;
 			flags |= Boolean.parseBoolean(includeConfigurePhase) ? IUBundleContainer.INCLUDE_CONFIGURE_PHASE : 0;
-			IUBundleContainer targetLocation = new IUBundleContainer(iuIDs, iuVer, uris, flags);
-			return targetLocation;
+			return TargetPlatformService.getDefault().newIULocation(iuIDs, iuVer, uris,
+					flags);
 		}
 		return null;
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
@@ -293,6 +293,7 @@ public class P2TargetUtils {
 		if (result.fProfile instanceof org.eclipse.equinox.internal.p2.engine.Profile) {
 			((org.eclipse.equinox.internal.p2.engine.Profile) result.fProfile).setProperty(PROP_SEQUENCE_NUMBER, "-1"); //$NON-NLS-1$
 		}
+		result.fProfile = null;
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence35Helper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence35Helper.java
@@ -247,7 +247,7 @@ public class TargetPersistence35Helper {
 				}
 			}
 			flags |= Boolean.parseBoolean(includeAllPlatforms) ? IUBundleContainer.INCLUDE_ALL_ENVIRONMENTS : 0;
-			container = new IUBundleContainer(iuIDs, iuVer, uris, flags);
+			container = TargetPlatformService.getDefault().newIULocation(iuIDs, iuVer, uris, flags);
 			break;
 		default:
 			break;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence36Helper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence36Helper.java
@@ -254,7 +254,7 @@ public class TargetPersistence36Helper {
 			}
 			flags |= Boolean.parseBoolean(includeAllPlatforms) ? IUBundleContainer.INCLUDE_ALL_ENVIRONMENTS : 0;
 			flags |= Boolean.parseBoolean(includeSource) ? IUBundleContainer.INCLUDE_SOURCE : 0;
-			container = new IUBundleContainer(iuIDs, iuVer, uris, flags);
+			container = TargetPlatformService.getDefault().newIULocation(iuIDs, iuVer, uris, flags);
 			break;
 		default:
 			break;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
@@ -59,6 +59,7 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -640,12 +641,22 @@ public class TargetPlatformService implements ITargetPlatformService {
 
 	@Override
 	public ITargetLocation newIULocation(IInstallableUnit[] units, URI[] repositories, int resolutionFlags) {
-		return new IUBundleContainer(units, repositories, resolutionFlags);
+		String[] fIds = new String[units.length];
+		Version[] fVersions = new Version[units.length];
+		for (int i = 0; i < units.length; i++) {
+			fIds[i] = units[i].getId();
+			fVersions[i] = units[i].getVersion();
+		}
+		return new IUBundleContainer(fIds, fVersions, repositories, resolutionFlags);
 	}
 
 	@Override
 	public ITargetLocation newIULocation(String[] unitIds, String[] versions, URI[] repositories, int resolutionFlags) {
-		return new IUBundleContainer(unitIds, versions, repositories, resolutionFlags);
+		Version[] fVersions = new Version[versions.length];
+		for (int i = 0; i < versions.length; i++) {
+			fVersions[i] = Version.create(versions[i]);
+		}
+		return new IUBundleContainer(unitIds, fVersions, repositories, resolutionFlags);
 	}
 
 }


### PR DESCRIPTION
Currently the IU location is updated in-place that has several drawbacks:
- we need to synchronize a to not mess up things
- cached items in the object can getting stale and drip into new state
- equals and hasCode can become unstable over time

to overcome this the code is changed in a way that an update is performed on a copy of the current state and a new object is returned and used to perform the update.