### PR TITLE
Add message value to API-tools annotations

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoExtend.java
+++ b/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoExtend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add 'value' element to provide a way to supply contextual information to clients
  *******************************************************************************/
 package org.eclipse.pde.api.tools.annotations;
 
@@ -30,5 +31,13 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface NoExtend {
+
+	/**
+	 * A message to provide contextual information to clients about why this
+	 * annotations is applied.
+	 *
+	 * @since 1.3
+	 */
+	String value() default "This class or interface is not intended to be extended by clients.";
 
 }

--- a/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoImplement.java
+++ b/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoImplement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add 'value' element to provide a way to supply contextual information to clients
  *******************************************************************************/
 package org.eclipse.pde.api.tools.annotations;
 
@@ -30,5 +31,13 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface NoImplement {
+
+	/**
+	 * A message to provide contextual information to clients about why this
+	 * annotations is applied.
+	 *
+	 * @since 1.3
+	 */
+	String value() default "This interface is not intended to be implemented by clients.";
 
 }

--- a/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoInstantiate.java
+++ b/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoInstantiate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add 'value' element to provide a way to supply contextual information to clients
  *******************************************************************************/
 package org.eclipse.pde.api.tools.annotations;
 
@@ -30,5 +31,13 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface NoInstantiate {
+
+	/**
+	 * A message to provide contextual information to clients about why this
+	 * annotations is applied.
+	 *
+	 * @since 1.3
+	 */
+	String value() default "This class is not intended to be instantiated by clients.";
 
 }

--- a/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoOverride.java
+++ b/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoOverride.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add 'value' element to provide a way to supply contextual information to clients
  *******************************************************************************/
 package org.eclipse.pde.api.tools.annotations;
 
@@ -30,5 +31,13 @@ import java.lang.annotation.Target;
 @Target(value = { ElementType.METHOD, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.CLASS)
 public @interface NoOverride {
+
+	/**
+	 * A message to provide contextual information to clients about why this
+	 * annotations is applied.
+	 *
+	 * @since 1.3
+	 */
+	String value() default "This method is not intended to be re-implemented or extended by clients.";
 
 }

--- a/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoReference.java
+++ b/apitools/org.eclipse.pde.api.tools.annotations/src/org/eclipse/pde/api/tools/annotations/NoReference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add 'value' element to provide a way to supply contextual information to clients
  *******************************************************************************/
 package org.eclipse.pde.api.tools.annotations;
 
@@ -34,4 +35,13 @@ import java.lang.annotation.Target;
 		ElementType.FIELD })
 @Retention(RetentionPolicy.CLASS)
 public @interface NoReference {
+
+	/**
+	 * A message to provide contextual information to clients about why this
+	 * annotations is applied.
+	 *
+	 * @since 1.3
+	 */
+	String value() default "This element is not intended to be referenced by clients.";
+
 }

--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 Regenerate docs
 Changed year
 Changed javadoc / new API +
+APItools annotation messages


### PR DESCRIPTION
This allows users of the annotations to provide contextual information to clients about why the annotations is applied.
This is common for users of the javadoc-annotations, but at the moment not possible when using the java-annotations.

Later PDE's API-Tools could also provide that information to developers of clients.

Instead of
```
/**
 * The doc.
 * @noextend This class is not intended to be sub-classed by clients.
 */
public abstract class MyClass {
```
one can use 
```
/**
 * The doc.
 */
@NoExtend("This class is not intended to be sub-classed by clients.")
public abstract class MyClass {
```