### PR TITLE
Fix NPE in ManifestEditor if none match

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
@@ -432,18 +432,18 @@ public class ManifestEditor extends PDELauncherFormEditor implements IShowEditor
 			manifestFile = new File(dir, ICoreConstants.BUNDLE_FILENAME_DESCRIPTOR);
 		}
 		try {
-			if (manifestFile.exists()) {
+			if (manifestFile != null && manifestFile.exists()) {
 				IFileStore store = EFS.getStore(manifestFile.toURI());
 				IEditorInput in = new FileStoreEditorInput(store);
 				manager.putContext(in, new BundleInputContext(this, in, file == manifestFile));
 			}
-			if (pluginFile.exists()) {
+			if (pluginFile != null && pluginFile.exists()) {
 				IFileStore store = EFS.getStore(pluginFile.toURI());
 				IEditorInput in = new FileStoreEditorInput(store);
 				manager.putContext(in, new PluginInputContext(this, in, file == pluginFile,
 						name.equals(ICoreConstants.FRAGMENT_FILENAME_DESCRIPTOR)));
 			}
-			if (buildFile.exists()) {
+			if (buildFile != null && buildFile.exists()) {
 				IFileStore store = EFS.getStore(buildFile.toURI());
 				IEditorInput in = new FileStoreEditorInput(store);
 				manager.putContext(in, new BuildInputContext(this, in, file == buildFile));


### PR DESCRIPTION
Currently if the ManifestEditor is opened on an input that does not match a local file a NPE can occur seen with JGit and open from staging view a pde.bnd file.