### PR TITLE
Remove special treatment of org.eclipse.swt in API-Tools

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/actions/DeltaSession.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/actions/DeltaSession.java
@@ -504,21 +504,13 @@ public class DeltaSession implements ISession {
 									IApiComponent p = providers[index];
 									if (!p.equals(apiComponent)) {
 										String id2 = p.getSymbolicName();
-										if (Util.ORG_ECLIPSE_SWT.equals(id2)) {
-											typeRoot = p.findTypeRoot(typeName);
-										} else {
-											typeRoot = p.findTypeRoot(typeName, id2);
-										}
+										typeRoot = p.findTypeRoot(typeName, id2);
 									}
 									index++;
 								}
 								break;
 							default:
-								if (Util.ORG_ECLIPSE_SWT.equals(id)) {
-									typeRoot = apiComponent.findTypeRoot(typeName);
-								} else {
-									typeRoot = apiComponent.findTypeRoot(typeName, id);
-								}
+								typeRoot = apiComponent.findTypeRoot(typeName, id);
 						}
 						if (typeRoot != null) {
 							IApiType structure = typeRoot.getStructure();
@@ -554,21 +546,13 @@ public class DeltaSession implements ISession {
 										IApiComponent p = providers[index];
 										if (!p.equals(apiComponent)) {
 											String id2 = p.getSymbolicName();
-											if (Util.ORG_ECLIPSE_SWT.equals(id2)) {
-												typeRoot = p.findTypeRoot(typeName);
-											} else {
-												typeRoot = p.findTypeRoot(typeName, id2);
-											}
+											typeRoot = p.findTypeRoot(typeName, id2);
 										}
 										index++;
 									}
 									break;
 								default:
-									if (Util.ORG_ECLIPSE_SWT.equals(id)) {
-										typeRoot = apiComponent.findTypeRoot(typeName);
-									} else {
-										typeRoot = apiComponent.findTypeRoot(typeName, id);
-									}
+									typeRoot = apiComponent.findTypeRoot(typeName, id);
 							}
 							if (typeRoot != null) {
 								IApiType structure = typeRoot.getStructure();

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
@@ -1309,11 +1309,7 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 		}
 		IApiTypeRoot classFile = null;
 		try {
-			if (Util.ORG_ECLIPSE_SWT.equals(id)) {
-				classFile = component.findTypeRoot(typeName);
-			} else {
-				classFile = component.findTypeRoot(typeName, id);
-			}
+			classFile = component.findTypeRoot(typeName, id);
 		} catch (CoreException e) {
 			ApiPlugin.log(e);
 		}
