### PR TITLE
Update the classpath based on a session property

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -67,6 +67,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 
 	public static final QualifiedName EXTERNAL_PROJECT_PROPERTY = new QualifiedName(PLUGIN_ID, "imported"); //$NON-NLS-1$
 	public static final QualifiedName TOUCH_PROJECT = new QualifiedName(PLUGIN_ID, "TOUCH_PROJECT"); //$NON-NLS-1$
+	public static final QualifiedName BND_CLASSPATH_INSTRUCTION_FILE = new QualifiedName(PLUGIN_ID, "BND_CLASSPATH_PROJECT"); //$NON-NLS-1$
 
 	public static final QualifiedName SCHEMA_PREVIEW_FILE = new QualifiedName(PLUGIN_ID, "SCHEMA_PREVIEW_FILE"); //$NON-NLS-1$
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -34,7 +34,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDECoreMessages;
 import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer;
-import org.eclipse.pde.internal.core.natures.BndProject;
 
 public class BndResourceChangeListener implements IResourceChangeListener {
 
@@ -50,9 +49,12 @@ public class BndResourceChangeListener implements IResourceChangeListener {
 					public boolean visit(IResourceDelta delta) throws CoreException {
 						IResource resource = delta.getResource();
 						if (resource instanceof IFile file) {
-							if (BndProject.INSTRUCTIONS_FILE.equals(file.getName())
-									&& BndProject.isBndProject(file.getProject())) {
-								updateProjects.add(file.getProject());
+							IProject project = file.getProject();
+							Object sessionProperty = project.getSessionProperty(PDECore.BND_CLASSPATH_INSTRUCTION_FILE);
+							if (sessionProperty instanceof IFile instr) {
+								if (instr.equals(file)) {
+									updateProjects.add(file.getProject());
+								}
 							}
 						}
 						return true;


### PR DESCRIPTION
Currently we check for a fixed combination of filename and project nature but the RequiredPluginsClasspathContainer can be used in other context as well.

To mitigate this, the classpath container sets a session property when it has used a bnd file to update the classpath that is then checked in the resource listener to decide if the classpath container needs to be updated.