### PR TITLE
Clean caches upon deletion of a Target Definition #1246

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
@@ -74,6 +74,7 @@ import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEPreferencesManager;
 import org.eclipse.pde.internal.core.TargetDefinitionManager;
+import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.osgi.service.prefs.BackingStoreException;
 
 /**
@@ -156,6 +157,7 @@ public class TargetPlatformService implements ITargetPlatformService {
 			fExtTargetHandles.remove(((ExternalFileTargetHandle) handle).getLocation());
 		}
 		((AbstractTargetHandle) handle).delete();
+		TargetPlatformHelper.getTargetDefinitionMap().remove(handle);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/LocalTargetDefinitionTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/LocalTargetDefinitionTests.java
@@ -766,6 +766,22 @@ public class LocalTargetDefinitionTests extends AbstractTargetTest {
 	}
 
 	/**
+	 * Test for https://github.com/eclipse-pde/eclipse.pde/issues/1246
+	 */
+	@Test
+	public void testDeleteCleansCaches() throws Exception {
+		ITargetDefinition definition = getNewTarget();
+		try {
+			assertFalse(TargetPlatformHelper.getTargetDefinitionMap().containsKey(definition.getHandle()));
+			definition.resolve(null);
+			assertTrue(TargetPlatformHelper.getTargetDefinitionMap().containsKey(definition.getHandle()));
+		} finally {
+			getTargetService().deleteTarget(definition.getHandle());
+			assertFalse(TargetPlatformHelper.getTargetDefinitionMap().containsKey(definition.getHandle()));
+		}
+	}
+
+	/**
 	 * Tests that a single (lower) version of a bundle can be included in the
 	 * target platform.
 	 */

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/TargetPlatformPreferencePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/TargetPlatformPreferencePage.java
@@ -744,9 +744,6 @@ public class TargetPlatformPreferencePage extends PreferencePage implements IWor
 			}
 			fRemoved.addAll(selected);
 			fTargets.removeAll(selected);
-			for (ITargetDefinition element : selected) {
-				TargetPlatformHelper.getTargetDefinitionMap().remove(element.getHandle());
-			}
 			// Quick hack because the first refresh loses the checkedState, which is being used to bold the active target
 			fTableViewer.refresh(false);
 			fTableViewer.refresh(true);


### PR DESCRIPTION
TargetPlatformHelper and TargetPlatformService keep separate caches for target definition, resulting in a leak of TargetDefinition objects.

The leak happens when TargetDefinition.resolve() caches data in TargetPlatformHelper.

Fixes #1246