### PR TITLE
Install features into the profile

### DIFF
--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.11.300.qualifier
+Bundle-Version: 3.12.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchConfigurationHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchConfigurationHelper.java
@@ -43,6 +43,7 @@ import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.P2Utils;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
+import org.eclipse.pde.internal.core.ifeature.IFeature;
 import org.eclipse.pde.internal.launching.IPDEConstants;
 import org.eclipse.pde.launching.IPDELauncherConstants;
 
@@ -123,6 +124,23 @@ public class LaunchConfigurationHelper {
 	 * @return a properties object containing the properties written out to config.ini
 	 */
 	public static Properties createConfigIniFile(ILaunchConfiguration configuration, String productID, Map<String, List<IPluginModelBase>> bundles, Map<IPluginModelBase, String> bundlesWithStartLevels, File configurationDirectory) throws CoreException {
+		return createConfigIniFile(configuration, productID, bundles, null, bundlesWithStartLevels, configurationDirectory);
+	}
+
+	/**
+	 * Writes out the config.ini and other configuration files based on the bundles being launched.  This includes
+	 * writing out bundles.info if the simple configurator is being used or platform.xml if update configurator
+	 * is being used.
+	 *
+	 * @param configuration launch configuration
+	 * @param productID id of the product being launched, may be <code>null</code>
+	 * @param bundles map of bundle id to plug-in model, these are the bundles being launched
+	 * @param features collection of features to install in the profile, might be null
+	 * @param bundlesWithStartLevels map of plug-in model to a string containing start level information
+	 * @param configurationDirectory config directory where the created files will be placed
+	 * @return a properties object containing the properties written out to config.ini
+	 */
+	public static Properties createConfigIniFile(ILaunchConfiguration configuration, String productID, Map<String, List<IPluginModelBase>> bundles, Map<IFeature, Boolean> features, Map<IPluginModelBase, String> bundlesWithStartLevels, File configurationDirectory) throws CoreException {
 		Properties properties = null;
 		// if we are to generate a config.ini, start with the values in the target platform's config.ini - bug 141918
 		if (configuration.getAttribute(IPDELauncherConstants.CONFIG_GENERATE_DEFAULT, true)) {
@@ -198,7 +216,7 @@ public class LaunchConfigurationHelper {
 
 				// Unless we are restarting an existing profile, generate/overwrite the profile
 				if (!configuration.getAttribute(IPDEConstants.RESTART, false) || !P2Utils.profileExists(profileID, p2DataArea)) {
-					P2Utils.createProfile(profileID, p2DataArea, bundles.values());
+					P2Utils.createProfile(profileID, p2DataArea, bundles.values(), features);
 				}
 				properties.setProperty("eclipse.p2.profile", profileID); //$NON-NLS-1$
 			}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/IPDELauncherConstants.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/IPDELauncherConstants.java
@@ -485,6 +485,12 @@ public interface IPDELauncherConstants {
 	String SELECTED_FEATURES = "selected_features"; //$NON-NLS-1$
 
 	/**
+	 * Launch configuration attribute key. The value is a List specifying the features that are selected as root features.
+	 * @since 3.12
+	 */
+	String ROOT_FEATURES = "root_features"; //$NON-NLS-1$
+
+	/**
 	 * Launch configuration attribute key. The value is a boolean specifying
 	 * if the feature-based launching mode should be used.
 	 * This mode will launch with all the workspace and external features

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -221,7 +221,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		// Create the platform configuration for the runtime workbench
 		String productID = LaunchConfigurationHelper.getProductID(configuration);
 		IPluginBase testPlugin = getTestPlugin(configuration);
-		LaunchConfigurationHelper.createConfigIniFile(configuration, productID, fAllBundles, fModels, getConfigurationDirectory(configuration));
+		LaunchConfigurationHelper.createConfigIniFile(configuration, productID, fAllBundles, null, fModels, getConfigurationDirectory(configuration));
 		TargetPlatformHelper.checkPluginPropertiesConsistency(fAllBundles, getConfigurationDirectory(configuration));
 
 		programArgs.add("-configuration"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
@@ -180,6 +180,7 @@ public class LaunchAction extends Action {
 		} else {
 			wc.removeAttribute(IPDELauncherConstants.USE_CUSTOM_FEATURES);
 			wc.removeAttribute(IPDELauncherConstants.SELECTED_FEATURES);
+			wc.removeAttribute(IPDELauncherConstants.ROOT_FEATURES);
 			wc.removeAttribute(IPDELauncherConstants.ADDITIONAL_PLUGINS);
 		}
 		wc.setAttribute(IPDELauncherConstants.AUTOMATIC_INCLUDE_REQUIREMENTS,
@@ -212,7 +213,12 @@ public class LaunchAction extends Action {
 		} // only add absent plugins
 
 		wc.setAttribute(IPDELauncherConstants.SELECTED_FEATURES, selectedFeatures);
+		Set<String> rootFeatures = Arrays.stream(fProduct.getFeatures()).filter(pf -> pf.isRootInstallMode())
+				.map(pf -> pf.getId())
+				.collect(Collectors.toSet());
+		wc.setAttribute(IPDELauncherConstants.ROOT_FEATURES, rootFeatures);
 		wc.setAttribute(IPDELauncherConstants.ADDITIONAL_PLUGINS, additionalPlugins);
+
 	}
 
 	private void appendBundle(Set<String> plugins, IPluginModelBase model, Optional<AdditionalPluginData> pConfig) {


### PR DESCRIPTION
Currently if one selects the option to allow installation of new software there is the problem that only plugins are available in the generated profiles. This makes testing of install scenarios possible but updates can not be tested because effectively nothing user visible is installed.

This now do two things:

 1) generates feature group IUs and install them into the profile
 2) if started from a product derive the root features from it