### PR TITLE
externalize plugin.xml strings

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.properties
+++ b/ui/org.eclipse.pde.ui/plugin.properties
@@ -309,3 +309,8 @@ locationProvider.reference.description = Add a reference to another target file
 
 locationProvider.repository.name = OSGi Repository
 locationProvider.repository.description = Add content from an OSGi Repository according to the Repository Service Specification
+
+RepositoryTargetLocationProvisioner.name = Bnd Repository
+RepositoryTargetLocationProvisioner.description = Download plug-ins from a repository defined in a Bnd workspace
+RunDescriptorTargetLocationProvisioner.description = The set of bundles defined by a Bnd run descriptor
+RunDescriptorTargetLocationProvisioner.name = Bnd Run Descriptor

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -2528,9 +2528,9 @@
             class="org.eclipse.pde.internal.ui.bndtools.RepositoryTargetLocationWizard"
             icon="platform:/plugin/org.eclipse.pde.ui/icons/bndtools/database.png"
             id="bndtools.RepositoryTargetLocationProvisioner"
-            name="Bnd Repository">
+            name="%RepositoryTargetLocationProvisioner.name">
          <description>
-            Download plug-ins from a repository defined in a Bnd workspace
+            %RepositoryTargetLocationProvisioner.description
          </description>
       </locationProvider>
    </extension>
@@ -2551,9 +2551,9 @@
             class="org.eclipse.pde.internal.ui.bndtools.RunDescriptorTargetLocationWizard"
             icon="platform:/plugin/org.eclipse.pde.ui/icons/bndtools/bndrun.gif"
             id="bndtools.RunDescriptorTargetLocationProvisioner"
-            name="Bnd Run Descriptor">
+            name="%RunDescriptorTargetLocationProvisioner.name">
          <description>
-            The set of bundles defined by a Bnd run descriptor
+            %RunDescriptorTargetLocationProvisioner.description
          </description>
       </locationProvider>
    </extension>


### PR DESCRIPTION
removes warnings like "The value for attribute 'name' is not externalized.  The value must begin with %"