### PR TITLE
Publish a product IU into the PDE launch profile

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Comparator Errors in 4.32 I-Build I20240304-0140
+Update to IPDELauncherConstants

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -121,7 +121,8 @@ Require-Bundle:
  org.eclipse.equinox.p2.garbagecollector;bundle-version="[1.3.100,2.0.0)",
  org.eclipse.equinox.p2.touchpoint.eclipse;bundle-version="[2.4.100,3.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.9.200,4.0.0)",
- org.eclipse.core.filesystem;bundle-version="[1.10.200,2.0.0)"
+ org.eclipse.core.filesystem;bundle-version="[1.10.200,2.0.0)",
+ org.eclipse.equinox.p2.publisher
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.pde.core

--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchConfigurationHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchConfigurationHelper.java
@@ -41,6 +41,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.P2Utils;
+import org.eclipse.pde.internal.core.P2Utils.ProductInfo;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.ifeature.IFeature;
@@ -216,7 +217,16 @@ public class LaunchConfigurationHelper {
 
 				// Unless we are restarting an existing profile, generate/overwrite the profile
 				if (!configuration.getAttribute(IPDEConstants.RESTART, false) || !P2Utils.profileExists(profileID, p2DataArea)) {
-					P2Utils.createProfile(profileID, p2DataArea, bundles.values(), features);
+					ProductInfo productInfo;
+					String productId = configuration.getAttribute(IPDELauncherConstants.PRODUCT_ID, ""); //$NON-NLS-1$
+					String productVersion = configuration.getAttribute(IPDELauncherConstants.PRODUCT_VERSION, "0.0.0"); //$NON-NLS-1$
+					String productName = configuration.getAttribute(IPDELauncherConstants.PRODUCT_NAME, ""); //$NON-NLS-1$
+					if (productId.isBlank()) {
+						productInfo = null;
+					} else {
+						productInfo = new ProductInfo(productId, productVersion, productName);
+					}
+					P2Utils.createProfile(profileID, p2DataArea, bundles.values(), features, productInfo);
 				}
 				properties.setProperty("eclipse.p2.profile", profileID); //$NON-NLS-1$
 			}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/IPDELauncherConstants.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/IPDELauncherConstants.java
@@ -66,6 +66,27 @@ public interface IPDELauncherConstants {
 	String PRODUCT = "product"; //$NON-NLS-1$
 
 	/**
+	 * Launch configuration attribute key. The value is a string specifying
+	 * the product id to be published in the profile of the run if enabled.
+	 * @since 3.13
+	 */
+	String PRODUCT_ID = "productId"; //$NON-NLS-1$
+
+	/**
+	 * Launch configuration attribute key. The value is a string specifying
+	 * the product version to be published in the profile of the run if enabled.
+	 * @since 3.13
+	 */
+	String PRODUCT_VERSION = "productVersion"; //$NON-NLS-1$
+
+	/**
+	 * Launch configuration attribute key. The value is a string specifying
+	 * the product name to be published in the profile of the run if enabled.
+	 * @since 3.13
+	 */
+	String PRODUCT_NAME = "productName"; //$NON-NLS-1$
+
+	/**
 	 * Launch configuration attribute key. The value is a boolean specifying
 	 * if the launch should appear in product-mode.  If the value is <code>false</code>,
 	 * the launch takes place in application-mode.

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
@@ -147,6 +147,24 @@ public class LaunchAction extends Action {
 	private ILaunchConfigurationWorkingCopy refreshConfiguration(ILaunchConfigurationWorkingCopy wc) {
 		wc.setAttribute(IPDELauncherConstants.PRODUCT, fProduct.getProductId());
 		wc.setAttribute(IPDELauncherConstants.APPLICATION, fProduct.getApplication());
+		String productId = fProduct.getId();
+		if (productId == null || productId.isEmpty()) {
+			wc.removeAttribute(IPDELauncherConstants.PRODUCT_ID);
+		} else {
+			wc.setAttribute(IPDELauncherConstants.PRODUCT_ID, productId);
+		}
+		String productVersion = fProduct.getVersion();
+		if (productVersion == null || productVersion.isEmpty()) {
+			wc.removeAttribute(IPDELauncherConstants.PRODUCT_VERSION);
+		} else {
+			wc.setAttribute(IPDELauncherConstants.PRODUCT_VERSION, productVersion);
+		}
+		String productName = fProduct.getName();
+		if (productName == null || productName.isEmpty()) {
+			wc.removeAttribute(IPDELauncherConstants.PRODUCT_NAME);
+		} else {
+			wc.setAttribute(IPDELauncherConstants.PRODUCT_NAME, productName);
+		}
 
 		if (TargetPlatformHelper.usesNewApplicationModel()) {
 			wc.setAttribute(IPDEConstants.LAUNCHER_PDE_VERSION, "3.3"); //$NON-NLS-1$


### PR DESCRIPTION
Currently PDE published already root-feature what is already a great win. But in a usual product install there is also one unit for the product and because that is missing it can't be updated in a launched product from the IDE.

This adds a very bare unit to the profile by just publish the product id/version/name, but already allows that P2 pick up the unit when an update is requested.