### PR TITLE
Validation dialog - Edit launch configuration link

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchValidationOperation.java
@@ -42,7 +42,7 @@ import org.eclipse.pde.internal.core.TargetPlatformHelper;
 public class LaunchValidationOperation implements IWorkspaceRunnable {
 
 	private BundleValidationOperation fOperation;
-	protected final ILaunchConfiguration fLaunchConfiguration;
+	public final ILaunchConfiguration fLaunchConfiguration;
 	protected final Set<IPluginModelBase> fModels;
 
 	public LaunchValidationOperation(ILaunchConfiguration configuration, Set<IPluginModelBase> models) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
@@ -1038,7 +1038,7 @@ public abstract class AbstractPluginBlock {
 			if (fDialog == null) {
 				if (fOperation.hasErrors()) {
 					fDialog = new PluginStatusDialog(getShell(), SWT.MODELESS | SWT.CLOSE | SWT.BORDER | SWT.TITLE | SWT.RESIZE);
-					fDialog.setInput(fOperation.getInput());
+					fDialog.setInput(fOperation);
 					fDialog.open();
 					fDialog = null;
 				} else if (fOperation.isEmpty()) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/FeatureBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/FeatureBlock.java
@@ -391,7 +391,7 @@ public class FeatureBlock {
 				if (fDialog == null) {
 					if (fOperation.hasErrors()) {
 						fDialog = new PluginStatusDialog(getShell(), SWT.MODELESS | SWT.CLOSE | SWT.BORDER | SWT.TITLE | SWT.RESIZE);
-						fDialog.setInput(fOperation.getInput());
+						fDialog.setInput(fOperation);
 						fDialog.open();
 						fDialog = null;
 					} else if (fOperation.isEmpty()) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginValidationStatusHandler.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginValidationStatusHandler.java
@@ -59,7 +59,7 @@ public class PluginValidationStatusHandler implements IStatusHandler {
 			PluginStatusDialog dialog = new PluginStatusDialog(shellProvider.getShell());
 			dialog.showLink(true);
 			dialog.showCancelButton(true);
-			dialog.setInput(op.getInput());
+			dialog.setInput(op);
 			result[0] = dialog.open();
 		});
 		if (result[0] == IDialogConstants.CANCEL_ID)


### PR DESCRIPTION
New link in the validation dialog to open the current launch configuration.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/305