### PR TITLE
Avoid silent CoreExceptions while project is closed

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -50,7 +50,9 @@ public class BndResourceChangeListener implements IResourceChangeListener {
 						IResource resource = delta.getResource();
 						if (resource instanceof IFile file) {
 							IProject project = file.getProject();
-							Object sessionProperty = project.getSessionProperty(PDECore.BND_CLASSPATH_INSTRUCTION_FILE);
+							Object sessionProperty = project.isOpen()
+									? project.getSessionProperty(PDECore.BND_CLASSPATH_INSTRUCTION_FILE)
+									: null;
 							if (sessionProperty instanceof IFile instr) {
 								if (instr.equals(file)) {
 									updateProjects.add(file.getProject());


### PR DESCRIPTION
which is the case in Tests like BasicAliasTest