### PR TITLE
Use soft references to cache image data in Plug-in Image Browser

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/WorkspaceRepository.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/WorkspaceRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012, 2015 Christian Pontesegger and others.
+ *  Copyright (c) 2012, 2024 Christian Pontesegger and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -78,12 +78,8 @@ public class WorkspaceRepository extends AbstractRepository {
 							case IResource.FILE :
 								// look for image files
 								if (isImageName(proxy.getName())) {
-									try {
-										IFile resource = (IFile) proxy.requestResource();
-										addImageElement(new ImageElement(createImageData(resource), pluginName, resource.getProjectRelativePath().toPortableString()));
-									} catch (Exception e) {
-										// could not create image for location
-									}
+									IFile resource = (IFile) proxy.requestResource();
+									addImageElement(new ImageElement(() -> createImageData(resource), pluginName, resource.getProjectRelativePath().toPortableString()));
 
 									if (monitor.isCanceled())
 										throw new OperationCanceledException();


### PR DESCRIPTION
The WorkspaceRepository class used by this view initializes the image data for all images that are found in the workspace. This approach doesn't scale very well and may cause OutOfMemory errors on large projects.

By using those soft references in combination with a lazy initialization, we can reduce the overall footprint on low-memory systems, without losing most of the benefits gained by caching.

~~Note that this approach doesn't work for images retrieved from jar files, as the image data can't be reloaded once the archive has been closed again which is why hard references are mandatory here.~~

One noteworthy difference to the old implementation that invalid/broken images are no longer skipped. Instead, the default image data of the ImageDescriptor (also used by e.g. the MissingImageDescriptor) is returned.

This change also resolves a suppressed ClassCastException in the searchDirectory() method of the AbstractRepository class, when trying to cast a java.io.File to an org.eclipse.core.resources.IFile.

Resolves #1179