@@ -1331,11 +1327,7 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 				IApiComponent p = providers[index];
 				if (!p.equals(component)) {
 					String id2 = p.getSymbolicName();
-					if (Util.ORG_ECLIPSE_SWT.equals(id2)) {
-						classFile = p.findTypeRoot(typeName);
-					} else {
-						classFile = p.findTypeRoot(typeName, id2);
-					}
+					classFile = p.findTypeRoot(typeName, id2);
 					if (classFile != null) {
 						IRequiredComponentDescription[] components = component.getRequiredComponents();
 						for (IRequiredComponentDescription description : components) {
@@ -1865,15 +1857,10 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 					if (Flags.isProtected(modifiers)) {
 						String typeName = delta.getTypeName();
 						if (typeName != null) {
-							IApiTypeRoot typeRoot = null;
 							IApiType type = null;
 							try {
 								String id = component.getSymbolicName();
-								if (Util.ORG_ECLIPSE_SWT.equals(id)) {
-									typeRoot = component.findTypeRoot(typeName);
-								} else {
-									typeRoot = component.findTypeRoot(typeName, id);
-								}
+								IApiTypeRoot typeRoot = component.findTypeRoot(typeName, id);
 								if (typeRoot == null) {
 									String packageName = Signatures.getPackageName(typeName);
 									// check if the type is provided by a
@@ -1885,11 +1872,7 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 										IApiComponent p = providers[index];
 										if (!p.equals(component)) {
 											String id2 = p.getSymbolicName();
-											if (Util.ORG_ECLIPSE_SWT.equals(id2)) {
-												typeRoot = p.findTypeRoot(typeName);
-											} else {
-												typeRoot = p.findTypeRoot(typeName, id2);
-											}
+											typeRoot = p.findTypeRoot(typeName, id2);
 										}
 										index++;
 									}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
@@ -555,25 +555,17 @@ public class BundleComponent extends Component {
 		List<IApiComponent> all = new ArrayList<>();
 		// build the classpath from bundle and all fragments
 		all.add(this);
-		boolean considerFragments = true;
-		if (Util.ORG_ECLIPSE_SWT.equals(getSymbolicName())) {
-			// if SWT is a project to be built/analyzed don't consider its
-			// fragments
-			considerFragments = !isApiEnabled();
-		}
-		if (considerFragments) {
-			BundleDescription[] fragments = getBundleDescription().getFragments();
-			for (BundleDescription fragment : fragments) {
-				if (!fragment.isResolved()) {
-					continue;
-				}
-				IApiComponent component = getBaseline().getApiComponent(fragment.getSymbolicName());
-				if (component != null) {
-					// force initialization of the fragment so we can
-					// retrieve its class file containers
-					component.getApiTypeContainers();
-					all.add(component);
-				}
+		BundleDescription[] fragments = getBundleDescription().getFragments();
+		for (BundleDescription fragment : fragments) {
+			if (!fragment.isResolved()) {
+				continue;
+			}
+			IApiComponent component = getBaseline().getApiComponent(fragment.getSymbolicName());
+			if (component != null) {
+				// force initialization of the fragment so we can
+				// retrieve its class file containers
+				component.getApiTypeContainers();
+				all.add(component);
 			}
 		}
 		Iterator<IApiComponent> iterator = all.iterator();

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/comparator/ApiComparator.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/comparator/ApiComparator.java
@@ -357,13 +357,8 @@ public class ApiComparator {
 				return NO_DELTA;
 			}
 			String typeName = typeRoot2.getTypeName();
-			IApiTypeRoot typeRoot = null;
 			String id = component.getSymbolicName();
-			if (Util.ORG_ECLIPSE_SWT.equals(id)) {
-				typeRoot = component.findTypeRoot(typeName);
-			} else {
-				typeRoot = component.findTypeRoot(typeName, id);
-			}
+			IApiTypeRoot typeRoot = component.findTypeRoot(typeName, id);
 			final IApiDescription apiDescription2 = component2.getApiDescription();
 			IApiAnnotations elementDescription2 = apiDescription2.resolveAnnotations(typeDescriptor2.getHandle());
 			int visibility = 0;
@@ -614,17 +609,9 @@ public class ApiComparator {
 	private static IDelta internalCompare(final IApiComponent component, final IApiComponent component2, final IApiBaseline referenceBaseline, final IApiBaseline baseline, final int visibilityModifiers, final Delta globalDelta, final IProgressMonitor monitor) throws CoreException {
 		final Set<String> typeRootBaseLineNames = new HashSet<>();
 		final String id = component.getSymbolicName();
-		IApiTypeContainer[] typeRootContainers = null;
-		IApiTypeContainer[] typeRootContainers2 = null;
 		final SubMonitor localmonitor = SubMonitor.convert(monitor, 4);
-		final boolean isSWT = Util.ORG_ECLIPSE_SWT.equals(id);
-		if (isSWT) {
-			typeRootContainers = component.getApiTypeContainers();
-			typeRootContainers2 = component2.getApiTypeContainers();
-		} else {
-			typeRootContainers = component.getApiTypeContainers(id);
-			typeRootContainers2 = component2.getApiTypeContainers(id);
-		}
+		IApiTypeContainer[] typeRootContainers = component.getApiTypeContainers(id);
+		IApiTypeContainer[] typeRootContainers2 = component2.getApiTypeContainers(id);
 		final IApiDescription apiDescription = component.getApiDescription();
 		final IApiDescription apiDescription2 = component2.getApiDescription();
 		if (typeRootContainers != null) {
@@ -652,12 +639,7 @@ public class ApiComparator {
 									// Annotation is missing, not an API?
 									visibility = 0;
 								}
-								IApiTypeRoot typeRoot2 = null;
-								if (isSWT) {
-									typeRoot2 = component2.findTypeRoot(typeName);
-								} else {
-									typeRoot2 = component2.findTypeRoot(typeName, id);
-								}
+								IApiTypeRoot typeRoot2 = component2.findTypeRoot(typeName, id);
 								IApiComponent provider = null;
 								IApiDescription providerApiDesc = null;
 								boolean reexported = false;
@@ -673,11 +655,7 @@ public class ApiComparator {
 										IApiComponent p = providers[index];
 										if (!p.equals(component2)) {
 											String id2 = p.getSymbolicName();
-											if (Util.ORG_ECLIPSE_SWT.equals(id2)) {
-												typeRoot2 = p.findTypeRoot(typeName);
-											} else {
-												typeRoot2 = p.findTypeRoot(typeName, id2);
-											}
+											typeRoot2 = p.findTypeRoot(typeName, id2);
 											if (typeRoot2 != null) {
 												provider = p;
 												providerApiDesc = p.getApiDescription();
@@ -813,12 +791,7 @@ public class ApiComparator {
 											if (elementDescription != null) {
 												visibility = elementDescription.getVisibility();
 											}
-											IApiTypeRoot typeRoot2 = null;
-											if (isSWT) {
-												typeRoot2 = component2.findTypeRoot(typeName);
-											} else {
-												typeRoot2 = component2.findTypeRoot(typeName, id);
-											}
+											IApiTypeRoot typeRoot2 = component2.findTypeRoot(typeName, id);
 											IApiDescription providerApiDesc = null;
 											if (typeRoot2 == null) {
 												// check if the type is provided
@@ -831,11 +804,7 @@ public class ApiComparator {
 													IApiComponent p = providers[index];
 													if (!p.equals(component2)) {
 														String id2 = p.getSymbolicName();
-														if (Util.ORG_ECLIPSE_SWT.equals(id2)) {
-															typeRoot2 = p.findTypeRoot(typeName);
-														} else {
-															typeRoot2 = p.findTypeRoot(typeName, id2);
-														}
+														typeRoot2 = p.findTypeRoot(typeName, id2);
 														if (typeRoot2 != null) {
 															providerApiDesc = p.getApiDescription();
 														}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
@@ -307,8 +307,6 @@ public final class Util {
 
 	public static final IPath MANIFEST_PROJECT_RELATIVE_PATH = IPath.fromOSString(JarFile.MANIFEST_NAME);
 
-	public static final String ORG_ECLIPSE_SWT = "org.eclipse.swt"; //$NON-NLS-1$
-
 	public static final int LATEST_OPCODES_ASM = Opcodes.ASM9;
 
 	/**


### PR DESCRIPTION
Now that https://github.com/eclipse-platform/eclipse.platform.swt/pull/1008 is submitted, I think we can remove the special treatment of SWT and its fragments, since they should simply be compared against the baseline as they are.
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1084