### PR TITLE
Move the AddBundleCompletionProposal and BuildpathQuickFixProcessor

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
@@ -4,8 +4,9 @@ Bundle-Name: Generic UI components related to BND
 Bundle-SymbolicName: org.eclipse.pde.bnd.ui;singleton:=true
 Bundle-Vendor: Eclipse.org
 Bundle-Version: 1.0.0.qualifier
-Export-Package: org.eclipse.pde.bnd.ui;version="1.0.0";x-friends:="org.eclipse.pde.ui",
+Export-Package: org.eclipse.pde.bnd.ui.autocomplete;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.preferences;version="1.0.0";x-friends:="org.eclipse.pde.ui",
+ org.eclipse.pde.bnd.ui.quickfix;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.templating;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.wizards;version="1.0.0";x-friends:="org.eclipse.pde.ui"
 Import-Package: aQute.bnd.build;version="4.5.0",
@@ -40,7 +41,7 @@ Require-Bundle: org.eclipse.jdt.ui,
 Automatic-Module-Name: org.eclipse.pde.bnd.ui
 Bundle-Activator: org.eclipse.pde.bnd.ui.Resources
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/org.bndtools.templating.repos.xml,
  OSGI-INF/org.eclipse.pde.bnd.ui.internal.Auxiliary.xml,
  OSGI-INF/org.eclipse.pde.bnd.ui.internal.TemplateAdapter.xml
-Bundle-ActivationPolicy: lazy

--- a/ui/org.eclipse.pde.bnd.ui/plugin.xml
+++ b/ui/org.eclipse.pde.bnd.ui/plugin.xml
@@ -5,7 +5,7 @@
 		<quickFixProcessor
 			id="org.eclipse.pde.bnd.ui.buildpathquickfix"
 			name="Buildpath Quick Fix"
-			class="org.eclipse.pde.bnd.ui.BuildpathQuickFixProcessor">
+			class="org.eclipse.pde.bnd.ui.quickfix.BuildpathQuickFixProcessor">
 			<handledMarkerTypes>
 				<markerType id="org.eclipse.jdt.core.problem" />
 			</handledMarkerTypes>

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/autocomplete/AddBundleCompletionProposal.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/autocomplete/AddBundleCompletionProposal.java
@@ -14,7 +14,7 @@
  *     BJ Hargrave <bj@hargrave.dev> - ongoing enhancements
  *     Christoph Läubrich - adapt to PDE codebase
  *******************************************************************************/
-package org.eclipse.pde.bnd.ui;
+package org.eclipse.pde.bnd.ui.autocomplete;
 
 import java.io.File;
 import java.util.Map;
@@ -35,6 +35,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.pde.bnd.ui.Resources;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/quickfix/BuildpathQuickFixProcessor.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/quickfix/BuildpathQuickFixProcessor.java
@@ -14,7 +14,7 @@
  *     BJ Hargrave <bj@hargrave.dev> - ongoing enhancements
  *     Christoph Läubrich - adapt to PDE codebase
  *******************************************************************************/
-package org.eclipse.pde.bnd.ui;
+package org.eclipse.pde.bnd.ui.quickfix;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -68,6 +68,8 @@ import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.IQuickFixProcessor;
+import org.eclipse.pde.bnd.ui.autocomplete.AddBundleCompletionProposal;
+
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectBuilder;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/QuickFixProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/QuickFixProcessor.java
@@ -51,7 +51,7 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.BundleSpecification;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.ImportPackageSpecification;
-import org.eclipse.pde.bnd.ui.AddBundleCompletionProposal;
+import org.eclipse.pde.bnd.ui.autocomplete.AddBundleCompletionProposal;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;


### PR DESCRIPTION
Now we have more and more features in this bundle it seems good to structure its packages more as we have already done for the other imported parts.

This moves the bundle completion proposal and buildpath quickfix to their own packages and removes the export of org.eclipse.pde.bnd.ui what should only be used internally.