### PR TITLE
Restore internal FilterStore.fFilterMap field to un-break Tycho's api-analysis

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/FilterStore.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/FilterStore.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -67,7 +66,7 @@ public class FilterStore implements IApiFilterStore {
 	/**
 	 * The mapping of filters for this store.
 	 */
-	protected Map<String, Set<IApiProblemFilter>> fFilterMap = null;
+	protected HashMap<String, Set<IApiProblemFilter>> fFilterMap = null;
 	/**
 	 * The bundle component backing this store
 	 */


### PR DESCRIPTION
See https://github.com/eclipse-pde/eclipse.pde/pull/1199/files#r1527617764