### PR TITLE
Allow launch prototypes in JUnit Plug-in Test (generic Test view)

### DIFF
--- a/ui/org.eclipse.pde.unittest.junit/plugin.xml
+++ b/ui/org.eclipse.pde.unittest.junit/plugin.xml
@@ -34,6 +34,7 @@
          point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
             allowCommandLine="true"
+            allowPrototypes="true"
             delegate="org.eclipse.pde.unittest.junit.launcher.AdvancedJUnitPluginLaunchConfigurationDelegate"
             delegateDescription="%JUnitPluginLaunchDelegate.description"
             delegateName="%JUnitPluginLaunchDelegate.name"

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/internal/launcher/JUnitPluginTabGroup.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/internal/launcher/JUnitPluginTabGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.PrototypeTab;
 import org.eclipse.jdt.debug.ui.launchConfigurations.JavaArgumentsTab;
 import org.eclipse.jdt.internal.junit.launcher.AssertionVMArg;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
@@ -36,7 +37,7 @@ public class JUnitPluginTabGroup extends AbstractPDELaunchConfigurationTabGroup 
 		ILaunchConfigurationTab[] tabs = null;
 		tabs = new ILaunchConfigurationTab[] { new JUnitPluginTestTab(), new PluginJUnitMainTab(),
 				new JavaArgumentsTab(), new PluginsTab(), new ConfigurationTab(true), new TracingTab(),
-				new EnvironmentTab(), new CommonTab() };
+				new EnvironmentTab(), new CommonTab(), new PrototypeTab() };
 		setTabs(tabs);
 	}
 

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginTestTab.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginTestTab.java
@@ -22,7 +22,6 @@ public class JUnitPluginTestTab extends TestTab {
 
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy config) {
-		// TODO Auto-generated method stub
 		super.performApply(config);
 
 		new ConfigureViewerSupport(JUnitPluginTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID).apply(config);


### PR DESCRIPTION
All the tabs are already hooked for prototype support (shared with other launch configs that support prototypes) thus only the final enable and show the configuration tab is needed.