### PR TITLE
Capture comparator errors and compile logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,8 @@ pipeline {
 						*/target/work/data/.metadata/*.log,\
 						*/tests/target/work/data/.metadata/*.log,\
 						apiAnalyzer-workspace/.metadata/*.log,\
-						*/target/artifactcomparison/**,\
+						**/target/artifactcomparison/**,\
+						**/target/compilelogs/**,\
 						repository/target/repository/**')
 					junit '**/target/surefire-reports/*.xml'
 					discoverGitReferenceBuild referenceJob: 'eclipse.pde/master'


### PR DESCRIPTION
... currently no baseline compare errors so have to wait for the problem to reoccur.