### PR TITLE
Inline variable and remove JavaDoc in PluginsTab

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/PluginsTab.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/PluginsTab.java
@@ -217,16 +217,9 @@ public class PluginsTab extends AbstractLauncherTab {
 		return fImage;
 	}
 
-	/**
-	 * Validates the tab.  If the feature option is chosen, and the workspace is not correctly set up,
-	 * the error message is set.
-	 *
-	 * @see org.eclipse.pde.ui.launcher.AbstractLauncherTab#validateTab()
-	 */
 	@Override
 	public void validateTab() {
-		String errorMessage = null;
-		setErrorMessage(errorMessage);
+		setErrorMessage(null);
 	}
 
 	@Override


### PR DESCRIPTION
The JavaDoc is outdates and the variable is a null value