### PR TITLE
Fix escaping of line-break in api.tools/build.properties

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/build.properties
+++ b/apitools/org.eclipse.pde.api.tools/build.properties
@@ -23,7 +23,7 @@ bin.includes = .,\
                plugin.xml,\
                lib/apitooling-ant.jar,\
                scripts/,\
-               fixed_api_descriptions/,
+               fixed_api_descriptions/,\
                OSGI-INF/
 jars.extra.classpath=platform:/plugin/org.apache.ant/lib/ant.jar,platform:/plugin/org.objectweb.asm
 jars.compile.order = .,\


### PR DESCRIPTION
Forgotten in https://github.com/eclipse-pde/eclipse.pde/pull/1116.