### PR TITLE
Add an option to ignore references

### DIFF
--- a/org.eclipse.pde.doc.user/guide/tools/target_shared/location_edit_site_wizard.htm
+++ b/org.eclipse.pde.doc.user/guide/tools/target_shared/location_edit_site_wizard.htm
@@ -32,6 +32,8 @@
 
 <p><strong>Include configure phase</strong> is an advanced option to control whether the configure phase of the download operation will be run.  The configure phase allows downloaded software to run additional operations.  If this causes problems for your software site, this option can be turned off.</p> 
 
+<p>The <strong>Follow repository references</strong> option will search repository references defined in your software sites. Disabling it in essence forces your software site to become self-contained.</p>
+
 <h3 class="related">Related references</h3>
 <a href="./edit_target_locations_tab.htm">Location Tab</a><br>
 <a href="./edit_target_wizard.htm">Edit Target Wizard</a><br>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IULocationFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/IULocationFactory.java
@@ -59,6 +59,7 @@ public class IULocationFactory implements ITargetLocationFactory {
 			String includeAllPlatforms = location.getAttribute(TargetDefinitionPersistenceHelper.ATTR_INCLUDE_ALL_PLATFORMS);
 			String includeSource = location.getAttribute(TargetDefinitionPersistenceHelper.ATTR_INCLUDE_SOURCE);
 			String includeConfigurePhase = location.getAttribute(TargetDefinitionPersistenceHelper.ATTR_INCLUDE_CONFIGURE_PHASE);
+			String followRepositoryReferences = location.getAttribute(TargetDefinitionPersistenceHelper.ATTR_FOLLOW_REPOSITORY_REFERENCES);
 
 			NodeList list = location.getChildNodes();
 			List<String> ids = new ArrayList<>();
@@ -101,6 +102,13 @@ public class IULocationFactory implements ITargetLocationFactory {
 			flags |= Boolean.parseBoolean(includeAllPlatforms) ? IUBundleContainer.INCLUDE_ALL_ENVIRONMENTS : 0;
 			flags |= Boolean.parseBoolean(includeSource) ? IUBundleContainer.INCLUDE_SOURCE : 0;
 			flags |= Boolean.parseBoolean(includeConfigurePhase) ? IUBundleContainer.INCLUDE_CONFIGURE_PHASE : 0;
+			// For backwards compatibility, followRepositoryReferences should be
+			// true when it's absent
+			if (followRepositoryReferences.isEmpty()) {
+				flags |= IUBundleContainer.FOLLOW_REPOSITORY_REFERENCES;
+			} else {
+				flags |= Boolean.parseBoolean(followRepositoryReferences) ? IUBundleContainer.FOLLOW_REPOSITORY_REFERENCES : 0;
+			}
 			return TargetPlatformService.getDefault().newIULocation(iuIDs, iuVer, uris,
 					flags);
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
@@ -1046,7 +1046,8 @@ public class P2TargetUtils {
 		Collection<IRepositoryReference> references = repository.getReferences();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, references.size() * 2);
 		for (IRepositoryReference reference : references) {
-			if (reference.getType() == IRepository.TYPE_METADATA && seen.add(reference)) {
+			if (reference.getType() == IRepository.TYPE_METADATA && reference.getOptions() == IRepository.ENABLED
+					&& seen.add(reference)) {
 				try {
 					IMetadataRepository referencedRepository = manager.loadRepository(reference.getLocation(),
 							subMonitor.split(1));

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinitionPersistenceHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinitionPersistenceHelper.java
@@ -87,6 +87,7 @@ public class TargetDefinitionPersistenceHelper {
 	static final String ATTR_INCLUDE_ALL_PLATFORMS = "includeAllPlatforms"; //$NON-NLS-1$
 	static final String ATTR_INCLUDE_SOURCE = "includeSource"; //$NON-NLS-1$
 	static final String ATTR_INCLUDE_CONFIGURE_PHASE = "includeConfigurePhase"; //$NON-NLS-1$
+	static final String ATTR_FOLLOW_REPOSITORY_REFERENCES = "followRepositoryReferences"; //$NON-NLS-1$
 	static final String ATTR_VERSION = "version"; //$NON-NLS-1$
 	static final String ATTR_CONFIGURATION = "configuration"; //$NON-NLS-1$
 	static final String ATTR_SEQUENCE_NUMBER = "sequenceNumber"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AttributeNameCompletionTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AttributeNameCompletionTests.java
@@ -30,8 +30,8 @@ public class AttributeNameCompletionTests extends AbstractTargetEditorTest {
 		// target
 		expectedProposalsByOffset.put(8, new String[] { "name", "sequenceNumber" });
 		// location
-		expectedProposalsByOffset.put(33, new String[] { "includeAllPlatforms", "includeConfigurePhase", "includeMode",
-				"includeSource", "type" });
+		expectedProposalsByOffset.put(33, new String[] { "followRepositoryReferences", "includeAllPlatforms",
+				"includeConfigurePhase", "includeMode", "includeSource", "type" });
 		// unit
 		expectedProposalsByOffset.put(41, new String[] { "id", "version" });
 		// repository
@@ -85,8 +85,7 @@ public class AttributeNameCompletionTests extends AbstractTargetEditorTest {
 				offset = Math.min(nextSpace, nextOpen);
 			}
 
-			ICompletionProposal[] completionProposals = contentAssist.computeCompletionProposals(textViewer,
-					offset);
+			ICompletionProposal[] completionProposals = contentAssist.computeCompletionProposals(textViewer, offset);
 			if (completionProposals.length != 0) {
 				Assert.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
 						+ proposalListToString(completionProposals));

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/AttributeNamesFullTestCaseTarget.txt
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/AttributeNamesFullTestCaseTarget.txt
@@ -1,6 +1,6 @@
 <target  name="" sequenceNumber=""  >
 <locations >
-<location  includeAllPlatforms="" includeConfigurePhase="" includeMode="" includeSource="" type=""  >
+<location  followRepositoryReferences="" includeAllPlatforms="" includeConfigurePhase="" includeMode="" includeSource="" type=""  >
 <unit  id="" version=""  />
 <repository  location=""  />
 </location>

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/ContainerContentsTestCaseTarget.txt
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/ContainerContentsTestCaseTarget.txt
@@ -10,7 +10,7 @@
 		<location configuration="/test/path/to/configuration/location/" path="/test/path/to/eclipse/" type="Profile"/>
 		<location id="org.eclipse.test" path="${eclipse_home}" type="Feature" version="1.2.3"/>
 		<location path="/test/path/to/eclipse/" type="Profile"/>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location followRepositoryReferences="false" includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="TESTURI"/>
 			<repository location="TESTURI2"/>
 			<unit id="unit1" version="1.0.0"/>

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/MultipleContainersSameRepoTestCaseTarget.txt
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/MultipleContainersSameRepoTestCaseTarget.txt
@@ -2,12 +2,12 @@
 <?pde version="3.8"?>
 <target>
 	<locations>
-		<location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+		<location followRepositoryReferences="false" includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
 			<repository location="TESTURI"/>
 			<unit id="unit1" version="1.0.0"/>
 			<unit id="unit2" version="2.0.0"/>
 		</location>
-		<location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+		<location followRepositoryReferences="false" includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
 			<repository location="TESTURI"/>
 		</location>
 	</locations>

--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/autocomplete/processors/AttributeNameCompletionProcessor.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/autocomplete/processors/AttributeNameCompletionProcessor.java
@@ -50,8 +50,9 @@ public class AttributeNameCompletionProcessor extends DelegateProcessor {
 	private final String[] target = new String[] { ITargetConstants.TARGET_NAME_ATTR, ITargetConstants.TARGET_SEQ_NO_ATTR };
 	private final String[] locations = new String[] {};
 	private final String[] location = new String[] { ITargetConstants.LOCATION_INCLUDE_PLATFORMS_ATTR,
-			ITargetConstants.LOCATION_INCLUDE_CONFIG_PHASE_ATTR, ITargetConstants.LOCATION_INCLUDE_MODE_ATTR,
-			ITargetConstants.LOCATION_INCLUDE_SOURCE_ATTR, ITargetConstants.LOCATION_TYPE_ATTR };
+			ITargetConstants.LOCATION_INCLUDE_CONFIG_PHASE_ATTR, ITargetConstants.LOCATION_FOLLOW_REPOSITORY_REFERENCES_ATTR,
+			ITargetConstants.LOCATION_INCLUDE_MODE_ATTR, ITargetConstants.LOCATION_INCLUDE_SOURCE_ATTR,
+			ITargetConstants.LOCATION_TYPE_ATTR };
 	private final String[] unit = new String[] { ITargetConstants.UNIT_ID_ATTR, ITargetConstants.UNIT_VERSION_ATTR };
 	private final String[] repository = new String[] { ITargetConstants.REPOSITORY_LOCATION_ATTR };
 	private final String[] targetJRE = new String[] { ITargetConstants.TARGET_JRE_PATH_ATTR };

--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/model/ITargetConstants.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/model/ITargetConstants.java
@@ -49,6 +49,7 @@ public interface ITargetConstants {
 	String TARGET_SEQ_NO_ATTR = "sequenceNumber"; //$NON-NLS-1$
 	String LOCATION_INCLUDE_PLATFORMS_ATTR = "includeAllPlatforms"; //$NON-NLS-1$
 	String LOCATION_INCLUDE_CONFIG_PHASE_ATTR = "includeConfigurePhase"; //$NON-NLS-1$
+	String LOCATION_FOLLOW_REPOSITORY_REFERENCES_ATTR = "followRepositoryReferences";
 	String LOCATION_INCLUDE_MODE_ATTR = "includeMode"; //$NON-NLS-1$
 	String LOCATION_INCLUDE_SOURCE_ATTR = "includeSource"; //$NON-NLS-1$
 	String LOCATION_ID_ATTR = "id"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/presentation/TargetPlatformAttributeRule.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/presentation/TargetPlatformAttributeRule.java
@@ -18,6 +18,7 @@ import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITar
 import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.LOCATION_INCLUDE_CONFIG_PHASE_ATTR;
 import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.LOCATION_INCLUDE_MODE_ATTR;
 import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.LOCATION_INCLUDE_PLATFORMS_ATTR;
+import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.LOCATION_FOLLOW_REPOSITORY_REFERENCES_ATTR;
 import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.LOCATION_INCLUDE_SOURCE_ATTR;
 import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.LOCATION_TYPE_ATTR;
 import static org.eclipse.pde.internal.genericeditor.target.extension.model.ITargetConstants.MISSING_MANIFEST;
@@ -41,8 +42,9 @@ public class TargetPlatformAttributeRule extends WordRule {
 
 	private static final String[] ATTRIBUTES = new String[] { TARGET_NAME_ATTR, UNIT_VERSION_ATTR, UNIT_ID_ATTR,
 			LOCATION_INCLUDE_PLATFORMS_ATTR, LOCATION_INCLUDE_MODE_ATTR, LOCATION_TYPE_ATTR, REPOSITORY_LOCATION_ATTR,
-			TARGET_JRE_PATH_ATTR, TARGET_SEQ_NO_ATTR, LOCATION_INCLUDE_CONFIG_PHASE_ATTR, LOCATION_INCLUDE_SOURCE_ATTR,
-			INCLUDE_DEPENDENCY_DEPTH, INCLUDE_DEPENDENCY_SCOPES, MISSING_MANIFEST };
+			TARGET_JRE_PATH_ATTR, TARGET_SEQ_NO_ATTR, LOCATION_INCLUDE_CONFIG_PHASE_ATTR,
+			LOCATION_FOLLOW_REPOSITORY_REFERENCES_ATTR, LOCATION_INCLUDE_SOURCE_ATTR, INCLUDE_DEPENDENCY_DEPTH,
+			INCLUDE_DEPENDENCY_SCOPES, MISSING_MANIFEST };
 	private final IToken attributeToken = new Token(
 			new TextAttribute(PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getColorRegistry()
 					.get(IGETEColorConstants.P_ATTRIBUTE)));

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditIUContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/EditIUContainerPage.java
@@ -110,6 +110,7 @@ public class EditIUContainerPage extends WizardPage implements IEditBundleContai
 	private Button fAllPlatformsButton;
 	private Button fIncludeSourceButton;
 	private Button fConfigurePhaseButton;
+	private Button fFollowRepositoryReferencesButton;
 	private Text fDetailsText;
 	private final ProvisioningUI profileUI;
 	private Thread refreshThread;
@@ -154,6 +155,7 @@ public class EditIUContainerPage extends WizardPage implements IEditBundleContai
 		flags |= fAllPlatformsButton.getSelection() ? IUBundleContainer.INCLUDE_ALL_ENVIRONMENTS : 0;
 		flags |= fIncludeSourceButton.getSelection() ? IUBundleContainer.INCLUDE_SOURCE : 0;
 		flags |= fConfigurePhaseButton.getSelection() ? IUBundleContainer.INCLUDE_CONFIGURE_PHASE : 0;
+		flags |= fFollowRepositoryReferencesButton.getSelection() ? IUBundleContainer.FOLLOW_REPOSITORY_REFERENCES : 0;
 		IUBundleContainer container = (IUBundleContainer) service.newIULocation(fAvailableIUGroup.getCheckedLeafIUs(), fRepoLocation != null ? new URI[] {fRepoLocation} : null, flags);
 		return container;
 	}
@@ -409,6 +411,8 @@ public class EditIUContainerPage extends WizardPage implements IEditBundleContai
 		fIncludeSourceButton.addSelectionListener(widgetSelectedAdapter(e -> warnIfGlobalSettingChanged()));
 		fConfigurePhaseButton = SWTFactory.createCheckButton(slicerGroup, Messages.EditIUContainerPage_IncludeConfigurePhase, null, true, 1);
 		fConfigurePhaseButton.addSelectionListener(widgetSelectedAdapter(e -> warnIfGlobalSettingChanged()));
+		fFollowRepositoryReferencesButton = SWTFactory.createCheckButton(slicerGroup, Messages.EditIUContainerPage_17, null, true, 1);
+		fFollowRepositoryReferencesButton.addSelectionListener(widgetSelectedAdapter(e -> warnIfGlobalSettingChanged()));
 
 	}
 
@@ -431,6 +435,7 @@ public class EditIUContainerPage extends WizardPage implements IEditBundleContai
 				noChange &= fAllPlatformsButton.getSelection() == iuContainer.getIncludeAllEnvironments();
 				noChange &= fIncludeSourceButton.getSelection() == iuContainer.getIncludeSource();
 				noChange &= fConfigurePhaseButton.getSelection() == iuContainer.getIncludeConfigurePhase();
+				noChange &= fFollowRepositoryReferencesButton.getSelection() == iuContainer.IsFollowRepositoryReferences();
 			}
 		}
 		if (noChange) {
@@ -575,6 +580,7 @@ public class EditIUContainerPage extends WizardPage implements IEditBundleContai
 			fAllPlatformsButton.setSelection(fEditContainer.getIncludeAllEnvironments());
 			fIncludeSourceButton.setSelection(fEditContainer.getIncludeSource());
 			fConfigurePhaseButton.setSelection(fEditContainer.getIncludeConfigurePhase());
+			fFollowRepositoryReferencesButton.setSelection(fEditContainer.IsFollowRepositoryReferences());
 		} else {
 			// If we are creating a new container, but there is an existing iu container we should use it's settings (otherwise we overwrite them)
 			ITargetLocation[] knownContainers = fTarget.getTargetLocations();
@@ -585,6 +591,7 @@ public class EditIUContainerPage extends WizardPage implements IEditBundleContai
 						fAllPlatformsButton.setSelection(((IUBundleContainer) knownContainer).getIncludeAllEnvironments());
 						fIncludeSourceButton.setSelection(((IUBundleContainer) knownContainer).getIncludeSource());
 						fConfigurePhaseButton.setSelection(((IUBundleContainer) knownContainer).getIncludeConfigurePhase());
+						fFollowRepositoryReferencesButton.setSelection(((IUBundleContainer) knownContainer).IsFollowRepositoryReferences());
 					}
 				}
 			}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/Messages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/Messages.java
@@ -92,6 +92,7 @@ public class Messages extends NLS {
 	public static String EditIUContainerPage_14;
 	public static String EditIUContainerPage_15;
 	public static String EditIUContainerPage_16;
+	public static String EditIUContainerPage_17;
 	public static String EditIUContainerPage_2;
 	public static String EditIUContainerPage_3;
 	public static String EditIUContainerPage_4;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/messages.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/messages.properties
@@ -87,6 +87,7 @@ EditIUContainerPage_13=&Properties...
 EditIUContainerPage_14=&Group by Category
 EditIUContainerPage_15=Show only the latest &version
 EditIUContainerPage_16=Include source if available
+EditIUContainerPage_17=Follow repository references
 EditIUContainerPage_2=By default, all required software is added to the target based on its environment settings. Turning this option off allows software to be added with missing requirements and multiple environments.  This setting applies to the entire target definition. 
 EditIUContainerPage_3=Include required software
 EditIUContainerPage_4=Changing the included software settings will affect all sites in your target definition


### PR DESCRIPTION
Note: there might be another way to do this, as I found a few half-wired up places. However,  I couldn't find one while investigating my use case, so I added somewhat simple code that implements my use case.

I'm trying to proxy an entire target platform through an artifact repository, i.e., Nexus. As such, I've defined the software sites in my target platform to point to proxies of my own server. Sadly, it seems like p2 software sites are not necessarily self-contained. Namely, they can contain references to other repositories.

In our case, this causes us to load 122 external repos. Strikingly, most of these come from _disabled_ references. As such I've added some code that would skip over these, let me know if that isn't allowed for some reason.
Using only the enabled references, I still have 5 hits, much less, much faster, but not good enough. As such, I included a new backwards-compatible Software Site option that includes (or excludes) the traversal of references. In essence, this forces your software sites to be self-contained.

This ticket inspired another small ticket in [p2](https://github.com/eclipse-equinox/p2/pull/506).