### PR TITLE
Don't print markers to not pollute the maven logs

### DIFF
--- a/ds/org.eclipse.pde.ds.tck/pom.xml
+++ b/ds/org.eclipse.pde.ds.tck/pom.xml
@@ -75,6 +75,8 @@
 								<local>true</local>
 								<!-- See https://github.com/osgi/osgi/issues/636 -->
 								<failOnError>false</failOnError>
+								<!-- See https://github.com/osgi/osgi/issues/636 -->
+								<printMarker>false</printMarker>
 								<bundles>
 									<bundle>org.eclipse.pde.core</bundle>
 									<bundle>org.eclipse.pde.ds.annotations</bundle>


### PR DESCRIPTION
Currently there are validation errors because of
https://github.com/osgi/osgi/issues/636

This disables the output to not pollute the log with messages not realted to the test.