### PR TITLE
Revert "Move long running operations to the activation of the PluginsTab"

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 Comparator Errors in 4.32 I-Build I20240304-0140
 Update to IPDELauncherConstants
+https://github.com/eclipse-pde/eclipse.pde/issues/1250

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/PluginsTab.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/PluginsTab.java
@@ -59,7 +59,6 @@ public class PluginsTab extends AbstractLauncherTab {
 	private Combo fDefaultAutoStart;
 	private Spinner fDefaultStartLevel;
 	private final Listener fListener;
-	private boolean fActivated;
 
 	private static final int DEFAULT_SELECTION = 0;
 	private static final int PLUGIN_SELECTION = 1;
@@ -157,16 +156,6 @@ public class PluginsTab extends AbstractLauncherTab {
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
-		// Long-running initialization happens on first activation of this tab
-	}
-
-	@Override
-	public void activated(ILaunchConfigurationWorkingCopy configuration) {
-		if (fActivated) {
-			// Since this method can be expensive, only activate this tab once.
-			return;
-		}
-
 		try {
 			int index = DEFAULT_SELECTION;
 			if (configuration.getAttribute(IPDELauncherConstants.USE_CUSTOM_FEATURES, false)) {
@@ -182,9 +171,6 @@ public class PluginsTab extends AbstractLauncherTab {
 			fDefaultAutoStart.setText(Boolean.toString(auto));
 			int level = configuration.getAttribute(IPDELauncherConstants.DEFAULT_START_LEVEL, 4);
 			fDefaultStartLevel.setSelection(level);
-
-			// If everything ran smoothly, this tab is activated
-			fActivated = true;
 		} catch (CoreException e) {
 			PDEPlugin.log(e);
 		}
@@ -202,9 +188,7 @@ public class PluginsTab extends AbstractLauncherTab {
 		int index = fSelectionCombo.getSelectionIndex();
 		configuration.setAttribute(IPDELauncherConstants.USE_DEFAULT, index == DEFAULT_SELECTION);
 		configuration.setAttribute(IPDELauncherConstants.USE_CUSTOM_FEATURES, index == FEATURE_SELECTION);
-		if (fActivated) {
-			fBlock.performApply(configuration);
-		}
+		fBlock.performApply(configuration);
 		// clear default values for auto-start and start-level if default
 		String autoText = fDefaultAutoStart.getText();
 		if (Boolean.toString(false).equals(autoText)) {
@@ -233,9 +217,16 @@ public class PluginsTab extends AbstractLauncherTab {
 		return fImage;
 	}
 
+	/**
+	 * Validates the tab.  If the feature option is chosen, and the workspace is not correctly set up,
+	 * the error message is set.
+	 *
+	 * @see org.eclipse.pde.ui.launcher.AbstractLauncherTab#validateTab()
+	 */
 	@Override
 	public void validateTab() {
-		setErrorMessage(null);
+		String errorMessage = null;
+		setErrorMessage(errorMessage);
 	}
 
 	@Override


### PR DESCRIPTION
This change reverts main change from commit 98a58656a74bd163c8f4ad8f7a36dc492ac67e1c because it caused a severe regression.

See https://github.com/eclipse-pde/eclipse.pde/pull/1233

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1250