### PR TITLE
fix ClasspathResolutionTest

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
@@ -75,7 +75,7 @@ public class ClasspathResolutionTest {
 		loadTargetPlatform("org.w3c.dom.events");
 		IProject project = ProjectUtils.importTestProject("tests/projects/demoMissedSystemModulePackage");
 		project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
-		IJavaProject javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+		IJavaProject javaProject = JavaCore.create(project);
 		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
 				PDECore.getDefault().getModelManager().findModel(project), project);
 		for (IClasspathEntry entry : container.getClasspathEntries()) {


### PR DESCRIPTION
.testImportSystemPackageDoesntAddExtraBundleJava11() to use public API instead of type cast.
Failing since I20240130-1800

Java nature and java project are now implemented as separate instances https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1916