### PR TITLE
Support finding a model by Resource instead of BundleDescription

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotationsClasspathContributor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotationsClasspathContributor.java
@@ -29,6 +29,7 @@ import org.eclipse.pde.core.IClasspathContributor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ClasspathUtilCore;
+import org.osgi.resource.Resource;
 
 public class ApiAnnotationsClasspathContributor implements IClasspathContributor {
 
@@ -36,7 +37,7 @@ public class ApiAnnotationsClasspathContributor implements IClasspathContributor
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
-		IPluginModelBase projectModel = PluginRegistry.findModel(project);
+		IPluginModelBase projectModel = PluginRegistry.findModel((Resource) project);
 		if (hasApiNature(projectModel)) {
 			return ClasspathUtilCore.classpathEntries(annotations().filter(model -> !model.equals(projectModel)))
 					.collect(Collectors.toList());

--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 Regenerate docs
 Changed year
+Changed javadoc / new API

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.17.300.qualifier
+Bundle-Version: 3.18.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IClasspathContributor.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.osgi.resource.Resource;
 
 /**
  * Implementors of this interface can contribute additional {@link IClasspathEntry}
@@ -38,15 +39,19 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 public interface IClasspathContributor {
 
 	/**
-	 * Get any additional classpath entries to add to a project when its classpath is
-	 * first computed.  The provided {@link BundleDescription} describes the plug-in
-	 * project that the classpath is being computed for.  Additional PDE model information
-	 * can be obtained using {@link PluginRegistry#findModel(BundleDescription)}.
+	 * Get any additional classpath entries to add to a project when its
+	 * classpath is first computed. The provided {@link BundleDescription}
+	 * describes the plug-in project that the classpath is being computed for.
+	 * Additional PDE model information can be obtained using
+	 * {@link PluginRegistry#findModel(Resource)}.
 	 *
-	 * @param project the bundle descriptor for the plug-in project having its classpath computed
-	 * @return additional classpath entries to add to the project, possibly empty, must not be <code>null</code>
+	 * @param project
+	 *            the bundle descriptor for the plug-in project having its
+	 *            classpath computed
+	 * @return additional classpath entries to add to the project, possibly
+	 *         empty, must not be <code>null</code>
 	 */
-	public List<IClasspathEntry> getInitialEntries(BundleDescription project);
+	List<IClasspathEntry> getInitialEntries(BundleDescription project);
 
 	/**
 	 * Get any additional classpath entries to add to a project when a new bundle
@@ -59,5 +64,5 @@ public interface IClasspathContributor {
 	 * @param addedDependency the bundle descriptor for the bundle being added to the classpath as a dependency
 	 * @return additional classpath entries to add to the project, possibly empty, must not be <code>null</code>
 	 */
-	public List<IClasspathEntry> getEntriesForDependency(BundleDescription project, BundleDescription addedDependency);
+	List<IClasspathEntry> getEntriesForDependency(BundleDescription project, BundleDescription addedDependency);
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/PluginRegistry.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/PluginRegistry.java
@@ -28,6 +28,7 @@ import org.eclipse.pde.internal.core.build.WorkspaceBuildModel;
 import org.eclipse.pde.internal.core.project.PDEProject;
 import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 /**
  * The central access point for models representing plug-ins found in the workspace
@@ -118,13 +119,30 @@ public class PluginRegistry {
 	/**
 	 * Returns a plug-in model associated with the given bundle description
 	 *
-	 * @param desc the bundle description
+	 * @param desc
+	 *            the bundle description
 	 *
-	 * @return a plug-in model associated with the given bundle description or <code>null</code>
-	 * 			if none exists
+	 * @return a plug-in model associated with the given bundle description or
+	 *         <code>null</code> if none exists
+	 * @deprecated Instead use {@link #findModel(Resource)}
 	 */
+	@Deprecated(forRemoval = true)
 	public static IPluginModelBase findModel(BundleDescription desc) {
-		return PDECore.getDefault().getModelManager().findModel(desc);
+		return findModel((Resource) desc);
+	}
+
+	/**
+	 * Returns a plug-in model associated with the given resource
+	 *
+	 * @param resource
+	 *            the (OSGi) resource to find a model for
+	 *
+	 * @return a plug-in model associated with the given bundle description or
+	 *         <code>null</code> if none exists
+	 * @since 3.18
+	 */
+	public static IPluginModelBase findModel(Resource resource) {
+		return PDECore.getDefault().getModelManager().findModel(resource);
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -33,7 +33,6 @@ import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.build.IBuild;
 import org.eclipse.pde.core.build.IBuildModel;
 import org.eclipse.pde.core.plugin.IFragment;
@@ -50,6 +49,7 @@ import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
 import org.eclipse.pde.internal.core.plugin.Fragment;
 import org.eclipse.pde.internal.core.plugin.Plugin;
 import org.eclipse.pde.internal.core.plugin.PluginBase;
+import org.osgi.resource.Resource;
 
 public class ClasspathUtilCore {
 
@@ -151,7 +151,7 @@ public class ClasspathUtilCore {
 		return false;
 	}
 
-	public static boolean isPatchFragment(BundleDescription desc) {
+	public static boolean isPatchFragment(Resource desc) {
 		IPluginModelBase model = PluginRegistry.findModel(desc);
 		return model instanceof IFragmentModel ? isPatchFragment(((IFragmentModel) model).getFragment()) : false;
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -39,6 +39,7 @@ import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.resource.Resource;
 
 /**
  * Utility class to return bundle description collections for a variety of
@@ -225,7 +226,7 @@ public class DependencyManager {
 		return Constants.RESOLUTION_OPTIONAL.equals(requirement.getDirectives().get(Constants.RESOLUTION_DIRECTIVE));
 	}
 
-	private static boolean isTestWorkspaceProject(BundleDescription f) {
+	private static boolean isTestWorkspaceProject(Resource f) {
 		// Be defensive when declaring a fragment as 'test'-fragment
 		IPluginModelBase pluginModel = PluginRegistry.findModel(f);
 		if (pluginModel != null) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEClasspathContainer.java
@@ -33,6 +33,7 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.plugin.IPluginLibrary;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.osgi.resource.Resource;
 
 public class PDEClasspathContainer {
 
@@ -171,7 +172,7 @@ public class PDEClasspathContainer {
 			BundleDescription[] fragments = desc.getFragments();
 			for (BundleDescription fragment : fragments) {
 				if (new File(fragment.getLocation(), libraryName).exists()) {
-					return PluginRegistry.findModel(fragment);
+					return PluginRegistry.findModel((Resource) fragment);
 				}
 			}
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEExtensionRegistry.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEExtensionRegistry.java
@@ -36,6 +36,7 @@ import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
 import org.eclipse.pde.internal.core.plugin.PluginExtension;
 import org.eclipse.pde.internal.core.plugin.PluginExtensionPoint;
 import org.eclipse.pde.internal.core.util.CoreUtility;
+import org.osgi.resource.Resource;
 
 public class PDEExtensionRegistry {
 
@@ -260,7 +261,8 @@ public class PDEExtensionRegistry {
 			return null;
 		}
 		long bundleId = Long.parseLong(contributor.getActualId());
-		BundleDescription desc = PDECore.getDefault().getModelManager().getState().getState().getBundle(Long.parseLong(contributor.getActualId()));
+		Resource desc = PDECore.getDefault().getModelManager().getState().getState()
+				.getBundle(Long.parseLong(contributor.getActualId()));
 		if (desc != null) {
 			return PluginRegistry.findModel(desc);
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEManager.java
@@ -29,6 +29,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModelBase;
 import org.osgi.framework.Constants;
+import org.osgi.resource.Resource;
 
 public class PDEManager {
 
@@ -37,7 +38,7 @@ public class PDEManager {
 		BundleDescription desc = getBundleDescription(model);
 		if (desc != null) {
 			BundleDescription[] fragments = desc.getFragments();
-			for (BundleDescription fragment : fragments) {
+			for (Resource fragment : fragments) {
 				IPluginModelBase candidate = PluginRegistry.findModel(fragment);
 				if (candidate instanceof IFragmentModel) {
 					result.add(candidate);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
@@ -36,6 +36,7 @@ import java.util.TreeMap;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -65,6 +66,7 @@ import org.eclipse.pde.core.target.ITargetDefinition;
 import org.eclipse.pde.core.target.LoadTargetDefinitionJob;
 import org.eclipse.pde.core.target.TargetBundle;
 import org.eclipse.pde.internal.core.target.P2TargetUtils;
+import org.osgi.resource.Resource;
 
 public class PluginModelManager implements IModelProviderListener {
 	private static final String fExternalPluginListFile = "SavedExternalPluginList.txt"; //$NON-NLS-1$
@@ -1072,14 +1074,17 @@ public class PluginModelManager implements IModelProviderListener {
 	/**
 	 * Returns a plug-in model associated with the given bundle description
 	 *
-	 * @param desc the bundle description
+	 * @param resource
+	 *            the bundle description
 	 *
-	 * @return a plug-in model associated with the given bundle description or <code>null</code>
-	 * 			if none exists
+	 * @return a plug-in model associated with the given bundle description or
+	 *         <code>null</code> if none exists
 	 */
-	public IPluginModelBase findModel(BundleDescription desc) {
-		ModelEntry entry = (desc != null) ? findEntry(desc.getSymbolicName()) : null;
-		return entry == null ? null : entry.getModel(desc);
+	public IPluginModelBase findModel(Resource resource) {
+		return Adapters.of(resource, BundleDescription.class).map(bd -> {
+			ModelEntry entry = findEntry(bd.getSymbolicName());
+			return entry == null ? null : entry.getModel(bd);
+		}).orElse(null);
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -58,6 +58,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.build.IBuildPropertiesConstants;
 import org.eclipse.pde.internal.core.bnd.BndProjectManager;
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
+import org.osgi.resource.Resource;
 
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
@@ -234,7 +235,7 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 			for (BundleDescription bundle : map.keySet()) {
 				sortedMap.put(bundle.toString(), bundle);
 			}
-			for (BundleDescription bundle : sortedMap.values()) {
+			for (Resource bundle : sortedMap.values()) {
 				IPluginModelBase model = PluginRegistry.findModel(bundle);
 				if (model != null && model.isEnabled()) {
 					addDependencyViaImportPackage(model.getBundleDescription(), added, map, entries);
@@ -406,7 +407,7 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 
 	private boolean addPlugin(BundleDescription desc, boolean useInclusions, Map<BundleDescription, List<Rule>> map,
 			List<IClasspathEntry> entries) throws CoreException {
-		IPluginModelBase model = PluginRegistry.findModel(desc);
+		IPluginModelBase model = PluginRegistry.findModel((Resource) desc);
 		if (model == null || !model.isEnabled()) {
 			return false;
 		}
@@ -475,7 +476,7 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 		}
 	}
 
-	private boolean hasExtensibleAPI(BundleDescription desc) {
+	private boolean hasExtensibleAPI(Resource desc) {
 		IPluginModelBase model = PluginRegistry.findModel(desc);
 		return model != null && ClasspathUtilCore.hasExtensibleAPI(model);
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
@@ -47,6 +47,7 @@ import org.eclipse.pde.core.target.ITargetDefinition;
 import org.eclipse.pde.core.target.TargetBundle;
 import org.eclipse.pde.internal.core.target.TargetPlatformService;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 /**
  * Manages where PDE should look when looking for source.  The locations may
@@ -392,7 +393,8 @@ public class SourceLocationManager implements ICoreConstants {
 			IConfigurationElement[] children = extension.getConfigurationElements();
 			RegistryContributor contributor = (RegistryContributor) extension.getContributor();
 			long bundleId = Long.parseLong(contributor.getActualId());
-			BundleDescription desc = PDECore.getDefault().getModelManager().getState().getState().getBundle(Long.parseLong(contributor.getActualId()));
+			Resource desc = PDECore.getDefault().getModelManager().getState().getState()
+					.getBundle(Long.parseLong(contributor.getActualId()));
 			IPluginModelBase base = null;
 			if (desc != null) {
 				base = PluginRegistry.findModel(desc);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -67,6 +67,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 public class TargetPlatformHelper {
 	private TargetPlatformHelper() { // static use only
@@ -609,7 +610,7 @@ public class TargetPlatformHelper {
 	}
 
 	private static String[] getValue(BundleDescription bundle, PDEState state) {
-		IPluginModelBase model = PluginRegistry.findModel(bundle);
+		IPluginModelBase model = PluginRegistry.findModel((Resource) bundle);
 		String[] result = null;
 		if (model != null) {
 			IPluginLibrary[] libs = model.getPluginBase().getLibraries();

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -26,6 +26,7 @@ import org.eclipse.pde.core.IClasspathContributor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ClasspathUtilCore;
+import org.osgi.resource.Resource;
 
 /**
  * This makes the <a href=
@@ -43,7 +44,7 @@ public class OSGiAnnotationsClasspathContributor implements IClasspathContributo
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
-		IPluginModelBase projectModel = PluginRegistry.findModel(project);
+		IPluginModelBase projectModel = PluginRegistry.findModel((Resource) project);
 		if (projectModel != null) {
 			return ClasspathUtilCore
 					.classpathEntries(annotations().filter(model -> !model.equals(projectModel)))

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BuildErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BuildErrorReporter.java
@@ -72,6 +72,7 @@ import org.eclipse.pde.internal.core.text.build.BuildModel;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.core.util.PatternConstructor;
 import org.osgi.framework.Constants;
+import org.osgi.resource.Resource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -925,7 +926,7 @@ public class BuildErrorReporter extends ErrorReporter implements IBuildPropertie
 			return false;
 		}
 		for (BundleDescription fragment : fragments) {
-			IPluginModelBase fragmentModel = PluginRegistry.findModel(fragment);
+			IPluginModelBase fragmentModel = PluginRegistry.findModel((Resource) fragment);
 			if (fragmentModel != null && fragmentModel.getUnderlyingResource() != null) {
 				IProject project = fragmentModel.getUnderlyingResource().getProject();
 				if (project.findMember(libname) != null) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PluginRebuilder.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PluginRebuilder.java
@@ -33,6 +33,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.IStateDeltaListener;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
+import org.osgi.resource.Resource;
 
 public class PluginRebuilder implements IStateDeltaListener, IResourceChangeListener {
 
@@ -107,7 +108,7 @@ public class PluginRebuilder implements IStateDeltaListener, IResourceChangeList
 					continue;
 				}
 
-				IPluginModelBase model = PluginRegistry.findModel(bundleDelta.getBundle());
+				IPluginModelBase model = PluginRegistry.findModel((Resource) bundleDelta.getBundle());
 				IResource resource = model == null ? null : model.getUnderlyingResource();
 				if (resource != null) {
 					fProjectNames.add(resource.getProject().getName());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/FeatureExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/FeatureExportOperation.java
@@ -102,6 +102,7 @@ import org.eclipse.pde.internal.core.project.PDEProject;
 import org.eclipse.pde.internal.core.target.TargetMetadataCollector;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.resource.Resource;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -366,8 +367,8 @@ public class FeatureExportOperation extends Job {
 
 	public void deleteBuildFiles(Object object) throws CoreException {
 		IModel model = null;
-		if (object instanceof BundleDescription) {
-			model = PluginRegistry.findModel((BundleDescription) object);
+		if (object instanceof Resource r) {
+			model = PluginRegistry.findModel(r);
 		} else if (object instanceof IModel) {
 			model = (IModel) object;
 		}
@@ -1189,7 +1190,8 @@ public class FeatureExportOperation extends Job {
 
 	static boolean isWorkspacePlugin(BundleDescription bundle) {
 		ModelEntry entry = PluginRegistry.findEntry(bundle.getSymbolicName());
-		return entry != null && Arrays.asList(entry.getWorkspaceModels()).contains(PluginRegistry.findModel(bundle));
+		return entry != null
+				&& Arrays.asList(entry.getWorkspaceModels()).contains(PluginRegistry.findModel((Resource) bundle));
 	}
 
 	public static void errorFound() {

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -75,6 +75,7 @@ import org.eclipse.pde.internal.launching.PDELaunchingPlugin;
 import org.eclipse.pde.internal.launching.PDEMessages;
 import org.eclipse.pde.launching.IPDELauncherConstants;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 public class BundleLauncherHelper {
 
@@ -157,7 +158,7 @@ public class BundleLauncherHelper {
 				? DependencyManager.getDependencies(bundle2startLevel.keySet(), DependencyManager.Options.INCLUDE_OPTIONAL_DEPENDENCIES)
 				: DependencyManager.getDependencies(bundle2startLevel.keySet());
 
-		requiredDependencies.stream() //
+		requiredDependencies.stream().map(Resource.class::cast) //
 				.map(PluginRegistry::findModel).filter(Objects::nonNull) //
 				.forEach(p -> addDefaultStartingBundle(bundle2startLevel, p));
 	}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/performance/parts/TargetPlatformPerfTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/performance/parts/TargetPlatformPerfTest.java
@@ -52,6 +52,7 @@ import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 import org.junit.Assert;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 /**
  * Tests the time it takes to resolve a target definition and set it as the target platform.
@@ -235,7 +236,7 @@ public class TargetPlatformPerfTest extends PerformanceTestCase {
 		for (BundleSpecification element : required) {
 			if (!allBundleNames.contains(element.getName())) {
 				allBundleNames.add(element.getName());
-				model = PluginRegistry.findModel(element.getBundle());
+				model = PluginRegistry.findModel((Resource) element.getBundle());
 				openRequiredBundles(model, allBundleNames);
 			}
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDELabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDELabelProvider.java
@@ -92,6 +92,7 @@ import org.eclipse.pde.internal.ui.util.SharedLabelProvider;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 public class PDELabelProvider extends SharedLabelProvider {
 	private static final String SYSTEM_BUNDLE = "system.bundle"; //$NON-NLS-1$
@@ -248,7 +249,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 	public String getObjectText(BundleDescription bundle) {
 		String id = bundle.getSymbolicName();
 		if (isFullNameModeEnabled()) {
-			IPluginModelBase model = PluginRegistry.findModel(bundle);
+			IPluginModelBase model = PluginRegistry.findModel((Resource) bundle);
 			if (model != null) {
 				return model.getPluginBase().getTranslatedName();
 			}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ImportPackageSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ImportPackageSection.java
@@ -104,6 +104,7 @@ import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.progress.UIJob;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 public class ImportPackageSection extends TableSection {
 
@@ -611,7 +612,7 @@ public class ImportPackageSection extends TableSection {
 		}
 		BundleDescription[] hosts = hostSpec.getHosts();
 		// At least one of fragment hosts has to have extensible API
-		for (BundleDescription host : hosts) {
+		for (Resource host : hosts) {
 			if (ClasspathUtilCore.hasExtensibleAPI(PluginRegistry.findModel(host)))
 				return false;
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
@@ -92,6 +92,7 @@ import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
+import org.osgi.resource.Resource;
 import org.osgi.service.prefs.BackingStoreException;
 
 public class ManifestEditor extends PDELauncherFormEditor implements IShowEditorInput {
@@ -113,7 +114,7 @@ public class ManifestEditor extends PDELauncherFormEditor implements IShowEditor
 		return openPluginEditor(PluginRegistry.findModel(id));
 	}
 
-	public static IEditorPart openPluginEditor(BundleDescription bd) {
+	public static IEditorPart openPluginEditor(Resource bd) {
 		return openPluginEditor(PluginRegistry.findModel(bd));
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PluginSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PluginSection.java
@@ -77,6 +77,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.IWorkingSetSelectionDialog;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
+import org.osgi.resource.Resource;
 
 /**
  * Section of the product editor on the {@code Contents} page that lists all
@@ -285,7 +286,7 @@ public class PluginSection extends AbstractProductContentSection<PluginSection> 
 		BundleDescription[] bundles = TargetPlatformHelper.getState().getBundles();
 		for (BundleDescription bundleDescription : bundles) {
 			if (!product.containsPlugin(bundleDescription.getSymbolicName())) {
-				IPluginModelBase pluginModel = PluginRegistry.findModel(bundleDescription);
+				IPluginModelBase pluginModel = PluginRegistry.findModel((Resource) bundleDescription);
 				if (pluginModel != null) {
 					pluginModelBaseList.add(pluginModel);
 				}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
@@ -104,6 +104,7 @@ import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.IWorkingSetSelectionDialog;
 import org.eclipse.ui.dialogs.PatternFilter;
+import org.osgi.resource.Resource;
 
 public abstract class AbstractPluginBlock {
 
@@ -876,7 +877,8 @@ public abstract class AbstractPluginBlock {
 				: new Options[] { Options.INCLUDE_NON_TEST_FRAGMENTS };
 		Set<BundleDescription> additionalBundles = DependencyManager.getDependencies(toCheck, options);
 
-		additionalBundles.stream().map(PluginRegistry::findModel).filter(Objects::nonNull).forEach(toCheck::add);
+		additionalBundles.stream().map(Resource.class::cast).map(PluginRegistry::findModel).filter(Objects::nonNull)
+				.forEach(toCheck::add);
 
 		checked = toCheck.toArray();
 		setCheckedElements(checked);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
@@ -84,6 +84,7 @@ import org.eclipse.pde.launching.IPDELauncherConstants;
 import org.eclipse.pde.launching.PDESourcePathProvider;
 import org.eclipse.pde.ui.launcher.EclipseLaunchShortcut;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.osgi.resource.Resource;
 
 public class LaunchAction extends Action {
 
@@ -377,7 +378,7 @@ public class LaunchAction extends Action {
 		if (product.includeRequirementsAutomatically()) {
 			Stream<BundleDescription> bundles = includedPlugins.stream().map(IPluginModelBase::getBundleDescription);
 			Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(bundles.toList());
-			return closure.stream().map(PluginRegistry::findModel);
+			return closure.stream().map(Resource.class::cast).map(PluginRegistry::findModel);
 		}
 		return includedPlugins.stream();
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/FindReferenceOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/FindReferenceOperation.java
@@ -32,6 +32,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.osgi.framework.Constants;
+import org.osgi.resource.Resource;
 
 public class FindReferenceOperation implements IWorkspaceRunnable {
 
@@ -69,7 +70,8 @@ public class FindReferenceOperation implements IWorkspaceRunnable {
 			SubMonitor iterationMonitor = subMonitor.split(1);
 			for (BundleSpecification require : requires) {
 				if (require.getName().equals(oldId)) {
-					CreateHeaderChangeOperation op = new CreateHeaderChangeOperation(PluginRegistry.findModel(dependent), Constants.REQUIRE_BUNDLE, oldId, fNewId);
+					CreateHeaderChangeOperation op = new CreateHeaderChangeOperation(
+							PluginRegistry.findModel((Resource) dependent), Constants.REQUIRE_BUNDLE, oldId, fNewId);
 					op.run(iterationMonitor);
 					TextFileChange change = op.getChange();
 					if (change != null) {
@@ -85,7 +87,7 @@ public class FindReferenceOperation implements IWorkspaceRunnable {
 		BundleDescription[] fragments = fDesc.getFragments();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, fragments.length);
 		String id = fDesc.getSymbolicName();
-		for (BundleDescription fragment : fragments) {
+		for (Resource fragment : fragments) {
 			IPluginModelBase base = PluginRegistry.findModel(fragment);
 			SubMonitor iterationMonitor = subMonitor.split(1);
 			if (base instanceof IFragmentModel && id.equals(((IFragmentModel) (base)).getFragment().getPluginId())) {
@@ -110,7 +112,9 @@ public class FindReferenceOperation implements IWorkspaceRunnable {
 			if (friends != null)
 				for (String friend : friends) {
 					if (friend.equals(id)) {
-						CreateHeaderChangeOperation op = new CreateHeaderChangeOperation(PluginRegistry.findModel(pkg.getExporter()), Constants.EXPORT_PACKAGE, id, fNewId);
+						CreateHeaderChangeOperation op = new CreateHeaderChangeOperation(
+								PluginRegistry.findModel((Resource) pkg.getExporter()), Constants.EXPORT_PACKAGE, id,
+								fNewId);
 						op.run(iterationMonitor);
 						TextFileChange change = op.getChange();
 						if (change != null)

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/ManifestPackageRenameParticipant.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/ManifestPackageRenameParticipant.java
@@ -34,6 +34,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.osgi.resource.Resource;
 
 public class ManifestPackageRenameParticipant extends PDERenameParticipant {
 
@@ -72,7 +73,7 @@ public class ManifestPackageRenameParticipant extends PDERenameParticipant {
 				BundleDescription[] dependents = desc.getDependents();
 				for (BundleDescription dependent : dependents) {
 					if (isAffected(desc, dependent)) {
-						IPluginModelBase candidate = PluginRegistry.findModel(dependent);
+						IPluginModelBase candidate = PluginRegistry.findModel((Resource) dependent);
 						if (candidate instanceof IBundlePluginModelBase) {
 							IFile file = (IFile) candidate.getUnderlyingResource();
 							addBundleManifestChange(file, result, pm);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/dependencies/DependenciesViewPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/dependencies/DependenciesViewPage.java
@@ -60,6 +60,7 @@ import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.actions.ActionContext;
 import org.eclipse.ui.part.Page;
+import org.osgi.resource.Resource;
 
 public abstract class DependenciesViewPage extends Page {
 	class FocusOnSelectionAction extends Action {
@@ -197,8 +198,8 @@ public abstract class DependenciesViewPage extends Page {
 		ISharedPluginModel model = null;
 		if (selectionElement instanceof BundleSpecification) {
 			model = PluginRegistry.findModel(((BundleSpecification) selectionElement).getName());
-		} else if (selectionElement instanceof BundleDescription) {
-			model = PluginRegistry.findModel((BundleDescription) selectionElement);
+		} else if (selectionElement instanceof Resource) {
+			model = PluginRegistry.findModel((Resource) selectionElement);
 		} else if (selectionElement instanceof IPluginBase) {
 			// root
 			model = ((IPluginBase) selectionElement).getModel();
@@ -398,11 +399,11 @@ public abstract class DependenciesViewPage extends Page {
 			} else if (selectionElement instanceof IPluginObject) {
 				base = (IPluginModelBase) ((IPluginObject) selectionElement).getModel();
 			} else if (selectionElement instanceof BundleSpecification) {
-				BundleDescription desc = (BundleDescription) ((BundleSpecification) selectionElement).getSupplier();
+				Resource desc = (BundleDescription) ((BundleSpecification) selectionElement).getSupplier();
 				if (desc != null)
 					base = PluginRegistry.findModel(desc);
-			} else if (selectionElement instanceof BundleDescription) {
-				base = PluginRegistry.findModel((BundleDescription) selectionElement);
+			} else if (selectionElement instanceof Resource) {
+				base = PluginRegistry.findModel((Resource) selectionElement);
 			}
 			if (base != null && base.getUnderlyingResource() != null) {
 				fRefactorAction.setSelection(base);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/plugins/PluginsView.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/plugins/PluginsView.java
@@ -117,6 +117,7 @@ import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.progress.IDeferredWorkbenchAdapter;
 import org.eclipse.ui.progress.IElementCollector;
 import org.eclipse.ui.progress.PendingUpdateAdapter;
+import org.osgi.resource.Resource;
 
 public class PluginsView extends ViewPart implements IPluginModelListener {
 
@@ -684,7 +685,7 @@ public class PluginsView extends ViewPart implements IPluginModelListener {
 				.map(IPluginModelBase.class::cast).toList();
 		Set<BundleDescription> set = DependencyManager.getSelfAndDependencies(models);
 		ArrayList<IPluginModelBase> result = new ArrayList<>(set.size());
-		for (BundleDescription bundle : set) {
+		for (Resource bundle : set) {
 			IPluginModelBase model = PluginRegistry.findModel(bundle);
 			if (model != null)
 				result.add(model);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifest.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifest.java
@@ -105,6 +105,7 @@ import org.eclipse.pde.internal.ui.util.PDEModelUtility;
 import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.osgi.framework.Constants;
+import org.osgi.resource.Resource;
 import org.osgi.service.prefs.BackingStoreException;
 
 import aQute.bnd.header.Attrs;
@@ -427,7 +428,7 @@ public class OrganizeManifest implements IOrganizeManifestsSettings {
 		HostSpecification hostSpec = bundleDesc.getHost();
 		if (hostSpec != null) {
 			BundleDescription[] hosts = hostSpec.getHosts();
-			for (BundleDescription host : hosts) {
+			for (Resource host : hosts) {
 				IPluginModelBase hostModel = PluginRegistry.findModel(host);
 				if (hostModel != null) {
 					findTranslatedXMLStrings(getTextModel(hostModel, false), list);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/EclipseLaunchShortcut.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/EclipseLaunchShortcut.java
@@ -50,6 +50,7 @@ import org.eclipse.pde.internal.ui.launcher.LaunchAction;
 import org.eclipse.pde.launching.IPDELauncherConstants;
 import org.eclipse.pde.launching.PDESourcePathProvider;
 import org.eclipse.ui.IEditorPart;
+import org.osgi.resource.Resource;
 
 /**
  * A launch shortcut capable of launching an Eclipse application.
@@ -297,7 +298,7 @@ public class EclipseLaunchShortcut extends AbstractLaunchShortcut {
 		Set<String> wsplugins = new HashSet<>();
 		Set<String> explugins = new HashSet<>();
 		Set<BundleDescription> plugins = DependencyManager.getSelfAndDependencies(Set.of(fModel));
-		for (BundleDescription plugin : plugins) {
+		for (Resource plugin : plugins) {
 			IPluginModelBase model = PluginRegistry.findModel(plugin);
 			if (model == null || !model.isEnabled())
 				continue;


### PR DESCRIPTION
BundleDescription belongs to the old resolver API instead we should use the OSGi Resource API.

This does the following:
- add a new method to find the model by Resource
- deprecate for removal the old find method
- use adapter for internal usage of BundleDescription to lookup the model
- clear references to the deprecated method

This will allow to adapt PDE in a more flexible way to other plugin models (e.g. BND / tycho / p2 / ... )