### PR TITLE
Fix: API tool reports fictitious changes to execution environment

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/.classpath
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/.project
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>bundle.b</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: API Tools Tests Plug-in B
+Bundle-SymbolicName: bundle.b
+Bundle-Version: 1.0.0
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
+Export-Package: test

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/src/test/Stub.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.b/src/test/Stub.java
@@ -1,0 +1,2 @@
+package test;
+public class Stub {}


### PR DESCRIPTION
The API tool only checks the Bundle-RequiredExecutionEnvironment header when comparing the baseline with the workspace bundle. If the EE of the baseline bundle is described via the Require-Capability header, an empty string is compared to the workspace EE, which is treated as an incompatibility.

This also adds a simple test case where the execution environment of two bundles is checked. One bundle uses the  Require-Capability, the other one the Bundle-RequiredExecutionEnvironment header.

Resolves https://github.com/eclipse-pde/eclipse.pde/issues/1301
