### PR TITLE
Do not create "build.properties does not exist" marker on non-PDE #1185

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.18.100.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestConsistencyChecker.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestConsistencyChecker.java
@@ -31,6 +31,7 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
@@ -41,6 +42,7 @@ import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDECoreMessages;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
+import org.eclipse.pde.internal.core.natures.PDE;
 import org.eclipse.pde.internal.core.project.PDEProject;
 import org.osgi.framework.Bundle;
 
@@ -372,6 +374,14 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 			}
 			// if build.properties doesn't exist and build problems != IGNORE, create a marker on the project bug 172451
 			try {
+				if (!project.hasNature(PDE.PLUGIN_NATURE)) {
+					// how did this happen?
+					ILog.get().error(
+							"eclipse.pde/issues/1185: validateBuildPropertiesExists called for project without plugin nature: " //$NON-NLS-1$
+									+ project.getName(), 
+							new IllegalStateException());
+					return;
+				}
 				Map<String, Object> attributes = new HashMap<>();
 				attributes.put(IMarker.SEVERITY, CompilerFlags.ERROR == severity ? IMarker.SEVERITY_ERROR : IMarker.SEVERITY_WARNING);
 				attributes.put(IMarker.MESSAGE, PDECoreMessages.ManifestConsistencyChecker_buildDoesNotExist);
@@ -379,6 +389,7 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 
 				project.createMarker(PDEMarkerFactory.MARKER_ID, attributes);
 			} catch (CoreException e) {
+				ILog.get().error("Unable to create marker", e); //$NON-NLS-1$
 			}
 		}
 	}


### PR DESCRIPTION
but log a IllegalStateException() to find out how that happens.

https://github.com/eclipse-pde/eclipse.pde/issues/1185