### PR TITLE
Register PluginContentMergeViewerCreator for .target content type

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -1356,6 +1356,9 @@
       <contentTypeBinding
             contentMergeViewerId="org.eclipse.pde.internal.ui.compare.PluginContentMergeViewerCreator"
             contentTypeId="org.eclipse.pde.fragmentManifest" />
+      <contentTypeBinding
+            contentMergeViewerId="org.eclipse.pde.internal.ui.compare.PluginContentMergeViewerCreator"
+            contentTypeId="org.eclipse.pde.targetFile" />
    </extension>
     <extension
          point="org.eclipse.ui.themes">


### PR DESCRIPTION
This enables syntax highlighting for .target files in compare editor.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1222