### PR TITLE
Rely on system-packages of Equinox JRE-1.1 profile

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -577,30 +577,6 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 	// Old JDKs can for example be obtained from https://www.oracle.com/java/technologies/downloads/archive/
 	@SuppressWarnings("nls")
 	private static final Map<String, List<String>> PRE_JAVA_9_SYSTEM_PACKAGES = Map.of(//
-			"JRE-1.1", List.of("java.applet", //
-					"java.awt", //
-					"java.awt.datatransfer", //
-					"java.awt.event", //
-					"java.awt.image", //
-					"java.awt.peer", //
-					"java.beans", //
-					"java.io", //
-					"java.lang", //
-					"java.lang.reflect", //
-					"java.math", //
-					"java.net", //
-					"java.rmi", //
-					"java.rmi.dgc", //
-					"java.rmi.registry", //
-					"java.rmi.server", //
-					"java.security", //
-					"java.security.acl", //
-					"java.security.interfaces", //
-					"java.sql", //
-					"java.text", //
-					"java.text.resources", //
-					"java.util", //
-					"java.util.zip"),
 			"J2SE-1.2", List.of("java.applet", //
 					"java.awt", //
 					"java.awt.color", //


### PR DESCRIPTION
With https://github.com/eclipse-equinox/equinox/pull/596 the JRE-1.1 profile embedded in Equinox was updated to have the expected system-packages.
Therefore the hard-coded ones in PDE can be removed.

See also https://github.com/eclipse-pde/eclipse.pde/issues/1231#issuecomment-2057561119.