### PR TITLE
Workaround for missing 4.31 SWT API descriptions

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/build.properties
+++ b/apitools/org.eclipse.pde.api.tools/build.properties
@@ -22,7 +22,8 @@ bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                lib/apitooling-ant.jar,\
-               scripts/
+               scripts/,\
+               fixed_api_descriptions/
 jars.extra.classpath=platform:/plugin/org.apache.ant/lib/ant.jar,platform:/plugin/org.objectweb.asm
 jars.compile.order = .,\
                      lib/apitooling-ant.jar

--- a/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.cocoa.macosx.aarch64_3.125.0.v20240227-1638.api_description
+++ b/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.cocoa.macosx.aarch64_3.125.0.v20240227-1638.api_description
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.swt.cocoa.macosx.aarch64_3.125.0.v20240206-1259" version="1.2">
+    <plugin id="org.eclipse.swt.cocoa.macosx.aarch64_3.125.0.v20240206-1259"/>
+    <package name="org.eclipse.swt.accessibility" visibility="1">
+        <type name="Accessible" restrictions="0">
+            <method name="internal_accessibilityActionDescription" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityActionNames" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/NSArray;"/>
+            <method name="internal_accessibilityAttributeNames" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/NSArray;"/>
+            <method name="internal_accessibilityAttributeValue" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityAttributeValue_forParameter" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;Lorg/eclipse/swt/internal/cocoa/id;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityFocusedUIElement" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityHitTest" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSPoint;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityIsAttributeSettable" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Z"/>
+            <method name="internal_accessibilityIsIgnored" restrictions="8" signature="(I)Z"/>
+            <method name="internal_accessibilityParameterizedAttributeNames" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/NSArray;"/>
+            <method name="internal_accessibilityPerformAction" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Z"/>
+            <method name="internal_accessibilitySetValue_forAttribute" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/id;Lorg/eclipse/swt/internal/cocoa/NSString;I)V"/>
+            <method name="internal_addRelationAttributes" restrictions="8" signature="(J)J"/>
+            <method name="internal_dispose_Accessible" restrictions="8" signature="()V"/>
+            <method name="internal_new_Accessible" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Control;)Lorg/eclipse/swt/accessibility/Accessible;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.browser" visibility="1">
+        <type name="Browser" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.custom" visibility="1">
+        <type name="CBanner" restrictions="2"/>
+        <type name="CTabFolder" restrictions="2"/>
+        <type name="CTabItem" restrictions="2"/>
+        <type name="StyledText" restrictions="2"/>
+        <type name="ViewForm" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.dnd" visibility="1">
+        <type name="Clipboard" restrictions="2"/>
+        <type name="DragSource" restrictions="2"/>
+        <type name="DropTarget" restrictions="2"/>
+        <type name="TransferData" restrictions="0">
+            <field name="data" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.graphics" visibility="1">
+        <type name="Color" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;[D)Lorg/eclipse/swt/graphics/Color;"/>
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;[DI)Lorg/eclipse/swt/graphics/Color;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Cursor" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/cocoa/NSCursor;)Lorg/eclipse/swt/graphics/Cursor;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Device" restrictions="0">
+            <method name="getDeviceZoom" restrictions="24" signature="()I"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="Drawable" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+        <type name="Font" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/cocoa/NSFont;)Lorg/eclipse/swt/graphics/Font;"/>
+            <field name="extraTraits" restrictions="8"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="FontData" restrictions="0">
+            <field name="height" restrictions="8"/>
+            <field name="name" restrictions="8"/>
+            <field name="nsName" restrictions="8"/>
+            <field name="style" restrictions="8"/>
+        </type>
+        <type name="FontMetrics" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(IIDII)Lorg/eclipse/swt/graphics/FontMetrics;"/>
+        </type>
+        <type name="GC" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Drawable;Lorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <method name="getGCData" restrictions="8" signature="()Lorg/eclipse/swt/graphics/GCData;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="GCData" restrictions="8"/>
+        <type name="Image" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;ILorg/eclipse/swt/internal/cocoa/NSImage;)Lorg/eclipse/swt/graphics/Image;"/>
+            <field name="handle" restrictions="8"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="type" restrictions="8"/>
+        </type>
+        <type name="ImageData" restrictions="0">
+            <method name="internal_new" restrictions="8" signature="(IIILorg/eclipse/swt/graphics/PaletteData;I[BI[B[BIIIIIII)Lorg/eclipse/swt/graphics/ImageData;"/>
+        </type>
+        <type name="Path" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Region" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Region;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TextLayout" restrictions="0">
+            <method name="setDefaultTabWidth" restrictions="8" signature="(I)V"/>
+        </type>
+        <type name="Transform" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.printing" visibility="1">
+        <type name="PrintDialog" restrictions="2"/>
+        <type name="Printer" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.widgets" visibility="1">
+        <type name="Button" restrictions="2"/>
+        <type name="Caret" restrictions="2"/>
+        <type name="ColorDialog" restrictions="2"/>
+        <type name="Combo" restrictions="2"/>
+        <type name="Control" restrictions="2">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="view" restrictions="8"/>
+        </type>
+        <type name="CoolBar" restrictions="2"/>
+        <type name="CoolItem" restrictions="2"/>
+        <type name="DateTime" restrictions="2"/>
+        <type name="Decorations" restrictions="2"/>
+        <type name="DirectoryDialog" restrictions="2"/>
+        <type name="Display" restrictions="0">
+            <method name="findWidget" restrictions="8" signature="(J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(JJ)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Widget;J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="sendPostExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+            <method name="sendPreExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+        </type>
+        <type name="ExpandBar" restrictions="2"/>
+        <type name="ExpandItem" restrictions="2"/>
+        <type name="FileDialog" restrictions="2"/>
+        <type name="FontDialog" restrictions="2"/>
+        <type name="Group" restrictions="2"/>
+        <type name="IME" restrictions="2"/>
+        <type name="Label" restrictions="2"/>
+        <type name="Link" restrictions="2"/>
+        <type name="List" restrictions="2"/>
+        <type name="Menu" restrictions="2"/>
+        <type name="MenuItem" restrictions="2"/>
+        <type name="MessageBox" restrictions="2"/>
+        <type name="ProgressBar" restrictions="2"/>
+        <type name="Sash" restrictions="2"/>
+        <type name="Scale" restrictions="2"/>
+        <type name="ScrollBar" restrictions="2"/>
+        <type name="Scrollable" restrictions="2"/>
+        <type name="Shell" restrictions="2">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+            <method name="internal_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+        </type>
+        <type name="Slider" restrictions="2"/>
+        <type name="Spinner" restrictions="2"/>
+        <type name="TabFolder" restrictions="2"/>
+        <type name="TabItem" restrictions="2"/>
+        <type name="Table" restrictions="2"/>
+        <type name="TableColumn" restrictions="2"/>
+        <type name="TableItem" restrictions="2"/>
+        <type name="TaskBar" restrictions="2"/>
+        <type name="TaskItem" restrictions="2"/>
+        <type name="Text" restrictions="2"/>
+        <type name="ToolBar" restrictions="2"/>
+        <type name="ToolItem" restrictions="2"/>
+        <type name="ToolTip" restrictions="2"/>
+        <type name="Tracker" restrictions="2"/>
+        <type name="Tray" restrictions="2"/>
+        <type name="TrayItem" restrictions="2"/>
+        <type name="Tree" restrictions="2"/>
+        <type name="TreeColumn" restrictions="2"/>
+        <type name="TreeItem" restrictions="2">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TypedListener" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/internal/SWTEventListener;)V"/>
+            <method name="getEventListener" restrictions="8" signature="()Lorg/eclipse/swt/internal/SWTEventListener;"/>
+            <method name="handleEvent" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Event;)V"/>
+        </type>
+        <type name="Widget" restrictions="0">
+            <method name="removeListener" restrictions="24" signature="(ILorg/eclipse/swt/internal/SWTEventListener;)V"/>
+        </type>
+    </package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.cocoa.macosx.x86_64_3.125.0.v20240227-1638.api_description
+++ b/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.cocoa.macosx.x86_64_3.125.0.v20240227-1638.api_description
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.swt.cocoa.macosx.x86_64_3.125.0.v20240206-1259" version="1.2">
+    <plugin id="org.eclipse.swt.cocoa.macosx.x86_64_3.125.0.v20240206-1259"/>
+    <package name="org.eclipse.swt.accessibility" visibility="1">
+        <type name="Accessible" restrictions="0">
+            <method name="internal_accessibilityActionDescription" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityActionNames" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/NSArray;"/>
+            <method name="internal_accessibilityAttributeNames" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/NSArray;"/>
+            <method name="internal_accessibilityAttributeValue" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityAttributeValue_forParameter" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;Lorg/eclipse/swt/internal/cocoa/id;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityFocusedUIElement" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityHitTest" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSPoint;I)Lorg/eclipse/swt/internal/cocoa/id;"/>
+            <method name="internal_accessibilityIsAttributeSettable" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Z"/>
+            <method name="internal_accessibilityIsIgnored" restrictions="8" signature="(I)Z"/>
+            <method name="internal_accessibilityParameterizedAttributeNames" restrictions="8" signature="(I)Lorg/eclipse/swt/internal/cocoa/NSArray;"/>
+            <method name="internal_accessibilityPerformAction" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/NSString;I)Z"/>
+            <method name="internal_accessibilitySetValue_forAttribute" restrictions="8" signature="(Lorg/eclipse/swt/internal/cocoa/id;Lorg/eclipse/swt/internal/cocoa/NSString;I)V"/>
+            <method name="internal_addRelationAttributes" restrictions="8" signature="(J)J"/>
+            <method name="internal_dispose_Accessible" restrictions="8" signature="()V"/>
+            <method name="internal_new_Accessible" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Control;)Lorg/eclipse/swt/accessibility/Accessible;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.browser" visibility="1">
+        <type name="Browser" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.custom" visibility="1">
+        <type name="CBanner" restrictions="2"/>
+        <type name="CTabFolder" restrictions="2"/>
+        <type name="CTabItem" restrictions="2"/>
+        <type name="StyledText" restrictions="2"/>
+        <type name="ViewForm" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.dnd" visibility="1">
+        <type name="Clipboard" restrictions="2"/>
+        <type name="DragSource" restrictions="2"/>
+        <type name="DropTarget" restrictions="2"/>
+        <type name="TransferData" restrictions="0">
+            <field name="data" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.graphics" visibility="1">
+        <type name="Color" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;[D)Lorg/eclipse/swt/graphics/Color;"/>
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;[DI)Lorg/eclipse/swt/graphics/Color;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Cursor" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/cocoa/NSCursor;)Lorg/eclipse/swt/graphics/Cursor;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Device" restrictions="0">
+            <method name="getDeviceZoom" restrictions="24" signature="()I"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="Drawable" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+        <type name="Font" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/cocoa/NSFont;)Lorg/eclipse/swt/graphics/Font;"/>
+            <field name="extraTraits" restrictions="8"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="FontData" restrictions="0">
+            <field name="height" restrictions="8"/>
+            <field name="name" restrictions="8"/>
+            <field name="nsName" restrictions="8"/>
+            <field name="style" restrictions="8"/>
+        </type>
+        <type name="FontMetrics" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(IIDII)Lorg/eclipse/swt/graphics/FontMetrics;"/>
+        </type>
+        <type name="GC" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Drawable;Lorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <method name="getGCData" restrictions="8" signature="()Lorg/eclipse/swt/graphics/GCData;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="GCData" restrictions="8"/>
+        <type name="Image" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;ILorg/eclipse/swt/internal/cocoa/NSImage;)Lorg/eclipse/swt/graphics/Image;"/>
+            <field name="handle" restrictions="8"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="type" restrictions="8"/>
+        </type>
+        <type name="ImageData" restrictions="0">
+            <method name="internal_new" restrictions="8" signature="(IIILorg/eclipse/swt/graphics/PaletteData;I[BI[B[BIIIIIII)Lorg/eclipse/swt/graphics/ImageData;"/>
+        </type>
+        <type name="Path" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Region" restrictions="0">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Region;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TextLayout" restrictions="0">
+            <method name="setDefaultTabWidth" restrictions="8" signature="(I)V"/>
+        </type>
+        <type name="Transform" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.printing" visibility="1">
+        <type name="PrintDialog" restrictions="2"/>
+        <type name="Printer" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.widgets" visibility="1">
+        <type name="Button" restrictions="2"/>
+        <type name="Caret" restrictions="2"/>
+        <type name="ColorDialog" restrictions="2"/>
+        <type name="Combo" restrictions="2"/>
+        <type name="Control" restrictions="2">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="view" restrictions="8"/>
+        </type>
+        <type name="CoolBar" restrictions="2"/>
+        <type name="CoolItem" restrictions="2"/>
+        <type name="DateTime" restrictions="2"/>
+        <type name="Decorations" restrictions="2"/>
+        <type name="DirectoryDialog" restrictions="2"/>
+        <type name="Display" restrictions="0">
+            <method name="findWidget" restrictions="8" signature="(J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(JJ)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Widget;J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="sendPostExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+            <method name="sendPreExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+        </type>
+        <type name="ExpandBar" restrictions="2"/>
+        <type name="ExpandItem" restrictions="2"/>
+        <type name="FileDialog" restrictions="2"/>
+        <type name="FontDialog" restrictions="2"/>
+        <type name="Group" restrictions="2"/>
+        <type name="IME" restrictions="2"/>
+        <type name="Label" restrictions="2"/>
+        <type name="Link" restrictions="2"/>
+        <type name="List" restrictions="2"/>
+        <type name="Menu" restrictions="2"/>
+        <type name="MenuItem" restrictions="2"/>
+        <type name="MessageBox" restrictions="2"/>
+        <type name="ProgressBar" restrictions="2"/>
+        <type name="Sash" restrictions="2"/>
+        <type name="Scale" restrictions="2"/>
+        <type name="ScrollBar" restrictions="2"/>
+        <type name="Scrollable" restrictions="2"/>
+        <type name="Shell" restrictions="2">
+            <method name="cocoa_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+            <method name="internal_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+        </type>
+        <type name="Slider" restrictions="2"/>
+        <type name="Spinner" restrictions="2"/>
+        <type name="TabFolder" restrictions="2"/>
+        <type name="TabItem" restrictions="2"/>
+        <type name="Table" restrictions="2"/>
+        <type name="TableColumn" restrictions="2"/>
+        <type name="TableItem" restrictions="2"/>
+        <type name="TaskBar" restrictions="2"/>
+        <type name="TaskItem" restrictions="2"/>
+        <type name="Text" restrictions="2"/>
+        <type name="ToolBar" restrictions="2"/>
+        <type name="ToolItem" restrictions="2"/>
+        <type name="ToolTip" restrictions="2"/>
+        <type name="Tracker" restrictions="2"/>
+        <type name="Tray" restrictions="2"/>
+        <type name="TrayItem" restrictions="2"/>
+        <type name="Tree" restrictions="2"/>
+        <type name="TreeColumn" restrictions="2"/>
+        <type name="TreeItem" restrictions="2">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TypedListener" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/internal/SWTEventListener;)V"/>
+            <method name="getEventListener" restrictions="8" signature="()Lorg/eclipse/swt/internal/SWTEventListener;"/>
+            <method name="handleEvent" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Event;)V"/>
+        </type>
+        <type name="Widget" restrictions="0">
+            <method name="removeListener" restrictions="24" signature="(ILorg/eclipse/swt/internal/SWTEventListener;)V"/>
+        </type>
+    </package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.gtk.linux.aarch64_3.125.0.v20240227-1638.api_description
+++ b/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.gtk.linux.aarch64_3.125.0.v20240227-1638.api_description
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.swt.gtk.linux.aarch64_3.125.0.v20240206-1259" version="1.2">
+    <plugin id="org.eclipse.swt.gtk.linux.aarch64_3.125.0.v20240206-1259"/>
+    <package name="org.eclipse.swt.accessibility" visibility="1">
+        <type name="Accessible" restrictions="0">
+            <method name="internal_dispose_Accessible" restrictions="8" signature="()V"/>
+            <method name="internal_new_Accessible" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Control;)Lorg/eclipse/swt/accessibility/Accessible;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.browser" visibility="1">
+        <type name="Browser" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.custom" visibility="1">
+        <type name="CBanner" restrictions="2"/>
+        <type name="CTabFolder" restrictions="2"/>
+        <type name="CTabItem" restrictions="2"/>
+        <type name="StyledText" restrictions="2"/>
+        <type name="ViewForm" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.dnd" visibility="1">
+        <type name="Clipboard" restrictions="2"/>
+        <type name="DragSource" restrictions="2"/>
+        <type name="DropTarget" restrictions="2"/>
+        <type name="TransferData" restrictions="0">
+            <field name="format" restrictions="8"/>
+            <field name="length" restrictions="8"/>
+            <field name="pValue" restrictions="8"/>
+            <field name="result" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.graphics" visibility="1">
+        <type name="Color" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/gtk/GdkRGBA;)Lorg/eclipse/swt/graphics/Color;"/>
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/gtk/GdkRGBA;I)Lorg/eclipse/swt/graphics/Color;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Cursor" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Cursor;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Device" restrictions="0">
+            <method name="getDeviceZoom" restrictions="24" signature="()I"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="xDisplay" restrictions="8"/>
+        </type>
+        <type name="DeviceData" restrictions="0">
+            <field name="application_class" restrictions="8"/>
+            <field name="application_name" restrictions="8"/>
+            <field name="display_name" restrictions="8"/>
+        </type>
+        <type name="Drawable" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+        <type name="Font" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Font;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="FontData" restrictions="0">
+            <field name="height" restrictions="8"/>
+            <field name="name" restrictions="8"/>
+            <field name="string" restrictions="8"/>
+            <field name="style" restrictions="8"/>
+        </type>
+        <type name="GC" restrictions="0">
+            <method name="getGCData" restrictions="8" signature="()Lorg/eclipse/swt/graphics/GCData;"/>
+            <method name="gtk_new" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Drawable;Lorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="GCData" restrictions="8">
+            <field name="backgroundRGBA" restrictions="8"/>
+            <field name="foregroundRGBA" restrictions="8"/>
+        </type>
+        <type name="Image" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJJ)Lorg/eclipse/swt/graphics/Image;"/>
+            <method name="gtk_new_from_pixbuf" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJ)Lorg/eclipse/swt/graphics/Image;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_gtk_refreshImageForZoom" restrictions="8" signature="()Z"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="mask" restrictions="8"/>
+            <field name="surface" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+        <type name="ImageData" restrictions="0">
+            <method name="internal_new" restrictions="8" signature="(IIILorg/eclipse/swt/graphics/PaletteData;I[BI[B[BIIIIIII)Lorg/eclipse/swt/graphics/ImageData;"/>
+        </type>
+        <type name="Path" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Pattern" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Region" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Region;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TextLayout" restrictions="0">
+            <method name="setDefaultTabWidth" restrictions="8" signature="(I)V"/>
+        </type>
+        <type name="Transform" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.printing" visibility="1">
+        <type name="PrintDialog" restrictions="2"/>
+        <type name="Printer" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.widgets" visibility="1">
+        <type name="Button" restrictions="2"/>
+        <type name="Caret" restrictions="2"/>
+        <type name="ColorDialog" restrictions="2"/>
+        <type name="Combo" restrictions="2"/>
+        <type name="Composite" restrictions="0">
+            <field name="embeddedHandle" restrictions="8"/>
+        </type>
+        <type name="Control" restrictions="2">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="CoolBar" restrictions="2"/>
+        <type name="CoolItem" restrictions="2"/>
+        <type name="DateTime" restrictions="2"/>
+        <type name="Decorations" restrictions="2"/>
+        <type name="DirectoryDialog" restrictions="2"/>
+        <type name="Display" restrictions="2">
+            <method name="extractFreeGError" restrictions="8" signature="(J)Ljava/lang/String;"/>
+            <method name="findWidget" restrictions="8" signature="(J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(JJ)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Widget;J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="sendPostExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+            <method name="sendPreExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+        </type>
+        <type name="ExpandBar" restrictions="2"/>
+        <type name="ExpandItem" restrictions="2"/>
+        <type name="FileDialog" restrictions="2"/>
+        <type name="FontDialog" restrictions="2"/>
+        <type name="Group" restrictions="2"/>
+        <type name="IME" restrictions="2"/>
+        <type name="Label" restrictions="2"/>
+        <type name="Link" restrictions="2"/>
+        <type name="List" restrictions="2"/>
+        <type name="Menu" restrictions="2"/>
+        <type name="MenuItem" restrictions="2"/>
+        <type name="MessageBox" restrictions="2"/>
+        <type name="ProgressBar" restrictions="2"/>
+        <type name="Sash" restrictions="2"/>
+        <type name="Scale" restrictions="2"/>
+        <type name="ScrollBar" restrictions="2"/>
+        <type name="Scrollable" restrictions="2"/>
+        <type name="Shell" restrictions="2">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+            <method name="internal_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+        </type>
+        <type name="Slider" restrictions="2"/>
+        <type name="Spinner" restrictions="2"/>
+        <type name="TabFolder" restrictions="2"/>
+        <type name="TabItem" restrictions="2"/>
+        <type name="Table" restrictions="2"/>
+        <type name="TableColumn" restrictions="2"/>
+        <type name="TableItem" restrictions="2"/>
+        <type name="TaskBar" restrictions="2"/>
+        <type name="TaskItem" restrictions="2"/>
+        <type name="Text" restrictions="2"/>
+        <type name="ToolBar" restrictions="2"/>
+        <type name="ToolItem" restrictions="2"/>
+        <type name="ToolTip" restrictions="2"/>
+        <type name="Tracker" restrictions="2"/>
+        <type name="Tray" restrictions="2"/>
+        <type name="TrayItem" restrictions="2"/>
+        <type name="Tree" restrictions="2"/>
+        <type name="TreeColumn" restrictions="2"/>
+        <type name="TreeItem" restrictions="2"/>
+        <type name="TypedListener" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/internal/SWTEventListener;)V"/>
+            <method name="getEventListener" restrictions="8" signature="()Lorg/eclipse/swt/internal/SWTEventListener;"/>
+            <method name="handleEvent" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Event;)V"/>
+        </type>
+        <type name="Widget" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="removeListener" restrictions="24" signature="(ILorg/eclipse/swt/internal/SWTEventListener;)V"/>
+        </type>
+    </package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.gtk.linux.ppc64le_3.125.0.v20240227-1638.api_description
+++ b/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.gtk.linux.ppc64le_3.125.0.v20240227-1638.api_description
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.swt.gtk.linux.ppc64le_3.125.0.v20240206-1259" version="1.2">
+    <plugin id="org.eclipse.swt.gtk.linux.ppc64le_3.125.0.v20240206-1259"/>
+    <package name="org.eclipse.swt.accessibility" visibility="1">
+        <type name="Accessible" restrictions="0">
+            <method name="internal_dispose_Accessible" restrictions="8" signature="()V"/>
+            <method name="internal_new_Accessible" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Control;)Lorg/eclipse/swt/accessibility/Accessible;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.browser" visibility="1">
+        <type name="Browser" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.custom" visibility="1">
+        <type name="CBanner" restrictions="2"/>
+        <type name="CTabFolder" restrictions="2"/>
+        <type name="CTabItem" restrictions="2"/>
+        <type name="StyledText" restrictions="2"/>
+        <type name="ViewForm" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.dnd" visibility="1">
+        <type name="Clipboard" restrictions="2"/>
+        <type name="DragSource" restrictions="2"/>
+        <type name="DropTarget" restrictions="2"/>
+        <type name="TransferData" restrictions="0">
+            <field name="format" restrictions="8"/>
+            <field name="length" restrictions="8"/>
+            <field name="pValue" restrictions="8"/>
+            <field name="result" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.graphics" visibility="1">
+        <type name="Color" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/gtk/GdkRGBA;)Lorg/eclipse/swt/graphics/Color;"/>
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/gtk/GdkRGBA;I)Lorg/eclipse/swt/graphics/Color;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Cursor" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Cursor;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Device" restrictions="0">
+            <method name="getDeviceZoom" restrictions="24" signature="()I"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="xDisplay" restrictions="8"/>
+        </type>
+        <type name="DeviceData" restrictions="0">
+            <field name="application_class" restrictions="8"/>
+            <field name="application_name" restrictions="8"/>
+            <field name="display_name" restrictions="8"/>
+        </type>
+        <type name="Drawable" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+        <type name="Font" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Font;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="FontData" restrictions="0">
+            <field name="height" restrictions="8"/>
+            <field name="name" restrictions="8"/>
+            <field name="string" restrictions="8"/>
+            <field name="style" restrictions="8"/>
+        </type>
+        <type name="GC" restrictions="0">
+            <method name="getGCData" restrictions="8" signature="()Lorg/eclipse/swt/graphics/GCData;"/>
+            <method name="gtk_new" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Drawable;Lorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="GCData" restrictions="8">
+            <field name="backgroundRGBA" restrictions="8"/>
+            <field name="foregroundRGBA" restrictions="8"/>
+        </type>
+        <type name="Image" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJJ)Lorg/eclipse/swt/graphics/Image;"/>
+            <method name="gtk_new_from_pixbuf" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJ)Lorg/eclipse/swt/graphics/Image;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_gtk_refreshImageForZoom" restrictions="8" signature="()Z"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="mask" restrictions="8"/>
+            <field name="surface" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+        <type name="ImageData" restrictions="0">
+            <method name="internal_new" restrictions="8" signature="(IIILorg/eclipse/swt/graphics/PaletteData;I[BI[B[BIIIIIII)Lorg/eclipse/swt/graphics/ImageData;"/>
+        </type>
+        <type name="Path" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Pattern" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Region" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Region;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TextLayout" restrictions="0">
+            <method name="setDefaultTabWidth" restrictions="8" signature="(I)V"/>
+        </type>
+        <type name="Transform" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.printing" visibility="1">
+        <type name="PrintDialog" restrictions="2"/>
+        <type name="Printer" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.widgets" visibility="1">
+        <type name="Button" restrictions="2"/>
+        <type name="Caret" restrictions="2"/>
+        <type name="ColorDialog" restrictions="2"/>
+        <type name="Combo" restrictions="2"/>
+        <type name="Composite" restrictions="0">
+            <field name="embeddedHandle" restrictions="8"/>
+        </type>
+        <type name="Control" restrictions="2">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="CoolBar" restrictions="2"/>
+        <type name="CoolItem" restrictions="2"/>
+        <type name="DateTime" restrictions="2"/>
+        <type name="Decorations" restrictions="2"/>
+        <type name="DirectoryDialog" restrictions="2"/>
+        <type name="Display" restrictions="2">
+            <method name="extractFreeGError" restrictions="8" signature="(J)Ljava/lang/String;"/>
+            <method name="findWidget" restrictions="8" signature="(J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(JJ)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Widget;J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="sendPostExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+            <method name="sendPreExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+        </type>
+        <type name="ExpandBar" restrictions="2"/>
+        <type name="ExpandItem" restrictions="2"/>
+        <type name="FileDialog" restrictions="2"/>
+        <type name="FontDialog" restrictions="2"/>
+        <type name="Group" restrictions="2"/>
+        <type name="IME" restrictions="2"/>
+        <type name="Label" restrictions="2"/>
+        <type name="Link" restrictions="2"/>
+        <type name="List" restrictions="2"/>
+        <type name="Menu" restrictions="2"/>
+        <type name="MenuItem" restrictions="2"/>
+        <type name="MessageBox" restrictions="2"/>
+        <type name="ProgressBar" restrictions="2"/>
+        <type name="Sash" restrictions="2"/>
+        <type name="Scale" restrictions="2"/>
+        <type name="ScrollBar" restrictions="2"/>
+        <type name="Scrollable" restrictions="2"/>
+        <type name="Shell" restrictions="2">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+            <method name="internal_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+        </type>
+        <type name="Slider" restrictions="2"/>
+        <type name="Spinner" restrictions="2"/>
+        <type name="TabFolder" restrictions="2"/>
+        <type name="TabItem" restrictions="2"/>
+        <type name="Table" restrictions="2"/>
+        <type name="TableColumn" restrictions="2"/>
+        <type name="TableItem" restrictions="2"/>
+        <type name="TaskBar" restrictions="2"/>
+        <type name="TaskItem" restrictions="2"/>
+        <type name="Text" restrictions="2"/>
+        <type name="ToolBar" restrictions="2"/>
+        <type name="ToolItem" restrictions="2"/>
+        <type name="ToolTip" restrictions="2"/>
+        <type name="Tracker" restrictions="2"/>
+        <type name="Tray" restrictions="2"/>
+        <type name="TrayItem" restrictions="2"/>
+        <type name="Tree" restrictions="2"/>
+        <type name="TreeColumn" restrictions="2"/>
+        <type name="TreeItem" restrictions="2"/>
+        <type name="TypedListener" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/internal/SWTEventListener;)V"/>
+            <method name="getEventListener" restrictions="8" signature="()Lorg/eclipse/swt/internal/SWTEventListener;"/>
+            <method name="handleEvent" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Event;)V"/>
+        </type>
+        <type name="Widget" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="removeListener" restrictions="24" signature="(ILorg/eclipse/swt/internal/SWTEventListener;)V"/>
+        </type>
+    </package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.gtk.linux.x86_64_3.125.0.v20240227-1638.api_description
+++ b/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.gtk.linux.x86_64_3.125.0.v20240227-1638.api_description
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.swt.gtk.linux.x86_64_3.125.0.v20240206-1259" version="1.2">
+    <plugin id="org.eclipse.swt.gtk.linux.x86_64_3.125.0.v20240206-1259"/>
+    <package name="org.eclipse.swt.accessibility" visibility="1">
+        <type name="Accessible" restrictions="0">
+            <method name="internal_dispose_Accessible" restrictions="8" signature="()V"/>
+            <method name="internal_new_Accessible" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Control;)Lorg/eclipse/swt/accessibility/Accessible;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.browser" visibility="1">
+        <type name="Browser" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.custom" visibility="1">
+        <type name="CBanner" restrictions="2"/>
+        <type name="CTabFolder" restrictions="2"/>
+        <type name="CTabItem" restrictions="2"/>
+        <type name="StyledText" restrictions="2"/>
+        <type name="ViewForm" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.dnd" visibility="1">
+        <type name="Clipboard" restrictions="2"/>
+        <type name="DragSource" restrictions="2"/>
+        <type name="DropTarget" restrictions="2"/>
+        <type name="TransferData" restrictions="0">
+            <field name="format" restrictions="8"/>
+            <field name="length" restrictions="8"/>
+            <field name="pValue" restrictions="8"/>
+            <field name="result" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.graphics" visibility="1">
+        <type name="Color" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/gtk/GdkRGBA;)Lorg/eclipse/swt/graphics/Color;"/>
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;Lorg/eclipse/swt/internal/gtk/GdkRGBA;I)Lorg/eclipse/swt/graphics/Color;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Cursor" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Cursor;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Device" restrictions="0">
+            <method name="getDeviceZoom" restrictions="24" signature="()I"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="xDisplay" restrictions="8"/>
+        </type>
+        <type name="DeviceData" restrictions="0">
+            <field name="application_class" restrictions="8"/>
+            <field name="application_name" restrictions="8"/>
+            <field name="display_name" restrictions="8"/>
+        </type>
+        <type name="Drawable" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+        <type name="Font" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Font;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="FontData" restrictions="0">
+            <field name="height" restrictions="8"/>
+            <field name="name" restrictions="8"/>
+            <field name="string" restrictions="8"/>
+            <field name="style" restrictions="8"/>
+        </type>
+        <type name="GC" restrictions="0">
+            <method name="getGCData" restrictions="8" signature="()Lorg/eclipse/swt/graphics/GCData;"/>
+            <method name="gtk_new" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Drawable;Lorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="GCData" restrictions="8">
+            <field name="backgroundRGBA" restrictions="8"/>
+            <field name="foregroundRGBA" restrictions="8"/>
+        </type>
+        <type name="Image" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJJ)Lorg/eclipse/swt/graphics/Image;"/>
+            <method name="gtk_new_from_pixbuf" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJ)Lorg/eclipse/swt/graphics/Image;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_gtk_refreshImageForZoom" restrictions="8" signature="()Z"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="mask" restrictions="8"/>
+            <field name="surface" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+        <type name="ImageData" restrictions="0">
+            <method name="internal_new" restrictions="8" signature="(IIILorg/eclipse/swt/graphics/PaletteData;I[BI[B[BIIIIIII)Lorg/eclipse/swt/graphics/ImageData;"/>
+        </type>
+        <type name="Path" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Pattern" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Region" restrictions="0">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Region;"/>
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TextLayout" restrictions="0">
+            <method name="setDefaultTabWidth" restrictions="8" signature="(I)V"/>
+        </type>
+        <type name="Transform" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.printing" visibility="1">
+        <type name="PrintDialog" restrictions="2"/>
+        <type name="Printer" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.widgets" visibility="1">
+        <type name="Button" restrictions="2"/>
+        <type name="Caret" restrictions="2"/>
+        <type name="ColorDialog" restrictions="2"/>
+        <type name="Combo" restrictions="2"/>
+        <type name="Composite" restrictions="0">
+            <field name="embeddedHandle" restrictions="8"/>
+        </type>
+        <type name="Control" restrictions="2">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="CoolBar" restrictions="2"/>
+        <type name="CoolItem" restrictions="2"/>
+        <type name="DateTime" restrictions="2"/>
+        <type name="Decorations" restrictions="2"/>
+        <type name="DirectoryDialog" restrictions="2"/>
+        <type name="Display" restrictions="2">
+            <method name="extractFreeGError" restrictions="8" signature="(J)Ljava/lang/String;"/>
+            <method name="findWidget" restrictions="8" signature="(J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(JJ)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Widget;J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="sendPostExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+            <method name="sendPreExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+        </type>
+        <type name="ExpandBar" restrictions="2"/>
+        <type name="ExpandItem" restrictions="2"/>
+        <type name="FileDialog" restrictions="2"/>
+        <type name="FontDialog" restrictions="2"/>
+        <type name="Group" restrictions="2"/>
+        <type name="IME" restrictions="2"/>
+        <type name="Label" restrictions="2"/>
+        <type name="Link" restrictions="2"/>
+        <type name="List" restrictions="2"/>
+        <type name="Menu" restrictions="2"/>
+        <type name="MenuItem" restrictions="2"/>
+        <type name="MessageBox" restrictions="2"/>
+        <type name="ProgressBar" restrictions="2"/>
+        <type name="Sash" restrictions="2"/>
+        <type name="Scale" restrictions="2"/>
+        <type name="ScrollBar" restrictions="2"/>
+        <type name="Scrollable" restrictions="2"/>
+        <type name="Shell" restrictions="2">
+            <method name="gtk_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+            <method name="internal_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+        </type>
+        <type name="Slider" restrictions="2"/>
+        <type name="Spinner" restrictions="2"/>
+        <type name="TabFolder" restrictions="2"/>
+        <type name="TabItem" restrictions="2"/>
+        <type name="Table" restrictions="2"/>
+        <type name="TableColumn" restrictions="2"/>
+        <type name="TableItem" restrictions="2"/>
+        <type name="TaskBar" restrictions="2"/>
+        <type name="TaskItem" restrictions="2"/>
+        <type name="Text" restrictions="2"/>
+        <type name="ToolBar" restrictions="2"/>
+        <type name="ToolItem" restrictions="2"/>
+        <type name="ToolTip" restrictions="2"/>
+        <type name="Tracker" restrictions="2"/>
+        <type name="Tray" restrictions="2"/>
+        <type name="TrayItem" restrictions="2"/>
+        <type name="Tree" restrictions="2"/>
+        <type name="TreeColumn" restrictions="2"/>
+        <type name="TreeItem" restrictions="2"/>
+        <type name="TypedListener" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/internal/SWTEventListener;)V"/>
+            <method name="getEventListener" restrictions="8" signature="()Lorg/eclipse/swt/internal/SWTEventListener;"/>
+            <method name="handleEvent" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Event;)V"/>
+        </type>
+        <type name="Widget" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="removeListener" restrictions="24" signature="(ILorg/eclipse/swt/internal/SWTEventListener;)V"/>
+        </type>
+    </package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.win32.win32.x86_64_3.125.0.v20240227-1638.api_description
+++ b/apitools/org.eclipse.pde.api.tools/fixed_api_descriptions/org.eclipse.swt.win32.win32.x86_64_3.125.0.v20240227-1638.api_description
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.swt.win32.win32.x86_64_3.125.0.v20240206-1259" version="1.2">
+    <plugin id="org.eclipse.swt.win32.win32.x86_64_3.125.0.v20240206-1259"/>
+    <package name="org.eclipse.swt.accessibility" visibility="1">
+        <type name="Accessible" restrictions="0">
+            <method name="internal_WM_GETOBJECT" restrictions="8" signature="(JJ)J"/>
+            <method name="internal_dispose_Accessible" restrictions="8" signature="()V"/>
+            <method name="internal_new_Accessible" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Control;)Lorg/eclipse/swt/accessibility/Accessible;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.browser" visibility="1">
+        <type name="Browser" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.custom" visibility="1">
+        <type name="CBanner" restrictions="2"/>
+        <type name="CTabFolder" restrictions="2"/>
+        <type name="CTabItem" restrictions="2"/>
+        <type name="StyledText" restrictions="2"/>
+        <type name="ViewForm" restrictions="2"/>
+    </package>
+    <package name="org.eclipse.swt.dnd" visibility="1">
+        <type name="Clipboard" restrictions="2"/>
+        <type name="DragSource" restrictions="2"/>
+        <type name="DropTarget" restrictions="2"/>
+        <type name="TransferData" restrictions="0">
+            <field name="formatetc" restrictions="8"/>
+            <field name="pIDataObject" restrictions="8"/>
+            <field name="result" restrictions="8"/>
+            <field name="stgmedium" restrictions="8"/>
+            <field name="type" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.graphics" visibility="1">
+        <type name="Color" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;I)Lorg/eclipse/swt/graphics/Color;"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;II)Lorg/eclipse/swt/graphics/Color;"/>
+        </type>
+        <type name="Cursor" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;I)Lorg/eclipse/swt/graphics/Cursor;"/>
+        </type>
+        <type name="Device" restrictions="0">
+            <method name="getDeviceZoom" restrictions="24" signature="()I"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="Drawable" restrictions="0">
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+        <type name="Font" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;J)Lorg/eclipse/swt/graphics/Font;"/>
+        </type>
+        <type name="FontData" restrictions="0">
+            <field name="data" restrictions="8"/>
+            <field name="height" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/internal/win32/LOGFONT;F)Lorg/eclipse/swt/graphics/FontData;"/>
+        </type>
+        <type name="FontMetrics" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/internal/win32/TEXTMETRIC;)Lorg/eclipse/swt/graphics/FontMetrics;"/>
+        </type>
+        <type name="GC" restrictions="0">
+            <method name="getGCData" restrictions="8" signature="()Lorg/eclipse/swt/graphics/GCData;"/>
+            <field name="handle" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Drawable;Lorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+            <method name="win32_new" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)Lorg/eclipse/swt/graphics/GC;"/>
+        </type>
+        <type name="GCData" restrictions="8"/>
+        <type name="Image" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="type" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;IJ)Lorg/eclipse/swt/graphics/Image;"/>
+        </type>
+        <type name="ImageData" restrictions="0">
+            <method name="internal_new" restrictions="8" signature="(IIILorg/eclipse/swt/graphics/PaletteData;I[BI[B[BIIIIIII)Lorg/eclipse/swt/graphics/ImageData;"/>
+        </type>
+        <type name="Path" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Pattern" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="Region" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/graphics/Device;I)Lorg/eclipse/swt/graphics/Region;"/>
+        </type>
+        <type name="TextLayout" restrictions="0">
+            <method name="setDefaultTabWidth" restrictions="8" signature="(I)V"/>
+        </type>
+        <type name="Transform" restrictions="0">
+            <field name="handle" restrictions="8"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.ole.win32" visibility="1">
+        <type name="OleClientSite" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Composite;ILjava/lang/String;Ljava/io/File;)V"/>
+        </type>
+        <type name="OleControlSite" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Composite;ILjava/lang/String;Ljava/io/File;)V"/>
+        </type>
+        <type name="Variant" restrictions="0">
+            <method name="win32_copy" restrictions="8" signature="(JLorg/eclipse/swt/ole/win32/Variant;)V"/>
+            <method name="win32_new" restrictions="8" signature="(J)Lorg/eclipse/swt/ole/win32/Variant;"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.printing" visibility="1">
+        <type name="PrintDialog" restrictions="2"/>
+        <type name="Printer" restrictions="0">
+            <field name="handle" restrictions="8"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <method name="isAutoScalable" restrictions="8" signature="()Z"/>
+        </type>
+    </package>
+    <package name="org.eclipse.swt.widgets" visibility="1">
+        <type name="Button" restrictions="2"/>
+        <type name="Caret" restrictions="2"/>
+        <type name="ColorDialog" restrictions="2"/>
+        <type name="Combo" restrictions="2"/>
+        <type name="Control" restrictions="2">
+            <field name="handle" restrictions="8"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+        </type>
+        <type name="CoolBar" restrictions="2"/>
+        <type name="CoolItem" restrictions="2"/>
+        <type name="DateTime" restrictions="2"/>
+        <type name="Decorations" restrictions="2"/>
+        <type name="DirectoryDialog" restrictions="2"/>
+        <type name="Display" restrictions="2">
+            <method name="findWidget" restrictions="8" signature="(J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(JJ)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="findWidget" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Widget;J)Lorg/eclipse/swt/widgets/Widget;"/>
+            <method name="internal_dispose_GC" restrictions="8" signature="(JLorg/eclipse/swt/graphics/GCData;)V"/>
+            <method name="internal_new_GC" restrictions="8" signature="(Lorg/eclipse/swt/graphics/GCData;)J"/>
+            <field name="msg" restrictions="8"/>
+            <method name="sendPostExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+            <method name="sendPreExternalEventDispatchEvent" restrictions="8" signature="()V"/>
+        </type>
+        <type name="ExpandBar" restrictions="2"/>
+        <type name="ExpandItem" restrictions="2"/>
+        <type name="FileDialog" restrictions="2"/>
+        <type name="FontDialog" restrictions="2"/>
+        <type name="Group" restrictions="2"/>
+        <type name="IME" restrictions="2"/>
+        <type name="Label" restrictions="2"/>
+        <type name="Link" restrictions="2"/>
+        <type name="List" restrictions="2"/>
+        <type name="Menu" restrictions="2">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="MenuItem" restrictions="2"/>
+        <type name="MessageBox" restrictions="2"/>
+        <type name="ProgressBar" restrictions="2"/>
+        <type name="Sash" restrictions="2"/>
+        <type name="Scale" restrictions="2"/>
+        <type name="ScrollBar" restrictions="2"/>
+        <type name="Scrollable" restrictions="2"/>
+        <type name="Shell" restrictions="2">
+            <method name="internal_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+            <method name="win32_new" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Display;J)Lorg/eclipse/swt/widgets/Shell;"/>
+        </type>
+        <type name="Slider" restrictions="2"/>
+        <type name="Spinner" restrictions="2"/>
+        <type name="TabFolder" restrictions="2"/>
+        <type name="TabItem" restrictions="2"/>
+        <type name="Table" restrictions="2"/>
+        <type name="TableColumn" restrictions="2"/>
+        <type name="TableItem" restrictions="2"/>
+        <type name="TaskBar" restrictions="2"/>
+        <type name="TaskItem" restrictions="2"/>
+        <type name="Text" restrictions="2"/>
+        <type name="ToolBar" restrictions="2"/>
+        <type name="ToolItem" restrictions="2"/>
+        <type name="ToolTip" restrictions="2"/>
+        <type name="Tracker" restrictions="2"/>
+        <type name="Tray" restrictions="2"/>
+        <type name="TrayItem" restrictions="2"/>
+        <type name="Tree" restrictions="2"/>
+        <type name="TreeColumn" restrictions="2"/>
+        <type name="TreeItem" restrictions="2">
+            <field name="handle" restrictions="8"/>
+        </type>
+        <type name="TypedListener" restrictions="0">
+            <method name="&lt;init&gt;" restrictions="8" signature="(Lorg/eclipse/swt/internal/SWTEventListener;)V"/>
+            <method name="getEventListener" restrictions="8" signature="()Lorg/eclipse/swt/internal/SWTEventListener;"/>
+            <method name="handleEvent" restrictions="8" signature="(Lorg/eclipse/swt/widgets/Event;)V"/>
+        </type>
+        <type name="Widget" restrictions="0">
+            <method name="removeListener" restrictions="24" signature="(ILorg/eclipse/swt/internal/SWTEventListener;)V"/>
+        </type>
+    </package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -40,8 +41,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.BundleSpecification;
@@ -77,6 +80,7 @@ import org.eclipse.pde.api.tools.internal.util.SourceDefaultHandler;
 import org.eclipse.pde.api.tools.internal.util.Util;
 import org.eclipse.pde.internal.core.TargetWeaver;
 import org.eclipse.pde.internal.core.util.ManifestUtils;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
