### PR TITLE
Fix UseScanManager.isValidArchive() and UseReportConverter

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseReportConverter.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseReportConverter.java
@@ -1680,7 +1680,7 @@ public class UseReportConverter extends HTMLConvertor {
 		}
 		// try looking in the default 'xml' directory as a raw report root
 		// might have been specified
-		return new File(getReportsRoot() + File.separator + "xml", "meta" + XML_EXTENSION); //$NON-NLS-1$ //$NON-NLS-2$
+		return new File(getReportsRoot() + File.separator + "xml", type + XML_EXTENSION); //$NON-NLS-1$
 	}
 
 	/**


### PR DESCRIPTION
In UseScanManager.isValidArchive() the jar/zip-file was closed too early making it impossible to read from it.

And in UseReportConverter.getXML() the default look up looked not at the wrong file when computing the filtered-counts.

Since especially the former seems to be broken for some time I wonder if API use-scans are a  used feature?
Does anybody know if the is used for the Eclipse SDK or SimRel? With that I could verify if this really is fixed (at the moment this is just an anticipated fix from looking at the code). Maybe @merks or @iloveeclipse?