### PR TITLE
Use RepositoryHelper.getWorkspaceBundlePools to find all workspace pools

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
@@ -1452,6 +1452,14 @@ public class P2TargetUtils {
 	 * @param additionalRepos the set to which additional repos are added.
 	 */
 	private void findWorkspaceRepos(Set<URI> additionalRepos) {
+		if (Boolean.parseBoolean(System.getProperty("pde.usePoolsInfo", "true"))) { //$NON-NLS-1$ //$NON-NLS-2$
+			try {
+				additionalRepos.addAll(RepositoryHelper.getWorkspaceBundlePools().stream().map(Path::toUri).toList());
+			} catch (Exception e) {
+				//$FALL-THROUGH$
+			}
+		}
+
 		IPreferencesService prefs = getPreferences();
 		if (prefs == null) {
 			return;


### PR DESCRIPTION
Guard the use such that -Dpde.usePoolsInfo=false can be used to disable the behavior.

https://github.com/eclipse-equinox/p2/issues/410