### PR TITLE
Avoid unhandled NPEs in FoldingReconcilerStrategy

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/folding/FoldingReconcilerStrategy.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/folding/FoldingReconcilerStrategy.java
@@ -60,6 +60,9 @@ public class FoldingReconcilerStrategy implements IReconcilingStrategy, IReconci
 
 	@Override
 	public void initialReconcile() {
+		if (projectionViewer == null || document == null) {
+			return;
+		}
 		ProjectionAnnotationModel projectionAnnotationModel = projectionViewer.getProjectionAnnotationModel();
 		if (document.get().equals(oldDocument) || projectionAnnotationModel == null)
 			return;


### PR DESCRIPTION
The exception below is printed to standard error every time a generic editor diff contribution is used in compare editor for target files. I assume it never worked as designed with TargetPlatformFoldingReconciler, so just add a NPE guard to prevent unhandled exceptions / printouts.

```
Exception in thread
"org.eclipse.pde.internal.genericeditor.target.extension.reconciler.folding.TargetPlatformFoldingReconciler"
java.lang.NullPointerException: Cannot invoke
"org.eclipse.jface.text.source.projection.ProjectionViewer.getProjectionAnnotationModel()"
because "this.projectionViewer" is null
	at org.eclipse.pde.internal.genericeditor.target.extension.reconciler.folding.FoldingReconcilerStrategy.initialReconcile(FoldingReconcilerStrategy.java:63)
	at org.eclipse.jface.text.reconciler.Reconciler.initialProcess(Reconciler.java:223)
	at org.eclipse.jface.text.reconciler.AbstractReconciler$BackgroundThread.run(AbstractReconciler.java:177)
```

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1798