### PR TITLE
Move the repository module to the individual bundles build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <module>build</module>
     <module>features</module>
     <module>org.eclipse.pde.doc.user</module>
-    <module>repository</module>
   </modules>
   
   <build>
@@ -49,6 +48,13 @@
 		       <version>${tycho.version}</version>
 		       <configuration>
 				   <failOnWarning>true</failOnWarning>
+			   </configuration>
+		  </plugin>
+		  <plugin>
+		       <groupId>org.eclipse.tycho</groupId>
+		       <artifactId>tycho-p2-repository-plugin</artifactId>
+		       <configuration>
+				   <includeAllSources>true</includeAllSources>
 			   </configuration>
 		  </plugin>
 	  </plugins>
@@ -74,6 +80,9 @@
           <url>https://repo.eclipse.org/content/repositories/eclipse/</url>
         </repository>
       </repositories>
+      <modules>
+	      <module>repository</module>
+	  </modules>
     </profile>
     <profile>
       <id>generate-feature-source</id>

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.pde" version="0.0.0"/>
-   <feature id="org.eclipse.pde.source" version="0.0.0"/>
-   <feature id="org.eclipse.pde.spies" version="0.0.0"/>
-   <feature id="org.eclipse.pde.spies.source" version="0.0.0"/>
-   <feature id="org.eclipse.pde.unittest.junit" version="0.0.0"/>
-   <feature id="org.eclipse.pde.unittest.junit.source" version="0.0.0"/>
-   <feature id="org.eclipse.e4.core.tools.feature" version="0.0.0"/>
-   <feature id="org.eclipse.e4.core.tools.feature.source" version="0.0.0"/>
-   <feature id="org.eclipse.e4.tools.persistence.feature" version="0.0.0"/>
-   <feature id="org.eclipse.e4.tools.persistence.feature.source" version="0.0.0"/>
-   <!-- Tests -->
+   <feature id="org.eclipse.pde" version="0.0.0">
+      <category name="category.pde.features"/>
+   </feature>
+   <feature id="org.eclipse.pde.spies" version="0.0.0">
+      <category name="category.pde.features"/>
+   </feature>
+   <feature id="org.eclipse.pde.unittest.junit" version="0.0.0">
+      <category name="category.pde.features"/>
+   </feature>
+   <feature id="org.eclipse.e4.core.tools.feature" version="0.0.0">
+      <category name="category.pde.tools"/>
+   </feature>
+   <feature id="org.eclipse.e4.tools.persistence.feature" version="0.0.0">
+      <category name="category.pde.tools"/>
+   </feature>
    <bundle id="org.eclipse.pde.ua.tests"/>
    <bundle id="org.eclipse.pde.ui.tests"/>
    <bundle id="org.eclipse.pde.ui.templates.tests"/>
@@ -19,4 +23,11 @@
    <bundle id="org.eclipse.pde.ds.tests"/>
    <bundle id="org.eclipse.pde.ua.tests"/>
    <bundle id="org.eclipse.pde.junit.runtime.tests"/>
+   <category-def name="category.pde.features" label="PDE Features">
+      <category name="category.pde"/>
+   </category-def>
+   <category-def name="category.pde.tools" label="PDE Additional Tools">
+      <category name="category.pde"/>
+   </category-def>
+   <category-def name="category.pde" label="Eclipse PDE™ (Plug-in Development Environment)"/>
 </site>


### PR DESCRIPTION
The repository is not really useful for the aggregator build therefore it can be moved to the individual bundles, also sources don't need to be specified directly in the category.xml