### PR TITLE
[DS] Use simple class name for single-element property annotations

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/AnnotationVisitor.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/AnnotationVisitor.java
@@ -1328,8 +1328,9 @@ public class AnnotationVisitor extends ASTVisitor {
 
 	private void collectComponentPropertyTypes(IDSDocumentFactory dsFactory,
 			LinkedHashMap<String, IDSProperty> newPropMap, Annotation propertyType) {
-		String fqdn = propertyType.getTypeName().getFullyQualifiedName();
 		ITypeBinding propertyTypeBinding = propertyType.resolveTypeBinding();
+		String simpleName = propertyTypeBinding.getName();
+
 		String prefix = getPrefix(propertyTypeBinding);
 		IMethodBinding[] methods = propertyTypeBinding.getDeclaredMethods();
 		Map<String, IDSProperty> map = Arrays.stream(methods)
@@ -1347,7 +1348,7 @@ public class AnnotationVisitor extends ASTVisitor {
 		}
 		if (propertyType instanceof MarkerAnnotation && map.isEmpty()) {
 			IDSProperty property = dsFactory.createProperty();
-			property.setPropertyName(NameGenerator.createClassPropertyName(fqdn, prefix));
+			property.setPropertyName(NameGenerator.createClassPropertyName(simpleName, prefix));
 			property.setPropertyType(IDSConstants.VALUE_PROPERTY_TYPE_BOOLEAN);
 			property.setPropertyValue(String.valueOf(Boolean.TRUE));
 			newPropMap.remove(property.getName()); // force re-insert (append)
@@ -1356,7 +1357,7 @@ public class AnnotationVisitor extends ASTVisitor {
 		}
 		if (propertyType instanceof SingleMemberAnnotation single && map.size() == 1) {
 			IDSProperty property = dsFactory.createProperty();
-			property.setPropertyName(NameGenerator.createClassPropertyName(fqdn, prefix));
+			property.setPropertyName(NameGenerator.createClassPropertyName(simpleName, prefix));
 			Expression expression = single.getValue();
 			property.setPropertyType(getPropertyType(expression.resolveTypeBinding()));
 			setPropertyValue(property, expression);


### PR DESCRIPTION
Using the full name of the AST element representing a single-element property annotations to derive the property name, makes the generated annotation depend on the way a ComponentPropertyType annotation is applied. For example with fully-qualified name or with the outer-class if it's a inner class.
Instead the simple name of the resolved annotation class should be used as stated in the OSGi compendium spec in '112.8.2.1 Component Property Mapping' [1]:
```
However, if the component property type is a single-element annotation, see 9.7.3 in [7] The Java Language Specification,
Java SE 8 Edition, then the property name for the value method is derived from the name of the component property type
rather than the name of the method.

In this case, the simple name of the component property type, that is, the name of the class without any package name or outer
class name, if the component property type is an inner class, must be converted to the property name as follows:
```

Without this the generated component XML for the following class contains the wrong property names, instead of `event.topics` and `my.comp` the names are `org.osgi.service.event.propertytypes.event.topics` and `my.comp.my.type`.

```
package test.ds.component.props;

@Component(service = EventHandler.class)
@org.osgi.service.event.propertytypes.EventTopics(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
@MyComp.MyType(Map.class)
public class MyComp implements EventHandler {

	@ComponentPropertyType
	@Target(ElementType.TYPE)
	public @interface MyType {
		Class<?>[] value();
	}

	@Override
	public void handleEvent(Event event) {
	}
}
```

[1] - https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.component.html#service.component-component.property.mapping