### PR TITLE
Use a dedicated test project that allows updating pde feature

### DIFF
--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -35,6 +35,22 @@
 				<plugins>
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<configuration>
+							<dependency-resolution>
+								<extraRequirements>
+									<requirement>
+										<!-- require the pde feature so we get this always from the reactor -->
+										<type>eclipse-feature</type>
+										<id>org.eclipse.pde</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+								</extraRequirements>
+							</dependency-resolution>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-maven-plugin</artifactId>
 					</plugin>
 					<plugin>
@@ -98,6 +114,20 @@
 					</plugin>
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-publisher-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<executions>
+							<execution>
+								<id>publish-products</id>
+								<goals>
+									<goal>publish-products</goal>
+								</goals>
+								<phase>pre-integration-test</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-surefire-plugin</artifactId>
 						<configuration>
 							<product>org.eclipse.sdk.ide</product>
@@ -111,15 +141,7 @@
 							</repositories>
 							<install>
 								<iu>
-									<id>org.eclipse.sdk.ide</id>
-								</iu>
-								<iu>
-									<id>org.eclipse.test</id>
-									<feature>true</feature>
-								</iu>
-								<iu>
-									<id>org.eclipse.tips.feature</id>
-									<feature>true</feature>
+									<id>org.eclipse.sdk.test.ide</id>
 								</iu>
 							</install>
 						</configuration>

--- a/build/org.eclipse.pde.build.tests/test-sdk.product
+++ b/build/org.eclipse.pde.build.tests/test-sdk.product
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Eclipse SDK" uid="org.eclipse.sdk.test.ide" id="org.eclipse.sdk.ide" application="org.eclipse.ui.ide.workbench" version="4.31.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
+      </programArgs>
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <launcher name="eclipse">
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+
+   <features>
+      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.platform.source"/>
+      <feature id="org.eclipse.jdt"/>
+      <feature id="org.eclipse.jdt.source"/>
+      <!-- PDE must be installed as a root so it can be updated -->
+      <feature id="org.eclipse.pde" installMode="root"/>
+      <feature id="org.eclipse.pde.source"/>
+      <feature id="org.eclipse.pde.spies"/>
+      <feature id="org.eclipse.pde.spies.source"/>
+      <feature id="org.eclipse.help"/>
+      <feature id="org.eclipse.help.source"/>
+      <feature id="org.eclipse.jdt.astview.feature"/>
+      <feature id="org.eclipse.jdt.jeview.feature"/>
+      <feature id="org.eclipse.jdt.bcoview.feature"/>
+      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.equinox.p2.user.ui.source"/>
+      <feature id="org.eclipse.e4.core.tools.feature"/>
+      <feature id="org.eclipse.e4.core.tools.feature.source"/>
+      <feature id="org.eclipse.tips.feature"/>
+      <feature id="org.eclipse.tips.feature.source"/>
+      <feature id="org.eclipse.test"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
+      <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
+      <property name="org.eclipse.update.reconcile" value="false" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
+   </configurations>
+
+</product>


### PR DESCRIPTION
Currently we use the sdk product to create the test runtime, this has the drawback that we can not use the current build pde code but always using the latest from the ibuilds,

This uses an own copy of the sdk product to setup the necessary
test runtime so we can customize this as required.