### PR TITLE
Make the generation of source feature configurable and skip e4.tools

### DIFF
--- a/e4tools/features/org.eclipse.e4.tools.persistence.feature/build.properties
+++ b/e4tools/features/org.eclipse.e4.tools.persistence.feature/build.properties
@@ -1,2 +1,4 @@
 bin.includes = feature.xml,\
                feature.properties
+
+pom.model.property.skipFeatureSource=true

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-pde/eclipse.pde.git</tycho.scmUrl>
+    <skipFeatureSource>false</skipFeatureSource>
   </properties>
 
   <modules>
@@ -96,6 +97,7 @@
                   <goal>feature-source</goal>
                 </goals>
                 <configuration>
+                  <skip>${skipFeatureSource}</skip>
                   <excludes>
                     <plugin id="org.eclipse.pde" />
                     <plugin id="org.eclipse.pde.doc.user" />


### PR DESCRIPTION
PDE has an option to generate source features but the e4 tools seem not to be published with source features so disable it to not get a warning about additional artifacts compared to baseline.