### PR TITLE
Rework PluginRegistry API and introduce VersionMatchRule enum

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the issue here
 Fix deprecation tag 'since' value
 Modernize pde.project description interfaces: https://github.com/eclipse-pde/eclipse.pde/pull/1341
+Rework PluginRegistry API and introduce VersionMatchRule enum : https://github.com/eclipse-pde/eclipse.pde/pull/1163

--- a/ui/org.eclipse.pde.core/.settings/.api_filters
+++ b/ui/org.eclipse.pde.core/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.pde.core" version="2">
+    <resource path="src/org/eclipse/pde/core/plugin/PluginRegistry.java" type="org.eclipse.pde.core.plugin.PluginRegistry">
+        <filter id="354463860">
+            <message_arguments>
+                <message_argument value="org.eclipse.pde.core.plugin.PluginRegistry"/>
+                <message_argument value="PluginRegistry()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/pde/internal/core/project/BundleProjectService.java" type="org.eclipse.pde.internal.core.project.BundleProjectService">
         <filter comment="Platform Team allows use of bundle importers for PDE import from source repository" id="640712815">
             <message_arguments>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/IMatchRules.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/IMatchRules.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,10 +14,13 @@
 package org.eclipse.pde.core.plugin;
 
 /**
- * This interface contains constants used throughout the plug-in
- * for plug-in reference matching. These rules are used to
- * control when determining if two compared versions are
- * equivalent.
+ * This interface contains constants used throughout the plug-in for plug-in
+ * reference matching. These rules are used to control when determining if two
+ * compared versions are equivalent.
+ *
+ * <p>
+ * New code should use {@link VersionMatchRule} instead.
+ * </p>
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/PluginRegistry.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/PluginRegistry.java
@@ -365,7 +365,7 @@ public class PluginRegistry {
 				max = model;
 				maxV = version;
 			} else {
-				if (VersionUtil.isGreaterOrEqualTo(version, maxV)) {
+				if (VersionMatchRule.GREATER_OR_EQUAL.matches(version, maxV)) {
 					max = model;
 					maxV = version;
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/VersionMatchRule.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/VersionMatchRule.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Hannes Wellmann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.core.plugin;
+
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+
+/**
+ * Defines the rules that are used to control when two compared versions match.
+ *
+ * @since 3.19
+ */
+public enum VersionMatchRule {
+	/**
+	 * A rule that matches if a version is perfectly
+	 * {@link Version#equals(Object) equal} to a reference.
+	 */
+	PERFECT("perfect") { //$NON-NLS-1$
+		@Override
+		public VersionRange rangeFor(Version reference) {
+			return new VersionRange(VersionRange.LEFT_CLOSED, reference, reference, VersionRange.RIGHT_CLOSED);
+		}
+
+		@Override
+		public boolean matches(Version version, Version reference) {
+			return reference.equals(version);
+		}
+	},
+	/**
+	 * A rule that matches if a version is <em>equivalent</em> to a reference,
+	 * which is the case if that version has the same {@link Version#getMajor()
+	 * major} and {@link Version#getMinor() minor} component and apart from that
+	 * is greater than or equal to the reference.
+	 */
+	EQUIVALENT("equivalent") { //$NON-NLS-1$
+		@Override
+		public VersionRange rangeFor(Version reference) {
+			Version upperBound = new Version(reference.getMajor(), reference.getMinor() + 1, 0);
+			return new VersionRange(VersionRange.LEFT_CLOSED, reference, upperBound, VersionRange.RIGHT_OPEN);
+		}
+
+		@Override
+		public boolean matches(Version version, Version reference) {
+			return version.getMajor() == reference.getMajor() && version.getMinor() == reference.getMinor()
+					&& version.compareTo(reference) >= 0;
+		}
+	},
+	/**
+	 * A rule that matches if a version is <em>compatible</em> to a reference,
+	 * which is the case if that version has the same {@link Version#getMajor()
+	 * major} component and apart from that is greater than or equal to the
+	 * reference.
+	 */
+	COMPATIBLE("compatible") { //$NON-NLS-1$
+		@Override
+		public VersionRange rangeFor(Version reference) {
+			Version upperBound = new Version(reference.getMajor() + 1, 0, 0);
+			return new VersionRange(VersionRange.LEFT_CLOSED, reference, upperBound, VersionRange.RIGHT_OPEN);
+		}
+
+		@Override
+		public boolean matches(Version version, Version reference) {
+			return version.getMajor() == reference.getMajor() && version.compareTo(reference) >= 0;
+		}
+	},
+	/**
+	 * A rule that matches if a version is greater than or equal to a reference.
+	 */
+	GREATER_OR_EQUAL("greaterOrEqual") { //$NON-NLS-1$
+		@Override
+		public VersionRange rangeFor(Version reference) {
+			return new VersionRange(VersionRange.LEFT_CLOSED, reference, null, VersionRange.RIGHT_OPEN);
+		}
+
+		@Override
+		public boolean matches(Version version, Version reference) {
+			return version.compareTo(reference) >= 0;
+		}
+	};
+
+	private final String name;
+
+	VersionMatchRule(String name) {
+		this.name = name;
+	}
+
+	public abstract VersionRange rangeFor(Version version);
+
+	public abstract boolean matches(Version version, Version reference);
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeatureImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeatureImport.java
@@ -37,7 +37,7 @@ public class FeatureImport extends VersionableObject implements IFeatureImport {
 
 	public IPlugin getPlugin() {
 		if (id != null && fType == PLUGIN) {
-			IPluginModelBase model = PluginRegistry.findModel(id, version, fMatch, null);
+			IPluginModelBase model = PluginRegistry.findModel(id, version, VersionUtil.matchRuleFromLiteral(fMatch));
 			return model instanceof IPluginModel ? ((IPluginModel) model).getPlugin() : null;
 		}
 		return null;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/ImportObject.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/ImportObject.java
@@ -89,7 +89,7 @@ public class ImportObject extends PluginReference implements IWritable, Serializ
 	protected IPluginModelBase findModel() {
 		String version = iimport.getVersion();
 		VersionRange range = new VersionRange(version);
-		return PluginRegistry.findModel(getId(), range, null);
+		return PluginRegistry.findModel(getId(), range);
 	}
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/search/PluginJavaSearchUtil.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/search/PluginJavaSearchUtil.java
@@ -44,7 +44,7 @@ public class PluginJavaSearchUtil {
 	public static IPluginModelBase[] getPluginImports(IPluginImport dep) {
 		HashSet<IPluginModelBase> set = new HashSet<>();
 		VersionRange range = new VersionRange(dep.getVersion());
-		collectAllPrerequisites(PluginRegistry.findModel(dep.getId(), range, null), set);
+		collectAllPrerequisites(PluginRegistry.findModel(dep.getId(), range), set);
 		return set.toArray(new IPluginModelBase[set.size()]);
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
@@ -10,13 +10,16 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
- *     Hannes Wellmann - Introduce VersionMatchRule enum
+ *     Hannes Wellmann - Rework PluginRegistry API, replace Equinox resolver's VersionRange and introduce VersionMatchRule enum
  *******************************************************************************/
 package org.eclipse.pde.internal.core.util;
+
+import java.util.Comparator;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.pde.core.plugin.IMatchRules;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
@@ -44,6 +47,18 @@ public class VersionUtil {
 			return Status.error(UtilMessages.BundleErrorReporter_invalidVersionRangeFormat, e);
 		}
 		return Status.OK_STATUS;
+	}
+
+	public static final Comparator<IPluginModelBase> BY_DESCENDING_PLUGIN_VERSION = Comparator
+			.comparing(VersionUtil::getVersion).reversed();
+
+	public static Version getVersion(IPluginModelBase model) {
+		String version = model.getPluginBase().getVersion();
+		try {
+			return Version.parseVersion(version);
+		} catch (IllegalArgumentException e) {
+		}
+		return Version.emptyVersion;
 	}
 
 	public static VersionMatchRule matchRuleFromLiteral(int literal) {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/PluginRegistryTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/PluginRegistryTests.java
@@ -85,7 +85,7 @@ public class PluginRegistryTests {
 
 	@Test
 	public void testRangeNone() {
-		IPluginModelBase model = PluginRegistry.findModel("org.eclipse.jdt.debug", null, null);
+		IPluginModelBase model = PluginRegistry.findModel("org.eclipse.jdt.debug", null, (PluginFilter) null);
 		assertNotNull(model);
 		assertEquals("org.eclipse.jdt.debug", model.getPluginBase().getId());
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDELabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDELabelProvider.java
@@ -31,7 +31,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.build.IBuildEntry;
 import org.eclipse.pde.core.plugin.IFragment;
 import org.eclipse.pde.core.plugin.IFragmentModel;
-import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPlugin;
 import org.eclipse.pde.core.plugin.IPluginAttribute;
 import org.eclipse.pde.core.plugin.IPluginBase;
@@ -44,6 +43,7 @@ import org.eclipse.pde.core.plugin.IPluginModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginObject;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
@@ -385,7 +385,8 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	public String getObjectText(ISiteBundle obj) {
-		IPluginModelBase modelBase = PluginRegistry.findModel(obj.getId(), obj.getVersion(), IMatchRules.COMPATIBLE, null);
+		IPluginModelBase modelBase = PluginRegistry.findModel(obj.getId(), obj.getVersion(),
+				VersionMatchRule.COMPATIBLE);
 		if (modelBase != null)
 			return getObjectText(modelBase.getPluginBase());
 		return preventNull(obj.getId());

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryLabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryLabelProvider.java
@@ -17,8 +17,8 @@
 package org.eclipse.pde.internal.ui.editor.category;
 
 import org.eclipse.jface.viewers.LabelProvider;
-import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.isite.ISiteBundle;
 import org.eclipse.pde.internal.core.isite.ISiteCategoryDefinition;
@@ -65,7 +65,7 @@ class CategoryLabelProvider extends LabelProvider {
 		}
 		if (element instanceof SiteBundleAdapter) {
 			ISiteBundle bundle = ((SiteBundleAdapter) element).bundle;
-			if (PluginRegistry.findModel(bundle.getId(), bundle.getVersion(), IMatchRules.COMPATIBLE, null) == null) {
+			if (PluginRegistry.findModel(bundle.getId(), bundle.getVersion(), VersionMatchRule.COMPATIBLE) == null) {
 				return this.fMissingSiteBundleImage;
 			}
 			return this.fSiteBundleImage;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyAnalysisSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyAnalysisSection.java
@@ -16,11 +16,11 @@ package org.eclipse.pde.internal.ui.editor.plugin;
 
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.pde.core.IBaseModel;
-import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.eclipse.pde.internal.core.builders.DependencyLoop;
 import org.eclipse.pde.internal.core.builders.DependencyLoopFinder;
 import org.eclipse.pde.internal.ui.PDELabelProvider;
@@ -102,7 +102,7 @@ public class DependencyAnalysisSection extends PDESection {
 		// The pluginModel set for this page does not have a BundleDescriptor
 		// set, therefore search the pluginModel from the registry that has it
 		IPluginBase pluginBase = pluginModel.getPluginBase();
-		return PluginRegistry.findModel(pluginBase.getId(), pluginBase.getVersion(), IMatchRules.PERFECT, null);
+		return PluginRegistry.findModel(pluginBase.getId(), pluginBase.getVersion(), VersionMatchRule.PERFECT);
 	}
 
 	private void doFindLoops(IPluginModelBase pluginModelBase) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PluginSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PluginSection.java
@@ -42,9 +42,9 @@ import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.DependencyManager.Options;
 import org.eclipse.pde.internal.core.ICoreConstants;
@@ -217,7 +217,7 @@ public class PluginSection extends AbstractProductContentSection<PluginSection> 
 		}
 		List<BundleDescription> list = Stream.of(plugins).map(plugin -> {
 			String version = VersionUtil.isEmptyVersion(plugin.getVersion()) ? null : plugin.getVersion();
-			return PluginRegistry.findModel(plugin.getId(), version, IMatchRules.PERFECT, null);
+			return PluginRegistry.findModel(plugin.getId(), version, VersionMatchRule.PERFECT);
 		}).filter(Objects::nonNull).map(IPluginModelBase::getBundleDescription).toList();
 
 		DependencyManager.Options[] options = includeOptional

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
@@ -52,9 +52,9 @@ import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.FeatureModelManager;
 import org.eclipse.pde.internal.core.PDECore;
@@ -382,7 +382,7 @@ public class LaunchAction extends Action {
 			if (id == null || version == null) {
 				continue;
 			}
-			IPluginModelBase model = PluginRegistry.findModel(id, version, IMatchRules.EQUIVALENT, null);
+			IPluginModelBase model = PluginRegistry.findModel(id, version, VersionMatchRule.EQUIVALENT);
 			if (model == null) {
 				model = PluginRegistry.findModel(id);
 			}


### PR DESCRIPTION
Modernize the PluginRegistry API that contains the antiquated `org.eclipse.osgi.service.resolver.VersionRange` by providing alternatives using the `org.osgi.framework.VersionRange` and deprecating the existing methods for removal.

In conjunction with that also mark `PluginRegistry.PluginFilter` as deprecated for removal since it is effectively a `Predicate<IPluginModelBase>` and just use the latter in the new methods.

This is currently an early draft to discuss the overall direction. Since the intention is to focus on the API callers of the now deprecated methods are not replaced in this PR. I'll do that in a follow-up.

About the API I'm also contemplating to further modernize the methods in `PluginRegistry` that now return a List to return a Stream instead. Then we could also save the filter arguments since callers can just filter the returned stream if desired.

Furthermore I would also like to replace the integer and string constants in `IMatchRules` by a corresponding Enum `VersionMatchRules` (or similar) that also provides method to obtain a predicate for a reference version that implements the literals matching rule or to obtain a corresponding `VersionRange` from a reference version (which ever is needed).


Part of https://github.com/eclipse-pde/eclipse.pde/issues/1069