@@ -820,6 +824,16 @@ public class BundleComponent extends Component {
 		return null;
 	}
 
+	// 3.125.0.v20240206-1259
+	private static final List<String> FIXED_API_DESCRIPTIONS = Arrays.asList(
+			"org.eclipse.swt.win32.win32.x86_64_3.125.0.v20240227-1638", //$NON-NLS-1$
+			"org.eclipse.swt.gtk.linux.x86_64_3.125.0.v20240227-1638", //$NON-NLS-1$
+			"org.eclipse.swt.gtk.linux.ppc64le_3.125.0.v20240227-1638", //$NON-NLS-1$
+			"org.eclipse.swt.gtk.linux.aarch64_3.125.0.v20240227-1638", //$NON-NLS-1$
+			"org.eclipse.swt.cocoa.macosx.aarch64_3.125.0.v20240227-1638", //$NON-NLS-1$
+			"org.eclipse.swt.cocoa.macosx.x86_64_3.125.0.v20240227-1638" //$NON-NLS-1$
+	);
+
 	/**
 	 * Parses a bundle's .api_description XML into a string. The file may be in
 	 * a jar or in a directory at the specified location.
@@ -833,13 +847,19 @@ public class BundleComponent extends Component {
 		InputStream stream = null;
 		String contents;
 		try {
-			String extension = IPath.fromOSString(bundleLocation.getName()).getFileExtension();
+			String fileName = bundleLocation.getName();
+			String extension = IPath.fromOSString(fileName).getFileExtension();
 			if (extension != null && extension.equals("jar") && bundleLocation.isFile()) { //$NON-NLS-1$
-				jarFile = new ZipFile(bundleLocation, ZipFile.OPEN_READ);
-				ZipEntry manifestEntry = jarFile.getEntry(IApiCoreConstants.API_DESCRIPTION_XML_NAME);
-				if (manifestEntry != null) {
-					// new file is present
-					stream = jarFile.getInputStream(manifestEntry);
+				String bundleAndVersion = fileName.substring(0, fileName.length() - ".jar".length()); //$NON-NLS-1$
+				if (FIXED_API_DESCRIPTIONS.contains(bundleAndVersion)) {
+					stream = loadFixedBundleApiDescription(bundleAndVersion);
+				} else {
+					jarFile = new ZipFile(bundleLocation, ZipFile.OPEN_READ);
+					ZipEntry manifestEntry = jarFile.getEntry(IApiCoreConstants.API_DESCRIPTION_XML_NAME);
+					if (manifestEntry != null) {
+						// new file is present
+						stream = jarFile.getInputStream(manifestEntry);
+					}
 				}
 			} else {
 				File file = new File(bundleLocation, IApiCoreConstants.API_DESCRIPTION_XML_NAME);
@@ -857,6 +877,20 @@ public class BundleComponent extends Component {
 			closingZipFileAndStream(stream, jarFile);
 		}
 		return contents;
+	}
+
+	/**
+	 * See https://github.com/eclipse-platform/eclipse.platform.swt/issues/1093 and
+	 * https://github.com/eclipse-pde/eclipse.pde/issues/1187.
+	 *
+	 * @param bundleAndVersion platform specific bundle name with version
+	 * @return stream opened for reading api description
+	 * @throws IOException
+	 */
+	private static InputStream loadFixedBundleApiDescription(String bundleAndVersion) throws IOException {
+		Bundle bundle = Platform.getBundle("org.eclipse.pde.api.tools"); //$NON-NLS-1$
+		IPath pathInBundle = IPath.fromOSString("fixed_api_descriptions/" + bundleAndVersion + ".api_description"); //$NON-NLS-1$ //$NON-NLS-2$
+		return FileLocator.openStream(bundle, pathInBundle, false);
 	}
 
 	/**


### PR DESCRIPTION
Added SWT API description files from last good 4.31 build I20240207-0610 https://download.eclipse.org/eclipse/updates/4.31-I-builds/I20240207-0610/plugins/

The files will be loaded instead of "empty" SWT API description files shipped with 4.31 RC2 build (3.125.0.v20240227-1638).

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1187