### PR TITLE
Add a new "Modify" button to Execution Environment section

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -2901,6 +2901,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String EditorUtilities_missingIcoNote;
 
+	public static String RequiredExecutionEnvironmentSection_modify;
+
 	public static String RequiredExecutionEnvironmentSection_add;
 
 	public static String RequiredExecutionEnvironmentSection_remove;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2283,6 +2283,7 @@ GetNonExternalizedStringsAction_allExternalizedMessage=All strings in manifest f
 RequiredExecutionEnvironmentSection_title=Execution Environments
 RequiredExecutionEnvironmentSection_add=Add...
 RequiredExecutionEnvironmentSection_remove=Remove
+RequiredExecutionEnvironmentSection_modify=Modify...
 RequiredExecutionEnvironmentSection_fragmentDesc=Specify the minimum execution environments required to run this fragment.
 RequiredExecutionEnvironmentSection_pluginDesc=Specify the minimum execution environments required to run this plug-in.
 RequiredExecutionEnvironmentSection_dialog_title=Execution Environments


### PR DESCRIPTION
Fixes : #1178

A new "Modify" button that allows to select the new EE, removes all old ones and updates the classpath in one go.

As part of this, this dialog should then be sorted by EE in descending order (highest EE first):