### PR TITLE
Move long running operations to the activation of the PluginsTab

### DIFF
--- a/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.doc.user; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/org.eclipse.pde.doc.user/pom.xml
+++ b/org.eclipse.pde.doc.user/pom.xml
@@ -17,7 +17,7 @@
     <version>4.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.pde.doc.user</artifactId>
-  <version>3.15.100-SNAPSHOT</version>
+  <version>3.15.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/PluginsTab.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/PluginsTab.java
@@ -59,6 +59,7 @@ public class PluginsTab extends AbstractLauncherTab {
 	private Combo fDefaultAutoStart;
 	private Spinner fDefaultStartLevel;
 	private final Listener fListener;
+	private boolean fActivated;
 
 	private static final int DEFAULT_SELECTION = 0;
 	private static final int PLUGIN_SELECTION = 1;
@@ -156,6 +157,16 @@ public class PluginsTab extends AbstractLauncherTab {
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
+		// Long-running initialization happens on first activation of this tab
+	}
+
+	@Override
+	public void activated(ILaunchConfigurationWorkingCopy configuration) {
+		if (fActivated) {
+			// Since this method can be expensive, only activate this tab once.
+			return;
+		}
+
 		try {
 			int index = DEFAULT_SELECTION;
 			if (configuration.getAttribute(IPDELauncherConstants.USE_CUSTOM_FEATURES, false)) {
@@ -171,6 +182,9 @@ public class PluginsTab extends AbstractLauncherTab {
 			fDefaultAutoStart.setText(Boolean.toString(auto));
 			int level = configuration.getAttribute(IPDELauncherConstants.DEFAULT_START_LEVEL, 4);
 			fDefaultStartLevel.setSelection(level);
+
+			// If everything ran smoothly, this tab is activated
+			fActivated = true;
 		} catch (CoreException e) {
 			PDEPlugin.log(e);
 		}
@@ -188,7 +202,9 @@ public class PluginsTab extends AbstractLauncherTab {
 		int index = fSelectionCombo.getSelectionIndex();
 		configuration.setAttribute(IPDELauncherConstants.USE_DEFAULT, index == DEFAULT_SELECTION);
 		configuration.setAttribute(IPDELauncherConstants.USE_CUSTOM_FEATURES, index == FEATURE_SELECTION);
-		fBlock.performApply(configuration);
+		if (fActivated) {
+			fBlock.performApply(configuration);
+		}
 		// clear default values for auto-start and start-level if default
 		String autoText = fDefaultAutoStart.getText();
 		if (Boolean.toString(false).equals(autoText)) {
@@ -217,16 +233,9 @@ public class PluginsTab extends AbstractLauncherTab {
 		return fImage;
 	}
 
-	/**
-	 * Validates the tab.  If the feature option is chosen, and the workspace is not correctly set up,
-	 * the error message is set.
-	 *
-	 * @see org.eclipse.pde.ui.launcher.AbstractLauncherTab#validateTab()
-	 */
 	@Override
 	public void validateTab() {
-		String errorMessage = null;
-		setErrorMessage(errorMessage);
+		setErrorMessage(null);
 	}
 
 	@Override


### PR DESCRIPTION
Move the long running operations in the `PluginsTab` from `initializeFrom` to `activated`. Only run these operations the first time the tab is activated in order to:
a. Only run them when the tab is actually selected
b. Not run them again if the tab is deselected and selected again (without leaving the current launch configuration)

## How to test
* Create 2 **new** launch configurations from inside the _Run Configurations_ dialog: one _Eclipse Application_ (1) and one _JUnit-Plugin Test_ (2)
* Select the `Plugins` tab in one of them and make some changes (save them)
* Move to the other configuration --> The `Plugins` tab should be selected and it should look fine. The activation should **not** be skipped _i.e._ it should **not** hit the `return;` in line 167
* Move back to the first configuration --> The `Plugins` tab should be selected and contain all changes you applied before. The activation should **not** be skipped
* Select another tab
* Select the `Plugins` tab again --> The activation should be skipped _i.e._ hit should hit the `return;` in line 167

![image](https://github.com/eclipse-pde/eclipse.pde/assets/2205684/d4bbd9a3-6f12-478f-b64a-1448aacd77d9)

* [x] I tested my changes thoroughly

Contributes to https://github.com/eclipse-pde/eclipse.pde/issues/1232

