### PR TITLE
Shortcut to Target Platform preferences in editor

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -39,6 +39,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String AbstractTargetPage_reloadTarget;
 
+	public static String AbstractTargetPage_openPreferences;
+
 	public static String AddActivationHeaderResolution_label;
 
 	public static String AddAutomaticModuleResolution_desc;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -70,6 +70,7 @@ import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.eclipse.pde.internal.ui.preferences.TargetPlatformPreferencePage;
 import org.eclipse.pde.internal.ui.shared.target.ITargetChangedListener;
 import org.eclipse.pde.internal.ui.shared.target.TargetContentsGroup;
 import org.eclipse.pde.internal.ui.shared.target.TargetLocationsGroup;
@@ -87,6 +88,7 @@ import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.dialogs.SaveAsDialog;
 import org.eclipse.ui.forms.AbstractFormPart;
 import org.eclipse.ui.forms.HyperlinkGroup;
@@ -406,8 +408,19 @@ public class TargetEditor extends FormEditor {
 		export.setToolTipText("Export"); //$NON-NLS-1$
 		export.setImageDescriptor(PDEPluginImages.DESC_EXPORT_TARGET_TOOL);
 
+		Action openTPPreference = new Action("openTPPreference") { //$NON-NLS-1$
+			@Override
+			public void run() {
+				PreferencesUtil.createPreferenceDialogOn(getSite().getShell(), TargetPlatformPreferencePage.PAGE_ID,
+						null, null).open();
+			}
+		};
+		openTPPreference.setToolTipText(PDEUIMessages.AbstractTargetPage_openPreferences);
+		openTPPreference.setImageDescriptor(PDEPluginImages.DESC_SETTINGS_OBJ);
+
 		form.getToolBarManager().add(setAsTarget);
 		form.getToolBarManager().add(export);
+		form.getToolBarManager().add(openTPPreference);
 		form.getToolBarManager().add(help);
 		form.updateToolBar();
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -488,6 +488,7 @@ SchemaAttributeDetails_use=Use:
 AbstractPluginBlock_counter={0} out of {1} selected
 AbstractTargetPage_setTarget=Set as Active Target Platform
 AbstractTargetPage_reloadTarget=Reload Target Platform
+AbstractTargetPage_openPreferences=Open the Target Platform preferences
 ###### Launchers #######################################
 MainTab_name = &Main
 MainTab_AttributeLabel_LauncherPDEVersion=PDE version


### PR DESCRIPTION
This helps when a user wants to switch between target definitions without the need of either navigating to another target definition file or the preference page listing all Target Platforms.

Resolves #1281