### PR TITLE
Adapt PDE's Oomph setupt to e4.tools merge

### DIFF
--- a/releng/org.eclipse.pde.setup/PDE.setup
+++ b/releng/org.eclipse.pde.setup/PDE.setup
@@ -177,7 +177,7 @@
             project="org.eclipse.pde"/>
         <operand
             xsi:type="workingsets:ExclusionPredicate"
-            excludedWorkingSet="//'pde.workingsets'/@workingSets[name='PDE%20API%20Tools'] //'pde.workingsets'/@workingSets[name='PDE%20Tests'] //'pde.workingsets'/@workingSets[name='PDE%20Build']"/>
+            excludedWorkingSet="//'pde.workingsets'/@workingSets[name='PDE%20API%20Tools'] //'pde.workingsets'/@workingSets[name='PDE%20Tests'] //'pde.workingsets'/@workingSets[name='PDE%20Build'] //'pde.workingsets'/@workingSets[name='E4%20Tools']"/>
       </predicate>
     </workingSet>
     <workingSet
@@ -220,6 +220,18 @@
         <operand
             xsi:type="workingsets:ExclusionPredicate"
             excludedWorkingSet="//'pde.workingsets'/@workingSets[name='PDE%20Build']"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="E4 Tools">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.pde"/>
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern="org\.eclipse\.e4\.tools.*"/>
       </predicate>
     </workingSet>
   </setupTask>


### PR DESCRIPTION
Follow-up of https://github.com/eclipse-pde/eclipse.pde/pull/1081.

@merks can you tell why the e4.tools project are not imported in the WS? I actually assumed that the targlet task should do that without adjustments.