### PR TITLE
Remove the org.eclipse.pde.build from the pde feature

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -26,15 +26,11 @@
       <import plugin="org.osgi.service.component.annotations"/>
       <import plugin="org.osgi.service.metatype.annotations"/>
       <import plugin="org.bndtools.templates.template"/>
-      <import plugin="biz.aQute.repository" />
+      <import plugin="biz.aQute.repository"/>
    </requires>
 
    <plugin
          id="org.eclipse.pde"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.pde.build"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
Currently the `org.eclipse.pde.build` is directly included in the PDE feature but pde-build is already a requirement and will be included automatically. Beside that it prevents to update `org.eclipse.pde.build` independent from PDE.

With this PR
- https://github.com/eclipse-pde/eclipse.pde/pull/1137

I noticed that the test still run against the i-build version and not the local compiled version. The reason is that the pde feature (that is installed as part of the test runtime) has a strict requirement to the `org.eclipse.pde.build`and therefore can't be updated.

As `org.eclipse.pde.build` is a requirement for pde.core it will be included anyways, also we currently don't really [maintain pde build anymore](https://github.com/eclipse-pde/eclipse.pde/tree/master/build) therefore it seems reasonable to handle it like any other dependency an not explicitly list it in the feature.