### PR TITLE
Touch o.e.pde.spy.model

### DIFF
--- a/ui/org.eclipse.pde.spy.model/forceQualifierUpdate.txt
+++ b/ui/org.eclipse.pde.spy.model/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403237 - o.e.e4.tools cannot be build with "mvn clean install"
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-pde/eclipse.pde/pull/1060


### PR DESCRIPTION
After https://github.com/eclipse-pde/eclipse.pde/pull/1060 got merged the build failed due to signing. This is similar issue like eclipse-platform/eclipse.platform.releng.aggregator#1673 so this is a simple check whether a "touch" would be enough.