### PR TITLE
Add org.eclipse.pde.feature dependency to pull additional requirements

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PDE JUnit Tests
 Bundle-SymbolicName: org.eclipse.pde.ui.tests; singleton:=true
-Bundle-Version: 3.12.400.qualifier
+Bundle-Version: 3.12.500.qualifier
 Bundle-ClassPath: tests.jar
 Bundle-Activator: org.eclipse.pde.ui.tests.PDETestsPlugin
 Bundle-Vendor: Eclipse.org

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.tests</artifactId>
-  <version>3.12.400-SNAPSHOT</version>
+  <version>3.12.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -23,9 +23,9 @@
 
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
-  	<testSuite>${project.artifactId}</testSuite>
-  	<testClass>org.eclipse.pde.ui.tests.AllPDETests</testClass>
-  	<surefire.testArgLine>-DDetectVMInstallationsJob.disabled=true</surefire.testArgLine>
+      <testSuite>${project.artifactId}</testSuite>
+      <testClass>org.eclipse.pde.ui.tests.AllPDETests</testClass>
+      <surefire.testArgLine>-DDetectVMInstallationsJob.disabled=true</surefire.testArgLine>
   </properties>
 
   <build>
@@ -45,6 +45,22 @@
           </dependencies>
         </configuration>
       </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <configuration>
+                    <dependency-resolution>
+                        <extraRequirements>
+                            <requirement>
+                                <!-- require the pde feature so we get additional dependencies -->
+                                <type>eclipse-feature</type>
+                                <id>org.eclipse.pde</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                        </extraRequirements>
+                    </dependency-resolution>
+                </configuration>
+            </plugin>
     </plugins>
   </build>
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
@@ -62,12 +62,12 @@ public class ClasspathResolutionTest {
 	@Rule
 	public final TestRule deleteCreatedTestProjectsAfter = ProjectUtils.DELETE_CREATED_WORKSPACE_PROJECTS_AFTER;
 
-	private static String javaxAnnotationProviderBSN;
+	private static String jakartaAnnotationProviderBSN;
 
 	@BeforeClass
 	public static void getJavaxAnnotationProviderBSN() {
 		Bundle bundle = FrameworkUtil.getBundle(jakarta.annotation.PostConstruct.class);
-		javaxAnnotationProviderBSN = bundle.getSymbolicName();
+		jakartaAnnotationProviderBSN = bundle.getSymbolicName();
 	}
 
 	@Test
@@ -100,17 +100,17 @@ public class ClasspathResolutionTest {
 
 	@Test
 	public void testImportExternalPreviouslySystemPackageAddsExtraBundle() throws Exception {
-		loadTargetPlatform(javaxAnnotationProviderBSN);
+		loadTargetPlatform(jakartaAnnotationProviderBSN);
 		IProject project = ProjectUtils.importTestProject("tests/projects/demoMissedExternalPackage");
 		// In Java 11, jakarta.annotation is not present, so the bundle *must*
 		// be part of classpath
 		List<String> classpathEntries = getRequiredPluginContainerEntries(project);
-		assertThat(classpathEntries).anyMatch(filename -> filename.contains(javaxAnnotationProviderBSN));
+		assertThat(classpathEntries).anyMatch(filename -> filename.contains(jakartaAnnotationProviderBSN));
 	}
 
 	@Test
 	public void testImportExternalPreviouslySystemPackageAddsExtraBundle_missingBREE() throws Exception {
-		loadTargetPlatform(javaxAnnotationProviderBSN);
+		loadTargetPlatform(jakartaAnnotationProviderBSN);
 		IProject project = ProjectUtils.importTestProject("tests/projects/demoMissedExternalPackageNoBREE");
 
 		IExecutionEnvironment java11 = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-11");
@@ -118,24 +118,24 @@ public class ClasspathResolutionTest {
 		// In Java 11, jakarta.annotation is not present, so the bundle *must*
 		// be part of classpath, even if no BREE is specified
 		List<String> classpathEntries = getRequiredPluginContainerEntries(project);
-		assertThat(classpathEntries).anyMatch(filename -> filename.contains(javaxAnnotationProviderBSN));
+		assertThat(classpathEntries).anyMatch(filename -> filename.contains(jakartaAnnotationProviderBSN));
 	}
 
 	@Test
 	public void testImportSystemPackageDoesntAddExtraBundleJava8() throws Exception {
-		loadTargetPlatform(javaxAnnotationProviderBSN);
+		loadTargetPlatform(jakartaAnnotationProviderBSN);
 		try (var mocked = mockExtraExtraJRESystemPackages("JavaSE-1.8", List.of("jakarta.annotation"))) {
 			IProject project = ProjectUtils.importTestProject("tests/projects/demoMissedSystemPackageJava8");
 			// In Java 8, jakarta.annotation is present, so the bundle must
 			// *NOT* be part of classpath
 			List<String> classpathEntries = getRequiredPluginContainerEntries(project);
-			assertThat(classpathEntries).isEmpty();
+			assertThat(classpathEntries).noneMatch(filename -> filename.contains(jakartaAnnotationProviderBSN));
 		}
 	}
 
 	@Test
 	public void testImportSystemPackageDoesntAddExtraBundleJava8_osgiEERequirement() throws Exception {
-		loadTargetPlatform(javaxAnnotationProviderBSN);
+		loadTargetPlatform(jakartaAnnotationProviderBSN);
 		try (var mocked = mockExtraExtraJRESystemPackages("JavaSE-1.8", List.of("jakarta.annotation"))) {
 			IProject project = ProjectUtils
 					.importTestProject("tests/projects/demoMissedSystemPackageJava8OsgiEERequirement");
@@ -143,7 +143,7 @@ public class ClasspathResolutionTest {
 			// Require-Capability
 			// --> jakarta.annotation bundle must not be on the classpath
 			List<String> classpathEntries = getRequiredPluginContainerEntries(project);
-			assertThat(classpathEntries).isEmpty();
+			assertThat(classpathEntries).noneMatch(filename -> filename.contains(jakartaAnnotationProviderBSN));
 		}
 	}
 


### PR DESCRIPTION
Currently the tests are missing some indirect requirements defined in the feature on their test, this adds the org.eclipse.pde.feature to make sure all declared items are pulled in.

See 
- https://github.com/eclipse-pde/eclipse.pde/issues/1205