### PR TITLE
[PDE-Build] Copy Eclipse-BundleShape and other headers in wrapped states

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -104,6 +104,10 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 		addedBundle = new ArrayList<>();
 		unqualifiedBundles = new ArrayList<>();
 		//forceQualifiers();
+		for (BundleDescription bundle : state.getBundles()) {
+			Dictionary<String, String> manifest = loadManifest(new File(bundle.getLocation()));
+			rememberManifestEntries(bundle, manifest, MANIFEST_ENTRIES);
+		}
 	}
 
 	public PDEState() {


### PR DESCRIPTION
For wrapped OSGi States obtained from pde.core/ui the Manifest 'Eclipse-BundleShape' entries, besides others, were not copied into the bundle's user-object Properties. This had the consequence that in ShapeAdvisor.getUnpackClause() the value of that entry could never be considered.
https://github.com/eclipse-pde/eclipse.pde/blob/c2d4b0c101bbcb0697edd9b8edf2a1aeb8e71b16/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ShapeAdvisor.java#L110-L113

The method only used to return the expected boolean value because of corresponding unpack-attributes in 'plugin' entries of feature.xml files. But since the removal of that otherwise unused attribute in https://github.com/eclipse-pde/eclipse.pde/pull/770 this makeshift was gone and ShapeAdvisor.getUnpackClause() always return false leading to all bundles in an exported product being in jar-shape, even if the 'Eclipse-BundleShape' entry in the MANIFEST.MF told something different.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/995
