### PR TITLE
Replace APIs using equinox-resolve's BundleDescription

### DIFF
--- a/ui/org.eclipse.pde.core/.settings/.api_filters
+++ b/ui/org.eclipse.pde.core/.settings/.api_filters
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.pde.core" version="2">
+    <resource path="src/org/eclipse/pde/core/IClasspathContributor.java" type="org.eclipse.pde.core.IClasspathContributor">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.pde.core.IClasspathContributor"/>
+                <message_argument value="getEntriesForDependency(IProject, Resource)"/>
+            </message_arguments>
+        </filter>
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.pde.core.IClasspathContributor"/>
+                <message_argument value="getInitialEntries(IProject)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/pde/internal/core/project/BundleProjectService.java" type="org.eclipse.pde.internal.core.project.BundleProjectService">
         <filter comment="Platform Team allows use of bundle importers for PDE import from source repository" id="640712815">
             <message_arguments>

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.19.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IClasspathContributor.java
@@ -17,6 +17,7 @@ package org.eclipse.pde.core;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.plugin.PluginRegistry;
@@ -40,6 +41,8 @@ import org.osgi.resource.Resource;
  * @since 3.9
  */
 public interface IClasspathContributor {
+	// TODO: The cleaner way would be to create a completely new interface and
+	// deprecate this one. But how to name it?
 
 	/**
 	 * Get any additional classpath entries to add to a project when its
@@ -53,8 +56,21 @@ public interface IClasspathContributor {
 	 *            classpath computed
 	 * @return additional classpath entries to add to the project, possibly
 	 *         empty, must not be <code>null</code>
+	 * @since 3.19
 	 */
-	List<IClasspathEntry> getInitialEntries(BundleDescription project);
+	default List<IClasspathEntry> getInitialEntries(IProject project) {
+		BundleDescription description = PluginRegistry.findModel(project).getBundleDescription();
+		return getInitialEntries(description);
+	}
+
+	/**
+	 * @deprecated Instead implement {@link #getInitialEntries(IProject)}
+	 */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default List<IClasspathEntry> getInitialEntries(BundleDescription project) {
+		throw new UnsupportedOperationException(
+				"This method is deprecated. Implement and call getInitialEntries(IProject) instead");
+	}
 
 	/**
 	 * Get any additional classpath entries to add to a project when a new bundle
@@ -66,6 +82,22 @@ public interface IClasspathContributor {
 	 * @param project the bundle descriptor for the plug-in project having its classpath computed
 	 * @param addedDependency the bundle descriptor for the bundle being added to the classpath as a dependency
 	 * @return additional classpath entries to add to the project, possibly empty, must not be <code>null</code>
+	 * @since 3.19
 	 */
-	List<IClasspathEntry> getEntriesForDependency(BundleDescription project, BundleDescription addedDependency);
+	default List<IClasspathEntry> getEntriesForDependency(IProject project, Resource addedDependency) {
+		BundleDescription description = PluginRegistry.findModel(project).getBundleDescription();
+		return getEntriesForDependency(description, (BundleDescription) addedDependency);
+	}
+
+	/**
+	 * @deprecated Instead implement
+	 *             {@link #getEntriesForDependency(IProject, Resource)}
+	 */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default List<IClasspathEntry> getEntriesForDependency(BundleDescription project,
+			BundleDescription addedDependency) {
+		throw new UnsupportedOperationException(
+				"This method is deprecated. Implement and call getEntriesForDependency(IProject, Resource) instead");
+	}
+
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/IPluginModelBase.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/IPluginModelBase.java
@@ -16,9 +16,9 @@ package org.eclipse.pde.core.plugin;
 import java.net.URL;
 
 import org.eclipse.core.runtime.URIUtil;
-import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.IModelChangeProvider;
 import org.eclipse.pde.core.build.IBuildModel;
+import org.osgi.resource.Resource;
 
 /**
  * This type of model is created by parsing the manifest file.
@@ -63,7 +63,7 @@ public interface IPluginModelBase extends ISharedExtensionsModel, IModelChangePr
 	 * @deprecated This method has always returned <code>null</code>.
 	 *   Since 3.7, use {@link PluginRegistry#createBuildModel(IPluginModelBase)} instead.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "4.19")
 	IBuildModel getBuildModel();
 
 	/**
@@ -128,20 +128,35 @@ public interface IPluginModelBase extends ISharedExtensionsModel, IModelChangePr
 	 * an encoding tool such as {@link URIUtil}. Deprecated in
 	 * 4.3.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "4.19")
 	URL getNLLookupLocation();
 
 	/**
-	 * Returns the bundle description of the plug-in
-	 * in case the plug-in uses the new OSGi bundle layout.
+	 * Returns the bundle {@link Resource} of the plug-in in case the plug-in
+	 * uses the OSGi bundle layout.
 	 *
-	 * @return bundle description if this is an OSGi plug-in,
-	 * or <code>null</code> if the plug-in is in a classic
-	 * format.
+	 * @return resource if this is an OSGi plug-in, or <code>null</code> if the
+	 *         plug-in is in a legacy format.
+	 * @since 3.19
+	 */
+	Resource getBundleResource();
+	// TODO: is the legacy format still supported? If yes, remove support for
+	// that as well?
+
+	/**
+	 * Returns the bundle description of the plug-in in case the plug-in uses
+	 * the new OSGi bundle layout.
+	 *
+	 * @return bundle description if this is an OSGi plug-in, or
+	 *         <code>null</code> if the plug-in is in a classic format.
 	 *
 	 * @since 3.0
+	 * @deprecated Instead use {@link #getBundleResource() }
 	 */
-	BundleDescription getBundleDescription();
+	@Deprecated(forRemoval = true, since = "4.19")
+	default org.eclipse.osgi.service.resolver.BundleDescription getBundleDescription() {
+		return (org.eclipse.osgi.service.resolver.BundleDescription) getBundleResource();
+	}
 
 	/**
 	 * Associates the bundle description of the plug-in
@@ -152,6 +167,11 @@ public interface IPluginModelBase extends ISharedExtensionsModel, IModelChangePr
 	 * with this model
 	 *
 	 * @since 3.0
+	 * @deprecated Users should never modify the OSGi bundle representation of a
+	 *             plugin-model, this is only done by PDE itself.
 	 */
-	void setBundleDescription(BundleDescription description);
+	@Deprecated(forRemoval = true, since = "4.19")
+	void setBundleDescription(org.eclipse.osgi.service.resolver.BundleDescription description);
+	// FIXME: I don't think users should be able to set a resource/desription.
+	// But check possible use-cases again.
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundlePluginModelBase.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundlePluginModelBase.java
@@ -333,7 +333,7 @@ public abstract class BundlePluginModelBase extends AbstractNLModel implements I
 	}
 
 	@Override
