### PR TITLE
Open edit launch dialog using correct mode

### DIFF
--- a/features/org.eclipse.pde.unittest.junit-feature/feature.xml
+++ b/features/org.eclipse.pde.unittest.junit-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde.unittest.junit"
       label="%featureName"
-      version="1.0.800.qualifier"
+      version="1.0.900.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/EclipsePluginValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/EclipsePluginValidationOperation.java
@@ -40,7 +40,11 @@ public class EclipsePluginValidationOperation extends LaunchValidationOperation 
 	private final Map<Object, Object[]> fExtensionErrors = new HashMap<>(2);
 
 	public EclipsePluginValidationOperation(ILaunchConfiguration configuration, Set<IPluginModelBase> models) {
-		super(configuration, models);
+		this(configuration, models, null);
+	}
+
+	public EclipsePluginValidationOperation(ILaunchConfiguration configuration, Set<IPluginModelBase> models, String launchMode) {
+		super(configuration, models, launchMode);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchValidationOperation.java
@@ -43,11 +43,17 @@ public class LaunchValidationOperation implements IWorkspaceRunnable {
 
 	private BundleValidationOperation fOperation;
 	public final ILaunchConfiguration fLaunchConfiguration;
+	public final String fLaunchMode;
 	protected final Set<IPluginModelBase> fModels;
 
 	public LaunchValidationOperation(ILaunchConfiguration configuration, Set<IPluginModelBase> models) {
+		this(configuration, models, null);
+	}
+
+	public LaunchValidationOperation(ILaunchConfiguration configuration, Set<IPluginModelBase> models, String launchMode) {
 		fLaunchConfiguration = configuration;
 		fModels = models;
+		fLaunchMode = launchMode;
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/ProductValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/ProductValidationOperation.java
@@ -24,7 +24,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 public class ProductValidationOperation extends LaunchValidationOperation {
 
 	public ProductValidationOperation(Set<IPluginModelBase> models) {
-		super(null, models);
+		super(null, models, null);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/AbstractPDELaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/AbstractPDELaunchConfiguration.java
@@ -75,6 +75,7 @@ import org.osgi.framework.Version;
 public abstract class AbstractPDELaunchConfiguration extends LaunchConfigurationDelegate {
 
 	protected File fConfigDir = null;
+	String launchMode;
 
 	/**
 	 * This field will control the addition of argument --add-modules=ALL-SYSTEM in the VM arguments
@@ -427,6 +428,7 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 	 * from the launch configuration
 	 */
 	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
+		launchMode = launch.getLaunchMode();
 		String attribute = launch.getAttribute(PDE_LAUNCH_SHOW_COMMAND);
 		boolean isShowCommand = false;
 		if (attribute != null) {
@@ -439,7 +441,6 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 				validatePluginDependencies(configuration, subMonitor.split(10));
 			}
 			validateProjectDependencies(configuration, subMonitor.split(10));
-			LauncherUtils.setLastLaunchMode(launch.getLaunchMode());
 			clear(configuration, subMonitor.split(10));
 		}
 		launch.setAttribute(PDE_LAUNCH_SHOW_COMMAND, "false"); //$NON-NLS-1$
@@ -556,7 +557,7 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 	 */
 	protected void validatePluginDependencies(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
 		Set<IPluginModelBase> models = BundleLauncherHelper.getMergedBundleMap(configuration, false).keySet();
-		EclipsePluginValidationOperation op = new EclipsePluginValidationOperation(configuration, models);
+		EclipsePluginValidationOperation op = new EclipsePluginValidationOperation(configuration, models, launchMode);
 		LaunchPluginValidator.runValidationOperation(op, monitor);
 	}
 

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
@@ -195,7 +195,7 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 		}
 
 		// Clear workspace and prompt, if necessary
-		LauncherUtils.clearWorkspace(configuration, fWorkspaceLocation, subMon.split(1));
+		LauncherUtils.clearWorkspace(configuration, fWorkspaceLocation, launchMode, subMon.split(1));
 
 		// clear config area, if necessary
 		if (configuration.getAttribute(IPDELauncherConstants.CONFIG_CLEAR_AREA, false)) {
@@ -238,7 +238,7 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 
 	@Override
 	protected void validatePluginDependencies(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
-		EclipsePluginValidationOperation op = new EclipsePluginValidationOperation(configuration, fModels.keySet());
+		EclipsePluginValidationOperation op = new EclipsePluginValidationOperation(configuration, fModels.keySet(), launchMode);
 		LaunchPluginValidator.runValidationOperation(op, monitor);
 	}
 

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
@@ -192,7 +192,7 @@ public class EquinoxLaunchConfiguration extends AbstractPDELaunchConfiguration {
 
 	@Override
 	protected void validatePluginDependencies(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
-		LaunchValidationOperation op = new LaunchValidationOperation(configuration, fModels.keySet());
+		LaunchValidationOperation op = new LaunchValidationOperation(configuration, fModels.keySet(), launchMode);
 		LaunchPluginValidator.runValidationOperation(op, monitor);
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginStatusDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginStatusDialog.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.debug.ui.ILaunchGroup;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
@@ -45,9 +47,9 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 
 /**
- * Dialog that opens when plug-in validation fails during launching.  Displays
- * a list of problems discovered.  Allows the user to continue the launch or
- * cancel if @link {@link #showCancelButton(boolean)} is set to true.
+ * Dialog that opens when plug-in validation fails during launching. Displays a
+ * list of problems discovered. Allows the user to continue the launch or cancel
+ * if @link {@link #showCancelButton(boolean)} is set to true.
  */
 public class PluginStatusDialog extends TrayDialog {
 
@@ -92,6 +94,7 @@ public class PluginStatusDialog extends TrayDialog {
 	private Map<?, ?> fInput;
 	private TreeViewer treeViewer;
 	private ILaunchConfiguration fLaunchConfiguration;
+	private String launchMode;
 
 	public PluginStatusDialog(Shell parentShell, int style) {
 		super(parentShell);
@@ -116,6 +119,7 @@ public class PluginStatusDialog extends TrayDialog {
 	public void setInput(LaunchValidationOperation operation) {
 		fInput = operation.getInput();
 		fLaunchConfiguration = operation.fLaunchConfiguration;
+		launchMode = operation.fLaunchMode;
 	}
 
 	@Override
@@ -154,8 +158,12 @@ public class PluginStatusDialog extends TrayDialog {
 				// Closing the validation dialog to avoid cyclic dependency
 				setReturnCode(CANCEL);
 				close();
+				ILaunchGroup launchGroup = DebugUITools.getLaunchGroup(fLaunchConfiguration, launchMode);
+				String groupIdentifier = launchGroup != null //
+						? launchGroup.getIdentifier()
+						: IDebugUIConstants.ID_RUN_LAUNCH_GROUP;
 				DebugUITools.openLaunchConfigurationDialog(Display.getCurrent().getActiveShell(), fLaunchConfiguration,
-						"org.eclipse.debug.ui.launchGroup.run", null); //$NON-NLS-1$
+						groupIdentifier, null);
 			}));
 		}
 	}
@@ -195,11 +203,9 @@ public class PluginStatusDialog extends TrayDialog {
 		return super.close();
 	}
 
-
 	protected String getDialogSectionName() {
 		return PDEPlugin.getPluginId() + ".PLUGIN_STATUS_DIALOG"; //$NON-NLS-1$
 	}
-
 
 	public void refresh(Map<?, ?> input) {
 		fInput = input;

--- a/ui/org.eclipse.pde.unittest.junit/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.pde.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.unittest.junit;singleton:=true
-Bundle-Version: 1.1.400.qualifier
+Bundle-Version: 1.1.500.qualifier
 Bundle-Activator: org.eclipse.pde.unittest.junit.JUnitPluginTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -357,6 +357,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 	 */
 	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor)
 			throws CoreException {
+		launchMode = launch.getLaunchMode();
 		fWorkspaceLocation = null;
 		fConfigDir = null;
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, false);
@@ -377,7 +378,6 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 			if (autoValidate)
 				validatePluginDependencies(configuration, subMonitor.split(1));
 			validateProjectDependencies(configuration, subMonitor.split(1));
-			LauncherUtils.setLastLaunchMode(launch.getLaunchMode());
 			clear(configuration, subMonitor.split(1));
 		}
 		launch.setAttribute(PDE_JUNIT_SHOW_COMMAND, "false"); //$NON-NLS-1$
@@ -1013,6 +1013,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 
 	// key is a model, value is startLevel:autoStart
 	private Map<IPluginModelBase, String> fModels;
+	private String launchMode;
 
 	private static final String PDE_JUNIT_SHOW_COMMAND = "pde.junit.showcommandline"; //$NON-NLS-1$
 
@@ -1234,7 +1235,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 		SubMonitor subMon = SubMonitor.convert(monitor, 50);
 
 		// Clear workspace and prompt, if necessary
-		LauncherUtils.clearWorkspace(configuration, fWorkspaceLocation, subMon.split(25));
+		LauncherUtils.clearWorkspace(configuration, fWorkspaceLocation, launchMode, subMon.split(25));
 
 		subMon.setWorkRemaining(25);
 
@@ -1267,7 +1268,8 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 	 */
 	protected void validatePluginDependencies(ILaunchConfiguration configuration, IProgressMonitor monitor)
 			throws CoreException {
-		EclipsePluginValidationOperation op = new EclipsePluginValidationOperation(configuration, fModels.keySet());
+		EclipsePluginValidationOperation op = new EclipsePluginValidationOperation(configuration, fModels.keySet(),
+				launchMode);
 		LaunchPluginValidator.runValidationOperation(op, monitor);
 	}
 }


### PR DESCRIPTION
When a launch fails validation, the user is given a link to Edit Launch Configuration. Previously, this link always opened the Edit Run Configurations dialog in Run mode, even if the user initially attempted to Debug. This change ensures that the edit dialog is opening using the original mode.