### PR TITLE
Fix compiler warnings in pde apitools tasks

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/APIToolsAnalysisTask.java
+++ b/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/APIToolsAnalysisTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -563,7 +563,8 @@ public class APIToolsAnalysisTask extends CommonUtilsTask {
 	 * @return an element that contains all the api problem nodes or null if an
 	 *         error occurred
 	 */
-	private void insertAPIProblems(Element root, Document document, List<IApiProblem> problems, ProblemCounter counter) throws CoreException {
+	private void insertAPIProblems(Element root, Document document, List<IApiProblem> problems,
+			ProblemCounter counter) {
 		Element apiProblems = document.createElement(IApiXmlConstants.ELEMENT_API_PROBLEMS);
 		root.appendChild(apiProblems);
 		Element element = null;

--- a/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/AnalysisReportConversionTask.java
+++ b/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/AnalysisReportConversionTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -307,7 +307,7 @@ public class AnalysisReportConversionTask extends Task {
 	/**
 	 * Write out the index file
 	 */
-	private void dumpIndexFile(File reportsRoot, Summary[] summaries, Summary allNonApiBundleSummary) {
+	private void dumpIndexFile(Summary[] summaries, Summary allNonApiBundleSummary) {
 		File htmlFile = new File(this.htmlReportsLocation, "index.html"); //$NON-NLS-1$
 		try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(htmlFile)))) {
 			if (allNonApiBundleSummary != null) {
@@ -469,7 +469,7 @@ public class AnalysisReportConversionTask extends Task {
 				if (!summariesList.isEmpty() || nonApiBundleSummary != null) {
 					Summary[] summaries = new Summary[summariesList.size()];
 					summariesList.toArray(summaries);
-					dumpIndexFile(reportsRoot, summaries, nonApiBundleSummary);
+					dumpIndexFile(summaries, nonApiBundleSummary);
 				}
 			}
 		} catch (SAXException | IOException e) {

--- a/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/MissingRefProblemsTask.java
+++ b/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/MissingRefProblemsTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -358,7 +358,7 @@ public class MissingRefProblemsTask extends CommonUtilsTask {
 	/**
 	 * Adds {@link IApiProblem}s to the given document and root
 	 */
-	private void insertAPIProblems(Element root, Document document, List<IApiProblem> problems) throws CoreException {
+	private void insertAPIProblems(Element root, Document document, List<IApiProblem> problems) {
 		Element apiProblems = document.createElement(IApiXmlConstants.ELEMENT_API_PROBLEMS);
 		root.appendChild(apiProblems);
 		Element element = null;


### PR DESCRIPTION
As reported at https://download.eclipse.org/eclipse/downloads/drops4/I20240103-1800/compilelogs/plugins/org.eclipse.pde.api.tools_1.3.300.v20231213-1508/lib_apitooling-ant.jar.html#OTHER_WARNINGS