### PR TITLE
[PDE-Build] Always use the OSGi profiles provided by the runtime bundle

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -823,13 +823,6 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 		state.resolve();
 	}
 
-	private File getOSGiLocation() {
-		BundleDescription osgiBundle = state.getBundle(BUNDLE_OSGI, null);
-		if (osgiBundle == null)
-			return null;
-		return new File(osgiBundle.getLocation());
-	}
-
 	private String[] getJavaProfiles() {
 		return getProfileManager().getJavaProfiles();
 	}
@@ -884,20 +877,7 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 
 	public ProfileManager getProfileManager() {
 		if (profileManager == null) {
-			File osgi = getOSGiLocation();
-			String[] sources = null;
-			if (osgi != null) {
-				if (eeSources != null) {
-					sources = new String[eeSources.length + 1];
-					sources[0] = osgi.getAbsolutePath();
-					System.arraycopy(eeSources, 0, sources, 1, eeSources.length);
-				} else {
-					sources = new String[] {osgi.getAbsolutePath()};
-				}
-				profileManager = new ProfileManager(sources, false);
-			} else {
-				profileManager = new ProfileManager(eeSources, true);
-			}
+			profileManager = new ProfileManager(eeSources, true);
 		}
 		return profileManager;
 	}


### PR DESCRIPTION
The code in PDE(-build) usually only matches respectively is adapted to content of the profiles provided by the org.eclipse.osgi bundle of the same release and not necessarily of previous or even future releases. For example with https://github.com/eclipse-pde/eclipse.pde/pull/1239 PDE-build now relies on the system.packages provided by the JRE-1.1 profile in o.e.osgi since this release. Of course these profiles are missing in previous versions of o.e.osgi. This causes errors during PDE's product export if an earlier version of o.e.osgi is in the target-platform because the system.packages for the JRE-1.1 are then null/empty.
