### PR TITLE
Fire the correct property in Product#setIncludeJre

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/Product.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/Product.java
@@ -900,7 +900,7 @@ public class Product extends ProductObject implements IProduct {
 		boolean old = fIncludeJre;
 		fIncludeJre = include;
 		if (isEditable()) {
-			firePropertyChanged(P_INCLUDE_LAUNCHERS, Boolean.toString(old), Boolean.toString(fIncludeJre));
+			firePropertyChanged(P_INCLUDE_JRE, Boolean.toString(old), Boolean.toString(fIncludeJre));
 		}
 
 	}


### PR DESCRIPTION
The property should be P_INCLUDE_JRE not P_INCLUDE_LAUNCHERS

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1278