### PR TITLE
Fire change event when the namespace (prefix) changes

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationCompilationParticipant.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationCompilationParticipant.java
@@ -154,7 +154,10 @@ public class DSAnnotationCompilationParticipant extends CompilationParticipant {
 			result = NEEDS_FULL_BUILD;
 		}
 
-		String specVersionStr = prefs.getString(Activator.PLUGIN_ID, Activator.PREF_SPEC_VERSION, DSAnnotationVersion.V1_3.name(),  new IScopeContext[] { new ProjectScope(project.getProject()), InstanceScope.INSTANCE, DefaultScope.INSTANCE });
+		String specVersionStr = prefs.getString(Activator.PLUGIN_ID, Activator.PREF_SPEC_VERSION,
+				DSAnnotationVersion.DEFAULT_VERSION.name(), new IScopeContext[] {
+						new ProjectScope(project.getProject()),
+						InstanceScope.INSTANCE, DefaultScope.INSTANCE });
 		DSAnnotationVersion specVersion = getEnumValue(specVersionStr, DSAnnotationVersion.class, DSAnnotationVersion.V1_3);
 
 		if (specVersion != state.getSpecVersion()) {

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationPropertyPage.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationPropertyPage.java
@@ -246,7 +246,7 @@ public class DSAnnotationPropertyPage extends PropertyPage implements IWorkbench
 		specVersionCombo.setContentProvider(ArrayContentProvider.getInstance());
 		specVersionCombo.setInput(List.of(DSAnnotationVersion.V1_2, DSAnnotationVersion.V1_3, DSAnnotationVersion.V1_4,
 				DSAnnotationVersion.V1_5));
-		specVersionCombo.setSelection(new StructuredSelection(DSAnnotationVersion.V1_5));
+		specVersionCombo.setSelection(new StructuredSelection(DSAnnotationVersion.DEFAULT_VERSION));
 		specVersionCombo.addSelectionChangedListener(new ISelectionChangedListener() {
 
 			@Override
@@ -311,7 +311,7 @@ public class DSAnnotationPropertyPage extends PropertyPage implements IWorkbench
 
 		boolean enableValue = prefs.getBoolean(Activator.PREF_ENABLED, false);
 		String pathValue = prefs.get(Activator.PREF_PATH, Activator.DEFAULT_PATH);
-		String specVersion = prefs.get(Activator.PREF_SPEC_VERSION, DSAnnotationVersion.V1_4.name());
+		String specVersion = prefs.get(Activator.PREF_SPEC_VERSION, DSAnnotationVersion.DEFAULT_VERSION.name());
 		String errorLevel = prefs.get(Activator.PREF_VALIDATION_ERROR_LEVEL, ValidationErrorLevel.error.name());
 		String missingUnbindMethodLevel = prefs.get(Activator.PREF_MISSING_UNBIND_METHOD_ERROR_LEVEL, errorLevel);
 		boolean generateBAPL = prefs.getBoolean(Activator.PREF_GENERATE_BAPL, true);
@@ -335,7 +335,7 @@ public class DSAnnotationPropertyPage extends PropertyPage implements IWorkbench
 		try {
 			specVersionEnum = DSAnnotationVersion.valueOf(specVersion);
 		} catch (IllegalArgumentException e) {
-			specVersionEnum = DSAnnotationVersion.V1_4;
+			specVersionEnum = DSAnnotationVersion.DEFAULT_VERSION;
 		}
 
 		specVersionCombo.setSelection(new StructuredSelection(specVersionEnum));

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationVersion.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationVersion.java
@@ -30,6 +30,8 @@ public enum DSAnnotationVersion {
 
 	V1_5("1.5", "http://www.osgi.org/xmlns/scr/v1.5.0"); //$NON-NLS-1$
 
+	public static final DSAnnotationVersion DEFAULT_VERSION = DSAnnotationVersion.V1_4;
+
 	private final String namespace;
 	private String version;
 

--- a/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/text/DSComponent.java
+++ b/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/text/DSComponent.java
@@ -14,8 +14,10 @@
  *     EclipseSource Corporation - ongoing enhancements
  *******************************************************************************/
 package org.eclipse.pde.internal.ds.core.text;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.pde.internal.core.text.IDocumentElementNode;
 import org.eclipse.pde.internal.ds.core.IDSComponent;
@@ -27,7 +29,6 @@ import org.eclipse.pde.internal.ds.core.IDSProperties;
 import org.eclipse.pde.internal.ds.core.IDSProperty;
 import org.eclipse.pde.internal.ds.core.IDSReference;
 import org.eclipse.pde.internal.ds.core.IDSService;
-
 
 /**
  * Represents the root "component" entry in a DS xml file. There may be only one
@@ -75,8 +76,7 @@ public class DSComponent extends DSObject implements IDSComponent {
 
 	@Override
 	public boolean canAddChild(int objectType) {
-		return objectType == TYPE_IMPLEMENTATION
-				|| objectType == TYPE_PROPERTIES || objectType == TYPE_PROPERTY
+		return objectType == TYPE_IMPLEMENTATION || objectType == TYPE_PROPERTIES || objectType == TYPE_PROPERTY
 				|| objectType == TYPE_SERVICE || objectType == TYPE_REFERENCE;
 	}
 
@@ -242,14 +242,10 @@ public class DSComponent extends DSObject implements IDSComponent {
 
 	@Override
 	public String[] getAttributesNames() {
-		return new String[] { IDSConstants.ATTRIBUTE_COMPONENT_ENABLED,
-				IDSConstants.ATTRIBUTE_COMPONENT_FACTORY,
-				IDSConstants.ATTRIBUTE_COMPONENT_IMMEDIATE,
-				IDSConstants.ATTRIBUTE_COMPONENT_NAME,
-				IDSConstants.ATTRIBUTE_COMPONENT_CONFIGURATION_POLICY,
-				IDSConstants.ATTRIBUTE_COMPONENT_ACTIVATE,
-				IDSConstants.ATTRIBUTE_COMPONENT_DEACTIVATE,
-				IDSConstants.ATTRIBUTE_COMPONENT_MODIFIED };
+		return new String[] { IDSConstants.ATTRIBUTE_COMPONENT_ENABLED, IDSConstants.ATTRIBUTE_COMPONENT_FACTORY,
+				IDSConstants.ATTRIBUTE_COMPONENT_IMMEDIATE, IDSConstants.ATTRIBUTE_COMPONENT_NAME,
+				IDSConstants.ATTRIBUTE_COMPONENT_CONFIGURATION_POLICY, IDSConstants.ATTRIBUTE_COMPONENT_ACTIVATE,
+				IDSConstants.ATTRIBUTE_COMPONENT_DEACTIVATE, IDSConstants.ATTRIBUTE_COMPONENT_MODIFIED };
 	}
 
 	@Override
@@ -290,6 +286,24 @@ public class DSComponent extends DSObject implements IDSComponent {
 	@Override
 	public void setModifiedeMethod(String name) {
 		setXMLAttribute(ATTRIBUTE_COMPONENT_MODIFIED, name);
+	}
+
+	@Override
+	public void setNamespace(String namespace) {
+		String oldNs = getNamespace();
+		super.setNamespace(namespace);
+		if (!Objects.equals(namespace, oldNs)) {
+			firePropertyChanged("xml_namespace", oldNs, namespace); //$NON-NLS-1$
+		}
+	}
+
+	@Override
+	public void setNamespacePrefix(String prefix) {
+		String oldPrefix = getNamespacePrefix();
+		super.setNamespacePrefix(prefix);
+		if (!Objects.equals(oldPrefix, prefix)) {
+			firePropertyChanged("xml_namespace_prefix", oldPrefix, prefix); //$NON-NLS-1$
+		}
 	}
 
 }


### PR DESCRIPTION
Currently if only the namespace (or prefix) changes this is not considered a change in the DS generator and the changes are discarded.

This checks if there is a change in then fires a change event.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/1112