### PR TITLE
Improve Generic Test view label capitalization

### DIFF
--- a/ui/org.eclipse.pde.unittest.junit/plugin.properties
+++ b/ui/org.eclipse.pde.unittest.junit/plugin.properties
@@ -20,9 +20,9 @@ JUnitPluginLaunchDelegate.description=The Eclipse JUnit Plug-in Unit Test Launch
 RunJUnitPluginLaunchShortcut.description=Runs a set of Unit tests
 DebugJUnitPluginLaunchShortcut.description=Debugs a set of Unit tests
 
-Launch.label= JUnit Plug-in Test (generic Test view)
+Launch.label= JUnit Plug-in Test (Generic Test view)
 
-JUnitPluginTestShortcut.label= JUnit Plug-in Test (generic Test view)
+JUnitPluginTestShortcut.label= JUnit Plug-in Test (Generic Test view)
 
 JUnitPluginTabGroup.description.debug= Create a configuration that will launch a Unit test in debug mode.
 JUnitPluginTabGroup.description.run= Create a configuration that will launch a Unit test.


### PR DESCRIPTION
"(generic Test view)" looks very bad in the UI.