### PR TITLE
Add support for using classpath of plain bnd projects

### DIFF
--- a/ui/org.eclipse.pde.core/.settings/.api_filters
+++ b/ui/org.eclipse.pde.core/.settings/.api_filters
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.pde.core" version="2">
-    <resource path="src/org/eclipse/pde/core/ModelChangedEvent.java" type="org.eclipse.pde.core.ModelChangedEvent">
-        <filter comment="This is PDEs own implementation" id="576725006">
-            <message_arguments>
-                <message_argument value="IModelChangedEvent"/>
-                <message_argument value="ModelChangedEvent"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/pde/internal/core/project/BundleProjectService.java" type="org.eclipse.pde.internal.core.project.BundleProjectService">
         <filter comment="Platform Team allows use of bundle importers for PDE import from source repository" id="640712815">
             <message_arguments>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3314,6 +3314,10 @@ public class PDEUIMessages extends NLS {
 	public static String AddBundleManifestVersionResolution_description;
 	public static String AddBundleManifestVersionResolution_label;
 
+	public static String AddPdeClasspathContainerClasspathFixProposal_0;
+
+	public static String AddPdeClasspathContainerClasspathFixProposal_1;
+
 	public static String AddToJavaSearchJob_0;
 
 	public static String AnnotationHover_version_change;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/AddPdeClasspathContainerClasspathFixProposal.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/AddPdeClasspathContainerClasspathFixProposal.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.correction.java;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ui.text.java.ClasspathFixProcessor.ClasspathFixProposal;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.ui.PDEPluginImages;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.eclipse.swt.graphics.Image;
+
+public class AddPdeClasspathContainerClasspathFixProposal extends ClasspathFixProposal {
+
+	private IJavaProject project;
+
+	public AddPdeClasspathContainerClasspathFixProposal(IJavaProject project) {
+		this.project = project;
+	}
+
+	@Override
+	public Change createChange(IProgressMonitor monitor) throws CoreException {
+		return newAddClasspathChange(project,
+				JavaCore.newContainerEntry(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH));
+	}
+
+	@Override
+	public String getDisplayString() {
+		return PDEUIMessages.AddPdeClasspathContainerClasspathFixProposal_0;
+	}
+
+	@Override
+	public String getAdditionalProposalInfo() {
+		return PDEUIMessages.AddPdeClasspathContainerClasspathFixProposal_1;
+	}
+
+	@Override
+	public Image getImage() {
+		return PDEPluginImages.get(PDEPluginImages.OBJ_DESC_BUNDLE);
+	}
+
+	@Override
+	public int getRelevance() {
+		return 10;
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/UnresolvedImportFixProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/UnresolvedImportFixProcessor.java
@@ -16,6 +16,7 @@ package org.eclipse.pde.internal.ui.correction.java;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -26,6 +27,8 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
 import org.eclipse.pde.internal.ui.correction.java.FindClassResolutionsOperation.AbstractClassResolutionCollector;
+
+import aQute.bnd.build.Project;
 
 /**
  * Offers a classpath fix proposal if the broken import statement can be
@@ -80,8 +83,14 @@ public class UnresolvedImportFixProcessor extends ClasspathFixProcessor {
 
 	@Override
 	public ClasspathFixProposal[] getFixImportProposals(IJavaProject project, String name) throws CoreException {
-		if (!WorkspaceModelManager.isPluginProject(project.getProject()))
+		if (!WorkspaceModelManager.isPluginProject(project.getProject())) {
+			IFile bnd = project.getProject().getFile(Project.BNDFILE);
+			if (bnd.exists()) {
+				// it could be a bnd workspace project!
+				return new ClasspathFixProposal[] { new AddPdeClasspathContainerClasspathFixProposal(project) };
+			}
 			return new ClasspathFixProposal[0];
+		}
 		ClasspathFixCollector collector = new ClasspathFixCollector();
 		// Add require bundles for junit5
 		if (name.startsWith("junit-jupiter") || name.startsWith("junit-platform") || name.startsWith("org.junit.jupiter") || name.startsWith("org.junit.platform")) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2531,6 +2531,8 @@ StateViewPage_openItem=Open
 StateViewPage_showOnlyUnresolved_label=Show only unresolved plug-ins
 SchemaPreviewLauncher_msgEditorHasUnsavedChanges=Open schema editor has unsaved changes
 AddBundleClassPathResolution_add=Add ''{0}'' to the bundle classpath
+AddPdeClasspathContainerClasspathFixProposal_0=Add Plug-in Dependencies Container
+AddPdeClasspathContainerClasspathFixProposal_1=Add a classpath container that is capable of suppling OSGi dependencies to your project based on project metadata and configuration files.
 AddToJavaSearchJob_0=Updating Java search scope
 AntGeneratingExportWizard_0=File overwrite
 # {0} will be a list of projects, separated by newlines, may be followed by an ellipsis


### PR DESCRIPTION
Currently if one imports a blain bnd-project the classpath is not setup unless one have some other tooling installed (e.g. bndtools)

This now adds support for evaluate the bnd project in case it is a "plain" bnd workspace project and adds the required items to the classpath container if it was added to the project.

To effectively use this feature one would additionally need:
- [x] https://github.com/eclipse-pde/eclipse.pde/pull/1054
- [ ] A way to update the classpath (currently Project > Plugin Tools > Update Classpath...) does not consider such projects
- [x] Add an option to enable the Plugin Dependencies container, currently one needs to enable it by manually edit the  classpath and project files, maybe in combination with previous entry it could just be added if update classpath is choosen