### PR TITLE
Write latest master build to downloads.eclipse.org

### DIFF
--- a/e4tools/features/org.eclipse.e4.tools.persistence.feature/forceQualifierUpdate.txt
+++ b/e4tools/features/org.eclipse.e4.tools.persistence.feature/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 # To force a version qualifier update add the bug here
+Touch to publish source feature.

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -6,6 +6,10 @@
    <feature id="org.eclipse.pde.spies.source" version="0.0.0"/>
    <feature id="org.eclipse.pde.unittest.junit" version="0.0.0"/>
    <feature id="org.eclipse.pde.unittest.junit.source" version="0.0.0"/>
+   <feature id="org.eclipse.e4.core.tools.feature" version="0.0.0"/>
+   <feature id="org.eclipse.e4.core.tools.feature.source" version="0.0.0"/>
+   <feature id="org.eclipse.e4.tools.persistence.feature" version="0.0.0"/>
+   <feature id="org.eclipse.e4.tools.persistence.feature.source" version="0.0.0"/>
    <!-- Tests -->
    <bundle id="org.eclipse.pde.ua.tests"/>
    <bundle id="org.eclipse.pde.ui.tests"/>


### PR DESCRIPTION
Using https://download.eclipse.org/pde/builds/master/ as destination so it can be tested more broadly.
Mainly motivated to have a permanent download space which wasn't there as discovered in
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4172