### PR TITLE
Disable ScriptGenerationTests#testBug238177

### DIFF
--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
@@ -827,6 +827,7 @@ public class ScriptGenerationTests extends PDETestCase {
 	}
 
 	@Test
+	@Ignore("this test fails on some linux versions for unkown reasons")
 	public void testBug238177() throws Exception {
 		IFolder buildFolder = newTest("238177");
 		IFolder a = Utils.createFolder(buildFolder, "plugins/A");


### PR DESCRIPTION
The test fails on some linux systems for unknown reasons.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/1119