### PR TITLE
Add an option to the product editor to flag it contain a JRE

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/ProductExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/ProductExportOperation.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -50,6 +51,7 @@ import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
 import org.eclipse.pde.internal.core.iproduct.IJREInfo;
 import org.eclipse.pde.internal.core.iproduct.ILauncherInfo;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
+import org.eclipse.pde.internal.core.product.JREInfo;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 
 public class ProductExportOperation extends FeatureExportOperation {
@@ -204,7 +206,7 @@ public class ProductExportOperation extends FeatureExportOperation {
 			}
 		}
 
-		IJREInfo jreInfo = fProduct.getJREInfo();
+		IJREInfo jreInfo = getJreInfo();
 		if (jreInfo != null) {
 			for (String[] configuration : configurations) {
 				String[] config = configuration;
@@ -261,6 +263,30 @@ public class ProductExportOperation extends FeatureExportOperation {
 			}
 		}
 		save(new File(file, ICoreConstants.BUILD_FILENAME_DESCRIPTOR), properties, "Build Configuration"); //$NON-NLS-1$
+	}
+
+	private IJREInfo getJreInfo() {
+		if (fProduct.includeJre()) {
+			return new JREInfo(fProduct.getModel()) {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public boolean includeJREWithProduct(String os) {
+					// always true for all os
+					return true;
+				}
+
+				@Override
+				public File getJVMLocation(String os) {
+					// always the default vm install, that is the one from the
+					// target definition
+					return JavaRuntime.getDefaultVMInstall().getInstallLocation();
+				}
+
+			};
+		}
+		return fProduct.getJREInfo();
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IProduct.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IProduct.java
@@ -50,6 +50,7 @@ public interface IProduct extends IProductObject {
 	String P_INTRO_ID = "introId"; //$NON-NLS-1$
 	String P_VERSION = "version"; //$NON-NLS-1$
 	String P_INCLUDE_LAUNCHERS = "includeLaunchers"; //$NON-NLS-1$
+	String P_INCLUDE_JRE = "includeJRE"; //$NON-NLS-1$
 	String P_INCLUDE_REQUIREMENTS_AUTOMATICALLY = "autoIncludeRequirements"; //$NON-NLS-1$
 
 	String getId();
@@ -67,6 +68,8 @@ public interface IProduct extends IProductObject {
 	ProductType getType();
 
 	boolean includeLaunchers();
+
+	boolean includeJre();
 
 	boolean includeRequirementsAutomatically();
 
@@ -186,5 +189,7 @@ public interface IProduct extends IProductObject {
 	boolean containsPlugin(String id);
 
 	boolean containsFeature(String id);
+
+	void setIncludeJre(boolean includeJre);
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/Product.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/Product.java
@@ -77,6 +77,7 @@ public class Product extends ProductObject implements IProduct {
 	private IJREInfo fJVMInfo;
 	private ProductType fType = ProductType.BUNDLES;
 	private boolean fIncludeLaunchers = true;
+	private boolean fIncludeJre = false;
 	private boolean fAutoIncludeRequirements = true;
 	private IWindowImages fWindowImages;
 	private ISplashInfo fSplashInfo;
@@ -207,6 +208,9 @@ public class Product extends ProductObject implements IProduct {
 		}
 		writer.print(" " + P_TYPE + "=\"" + fType + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		writer.print(" " + P_INCLUDE_LAUNCHERS + "=\"" + fIncludeLaunchers + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		if (fIncludeJre) {
+			writer.print(" " + P_INCLUDE_JRE + "=\"true\""); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		writer.print(" " + P_INCLUDE_REQUIREMENTS_AUTOMATICALLY + "=\"" + fAutoIncludeRequirements + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		writer.println(">"); //$NON-NLS-1$
 
@@ -366,6 +370,8 @@ public class Product extends ProductObject implements IProduct {
 			}
 			String launchers = element.getAttribute(P_INCLUDE_LAUNCHERS);
 			fIncludeLaunchers = launchers.isBlank() || "true".equals(launchers); //$NON-NLS-1$
+			String jre = element.getAttribute(P_INCLUDE_JRE);
+			fIncludeJre = Boolean.parseBoolean(jre);
 			String autoAdd = element.getAttribute(P_INCLUDE_REQUIREMENTS_AUTOMATICALLY);
 			fAutoIncludeRequirements = autoAdd.isBlank() || "true".equals(autoAdd); //$NON-NLS-1$
 
@@ -876,11 +882,26 @@ public class Product extends ProductObject implements IProduct {
 	}
 
 	@Override
+	public boolean includeJre() {
+		return fIncludeJre;
+	}
+
+	@Override
 	public void setIncludeLaunchers(boolean include) {
 		boolean old = fIncludeLaunchers;
 		fIncludeLaunchers = include;
 		if (isEditable()) {
 			firePropertyChanged(P_INCLUDE_LAUNCHERS, Boolean.toString(old), Boolean.toString(fIncludeLaunchers));
 		}
+	}
+
+	@Override
+	public void setIncludeJre(boolean include) {
+		boolean old = fIncludeJre;
+		fIncludeJre = include;
+		if (isEditable()) {
+			firePropertyChanged(P_INCLUDE_LAUNCHERS, Boolean.toString(old), Boolean.toString(fIncludeJre));
+		}
+
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -2157,6 +2157,7 @@ public class PDEUIMessages extends NLS {
 	public static String ProductInfoSection_app;
 	public static String ProductInfoSection_appTooltip;
 	public static String ProductInfoSection_launchers;
+	public static String ProductInfoSection_jre;
 	public static String SplashSection_title;
 	public static String SplashSection_desc;
 	public static String SplashSection_plugin;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/GeneralInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/GeneralInfoSection.java
@@ -46,6 +46,7 @@ public class GeneralInfoSection extends PDESection {
 	private FormEntry fNameEntry;
 	private FormEntry fVersionEntry;
 	private Button fLaunchersButton;
+	private Button fJreButton;
 
 	private static int NUM_COLUMNS = 3;
 
@@ -146,12 +147,20 @@ public class GeneralInfoSection extends PDESection {
 	}
 
 	private void createLaunchersOption(Composite client, FormToolkit toolkit) {
+		// includes launcher
 		fLaunchersButton = toolkit.createButton(client, PDEUIMessages.ProductInfoSection_launchers, SWT.CHECK);
 		GridData data = new GridData();
 		data.horizontalSpan = 2;
 		fLaunchersButton.setLayoutData(data);
 		fLaunchersButton.setEnabled(isEditable());
 		fLaunchersButton.addSelectionListener(widgetSelectedAdapter(e -> getProduct().setIncludeLaunchers(fLaunchersButton.getSelection())));
+		// includes JRE
+		fJreButton = toolkit.createButton(client, PDEUIMessages.ProductInfoSection_jre, SWT.CHECK);
+		fJreButton.setLayoutData(data);
+		fJreButton.setEnabled(isEditable());
+		fJreButton.addSelectionListener(
+				widgetSelectedAdapter(e -> getProduct().setIncludeJre(fJreButton.getSelection())));
+
 	}
 
 	@Override
@@ -191,6 +200,7 @@ public class GeneralInfoSection extends PDESection {
 			fVersionEntry.setValue(product.getVersion(), true);
 		}
 		fLaunchersButton.setSelection(product.includeLaunchers());
+		fJreButton.setSelection(product.includeJre());
 		super.refresh();
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2120,6 +2120,7 @@ ProductInfoSection_new=New...
 ProductInfoSection_app=Application:
 ProductInfoSection_appTooltip=The application extension identifier
 ProductInfoSection_launchers=The product includes native launcher artifacts
+ProductInfoSection_jre=The product includes a JRE
 SplashSection_title=Location
 SplashSection_desc=The splash screen appears when the product launches. Specify the plug-in in which the splash screen is located.
 SplashSection_plugin=Plug-in:


### PR DESCRIPTION
Currently if one wants to include a JRE it is needed to specify a concrete EE for each of the linux/win/mac what is quite cumbersome and could easily forgotten to update.

Instead this adds a new flag "includeJRE" in the product that enables this for all os at once and always uses the default vm (what is the one from the target platform or user chosen default).

This will also make it easier for Tools like Tycho that already investigate the 'includeLaunchers' flag.

![grafik](https://github.com/eclipse-pde/eclipse.pde/assets/1331477/afc4380a-5077-4783-bbcf-1f575aba8fb0)
