### PR TITLE
Fix lookup of workspace located annotation providers

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotationsClasspathContributor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotationsClasspathContributor.java
@@ -36,9 +36,10 @@ public class ApiAnnotationsClasspathContributor implements IClasspathContributor
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
-		IPluginModelBase model = PluginRegistry.findModel(project);
-		if (hasApiNature(model)) {
-			return ClasspathUtilCore.classpathEntries(annotations()).collect(Collectors.toList());
+		IPluginModelBase projectModel = PluginRegistry.findModel(project);
+		if (hasApiNature(projectModel)) {
+			return ClasspathUtilCore.classpathEntries(annotations().filter(model -> !model.equals(projectModel)))
+					.collect(Collectors.toList());
 		}
 		return Collections.emptyList();
 	}

--- a/ui/org.eclipse.pde.core/.settings/.api_filters
+++ b/ui/org.eclipse.pde.core/.settings/.api_filters
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.pde.core" version="2">
+    <resource path="src/org/eclipse/pde/core/ModelChangedEvent.java" type="org.eclipse.pde.core.ModelChangedEvent">
+        <filter comment="This is PDEs own implementation" id="576725006">
+            <message_arguments>
+                <message_argument value="IModelChangedEvent"/>
+                <message_argument value="ModelChangedEvent"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/pde/internal/core/project/BundleProjectService.java" type="org.eclipse.pde.internal.core.project.BundleProjectService">
         <filter comment="Platform Team allows use of bundle importers for PDE import from source repository" id="640712815">
             <message_arguments>
                 <message_argument value="Team"/>
                 <message_argument value="BundleProjectService"/>
                 <message_argument value="getBundleImporters()"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/pde/internal/core/target/ExportTargetJob.java" type="org.eclipse.pde.internal.core.target.ExportTargetJob">
-        <filter comment="Using IProvidedCapability is the only current available option to export a p2 target correctly" id="640712815">
-            <message_arguments>
-                <message_argument value="IProvidedCapability"/>
-                <message_argument value="ExportTargetJob"/>
-                <message_argument value="getName()"/>
-            </message_arguments>
-        </filter>
-        <filter comment="Using IProvidedCapability is the only current available option to export a p2 target correctly" id="640712815">
-            <message_arguments>
-                <message_argument value="IProvidedCapability"/>
-                <message_argument value="ExportTargetJob"/>
-                <message_argument value="getNamespace()"/>
             </message_arguments>
         </filter>
     </resource>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/PluginRegistry.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/PluginRegistry.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.VersionRange;
@@ -408,13 +409,16 @@ public class PluginRegistry {
 	 */
 	public static IBuildModel createBuildModel(IPluginModelBase model) throws CoreException {
 		if (model != null) {
-			IProject project = model.getUnderlyingResource().getProject();
-			if (project != null) {
-				IFile buildFile = PDEProject.getBuildProperties(project);
-				if (buildFile.exists()) {
-					IBuildModel buildModel = new WorkspaceBuildModel(buildFile);
-					buildModel.load();
-					return buildModel;
+			IResource resource = model.getUnderlyingResource();
+			if (resource != null) {
+				IProject project = resource.getProject();
+				if (project != null) {
+					IFile buildFile = PDEProject.getBuildProperties(project);
+					if (buildFile.exists()) {
+						IBuildModel buildModel = new WorkspaceBuildModel(buildFile);
+						buildModel.load();
+						return buildModel;
+					}
 				}
 			}
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -43,9 +43,11 @@ public class OSGiAnnotationsClasspathContributor implements IClasspathContributo
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
-		IPluginModelBase model = PluginRegistry.findModel(project);
-		if (model != null) {
-			return ClasspathUtilCore.classpathEntries(annotations()).collect(Collectors.toList());
+		IPluginModelBase projectModel = PluginRegistry.findModel(project);
+		if (projectModel != null) {
+			return ClasspathUtilCore
+					.classpathEntries(annotations().filter(model -> !model.equals(projectModel)))
+					.collect(Collectors.toList());
 		}
 		return Collections.emptyList();
 	}


### PR DESCRIPTION
Currently, if a annotation project is part of the workspace (most notable (org.eclipse.pde.api.tools.annotations) it currently does not resolve the binary folders correctly.

This fixes the conversion of plugin models to classpath entries by check if a build model is available and if found uses the binary folders as classpath entries instead of the base location.