-	public BundleDescription getBundleDescription() {
+	public BundleDescription getBundleResource() {
 		return fBundleDescription;
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/AbstractPluginModelBase.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/AbstractPluginModelBase.java
@@ -236,7 +236,7 @@ public abstract class AbstractPluginModelBase extends AbstractNLModel implements
 	}
 
 	@Override
-	public BundleDescription getBundleDescription() {
+	public BundleDescription getBundleResource() {
 		return fBundleDescription;
 	}
 

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/FragmentModel.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/FragmentModel.java
@@ -35,7 +35,7 @@ public class FragmentModel extends PluginModelBase implements IFragmentModel {
 	}
 
 	@Override
-	public BundleDescription getBundleDescription() {
+	public BundleDescription getBundleResource() {
 		return null;
 	}
 

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginModel.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginModel.java
@@ -35,7 +35,7 @@ public class PluginModel extends PluginModelBase implements IPluginModel {
 	}
 
 	@Override
-	public BundleDescription getBundleDescription() {
+	public BundleDescription getBundleResource() {
 		return null;
 	}
 


### PR DESCRIPTION
Modernize the PDE APIs that contains the antiquated `org.eclipse.osgi.service.resolver.BundleDescription` by providing alternatives using the `org.osgi.resource.Resource` and deprecating the existing methods for removal.


Part of https://github.com/eclipse-pde/eclipse.pde/issues/1069

This is currently an early draft to discuss the overall direction. Since the intention is to focus on the API callers of the now deprecated methods are not replaced in this PR. Replacing all the usages of `BundleDescription` will be a much greater effort that will happen subsequently during the deprecation period.

Maybe it is not even possible to complete #1069 (with reasonable effort) while the old methods are still available. So I think it is better to start the deprecation earlier than later.
In combination with #1163 all PDE APIs using a type from `org.eclipse.osgi.service.resolver` should be deprecated.


