### PR TITLE
Only schedule a build if manifest builder is enabled for project

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
@@ -53,6 +53,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.build.BundleHelper;
 import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.builders.PDEBuilderHelper;
+import org.eclipse.pde.internal.core.natures.PDE;
 import org.eclipse.pde.internal.core.util.ManifestUtils;
 import org.eclipse.pde.internal.core.util.UtilMessages;
 import org.osgi.framework.BundleException;
@@ -300,7 +301,6 @@ public class MinimalState {
 			}
 		});
 	}
-	private static final String PDE_MANIFEST_BUILDER = "org.eclipse.pde.ManifestBuilder"; //$NON-NLS-1$
 
 	public static void triggerSystemPackagesReload() {
 		final String jobFamily = "pde.internal.ReresolveStateAfterVMorEEchanges"; //$NON-NLS-1$
@@ -336,9 +336,10 @@ public class MinimalState {
 		// Perform PDE-Manifest build, to re-validate all Manifests
 		MultiStatus status = new MultiStatus(MinimalState.class, 0, "Reload of JRE system-packages encountered issues"); //$NON-NLS-1$
 		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
-			if (PDEBuilderHelper.isPDEProject(project)) {
+			if (PDEBuilderHelper.hasManifestBuilder(project)) {
 				try {
-					project.build(IncrementalProjectBuilder.FULL_BUILD, PDE_MANIFEST_BUILDER, null, null);
+					project.build(IncrementalProjectBuilder.FULL_BUILD, PDE.MANIFEST_BUILDER_ID, null,
+							null);
 				} catch (CoreException e) { // ignore
 					status.add(e.getStatus());
 				}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestConsistencyChecker.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestConsistencyChecker.java
@@ -42,7 +42,6 @@ import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDECoreMessages;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
-import org.eclipse.pde.internal.core.natures.PDE;
 import org.eclipse.pde.internal.core.project.PDEProject;
 import org.osgi.framework.Bundle;
 
@@ -247,6 +246,12 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 	}
 
 	private void validateProject(int type, IProgressMonitor monitor) {
+		if (!PDEBuilderHelper.hasManifestBuilder(getProject())) {
+			ILog.get().error(String.format(
+					"eclipse.pde/issues/1185: validateBuildPropertiesExists called for project without ManifestBuilder: %s", //$NON-NLS-1$
+					getProject().getName()), new IllegalStateException());
+			return;
+		}
 		SubMonitor subMonitor = SubMonitor.convert(monitor, PDECoreMessages.ManifestConsistencyChecker_builderTaskName, getWorkAmount(type));
 		if ((type & STRUCTURE) != 0) {
 			validateProjectStructure(type, subMonitor.split(1));
@@ -374,14 +379,6 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 			}
 			// if build.properties doesn't exist and build problems != IGNORE, create a marker on the project bug 172451
 			try {
-				if (!project.hasNature(PDE.PLUGIN_NATURE)) {
-					// how did this happen?
-					ILog.get().error(
-							"eclipse.pde/issues/1185: validateBuildPropertiesExists called for project without plugin nature: " //$NON-NLS-1$
-									+ project.getName(), 
-							new IllegalStateException());
-					return;
-				}
 				Map<String, Object> attributes = new HashMap<>();
 				attributes.put(IMarker.SEVERITY, CompilerFlags.ERROR == severity ? IMarker.SEVERITY_ERROR : IMarker.SEVERITY_WARNING);
 				attributes.put(IMarker.MESSAGE, PDECoreMessages.ManifestConsistencyChecker_buildDoesNotExist);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEBuilderHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEBuilderHelper.java
@@ -14,10 +14,12 @@
 package org.eclipse.pde.internal.core.builders;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.pde.core.build.IBuild;
@@ -74,6 +76,18 @@ public class PDEBuilderHelper {
 	public static boolean isPDEProject(IProject project) {
 		return project != null && project.isAccessible()
 				&& (PDE.hasPluginNature(project) || PDE.hasFeatureNature(project) || PDE.hasUpdateSiteNature(project));
+	}
+
+	public static boolean hasManifestBuilder(IProject project) {
+		if (project != null && project.isAccessible()) {
+			try {
+				return Arrays.stream(project.getDescription().getBuildSpec())
+						.anyMatch(cmd -> PDE.MANIFEST_BUILDER_ID.equals(cmd.getBuilderName()));
+			} catch (CoreException e) {
+				// must assume then that it has not the required builder
+			}
+		}
+		return false;
 	}
 
 }


### PR DESCRIPTION
Currently MinimalState schedules a build for every project that has any PDE nature, this can lead to projects scanned that have no ManifestBuilder enabled at all and creating unrelated warnings.

This now checks if the builder is enabled for the project before scheduling a build. Also the check for possible invalid invocations is moved up so it is triggered even if a build.properties exits.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/1185