### PR TITLE
Provide only compatible JUnit 5 test engines in RemotePluginTestRunner

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Export-Package: org.eclipse.pde.internal.junit.runtime;x-internal:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.ui.testing;resolution:=optional
+DynamicImport-Package: org.junit.platform.engine
 Automatic-Module-Name: org.eclipse.pde.junit.runtime


### PR DESCRIPTION
Currently, it is possible that the `RemotePluginTestRunner` loads bundles with "incompatible" test engines. This means, the engine is version-incompatible with the `TestEngine` interface. In such a case, the execution will fail,  because the `ServiceLoader` tries to load this engine as a provider for the `TestEngine` service but fails because it cannot assign the engine to the `TestEngine` interface. One such case is the execution of tests with Tycho, which can use a different JUnit version than the one used in the JDT test bundles. 

This change ensures that bundles providing incompatible engines are not added to the class loader used for executing the test to ensure that service loading for the engines does not fail.

## How to Reproduce
An example for the error is the execution of session tests with JUnit 5, as proposed in eclipse-platform/eclipse.platform#1086. There, the session test `org.eclipse.core.tests.runtime.jobs.Bug_412138` is ported to JUnit 5, but fails because the `org.eclipse.tycho.surefire.osgibooter` is found as an engine provider and provides incompatible engine versions. See for example [this log](https://github.com/eclipse-platform/eclipse.platform/actions/runs/7492899271/job/20397430481):
```
java.util.ServiceConfigurationError: org.junit.platform.engine.TestEngine: org.junit.jupiter.engine.JupiterTestEngine not a subtype
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1244)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
	at java.base/java.lang.Iterable.forEach(Iterable.java:74)
	at org.junit.platform.launcher.core.LauncherFactory.collectTestEngines(LauncherFactory.java:160)
```
With this fix applied, the test runs fine, as the the engine is not loaded from the `org.eclipse.tycho.surefire.osgibooter` bundle's class loader, but from the one of the test engine bundles.