### PR TITLE
BundleComponent.isValidBundle() should no throw if reading manifest fail

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
@@ -268,9 +268,15 @@ public class BundleComponent extends Component {
 	 *
 	 * @return true if the bundle at the given location is valid false otherwise
 	 */
-	public boolean isValidBundle() throws CoreException {
-		Map<String, String> manifest = getManifest();
-		return manifest != null && (manifest.get(Constants.BUNDLE_NAME) != null && manifest.get(Constants.BUNDLE_VERSION) != null);
+	public boolean isValidBundle() {
+		try {
+			Map<String, String> manifest = getManifest();
+			return manifest != null
+					&& (manifest.get(Constants.BUNDLE_NAME) != null && manifest.get(Constants.BUNDLE_VERSION) != null);
+		} catch (CoreException e) {
+			// if loading the manifest fails, this is NOT a valid bundle obviously...
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Currently BundleComponent.isValidBundle() is used to check if a bundle is valid and should be considered for the baseline. If the location points to something that chase no manifest at all (or an invalid manifest) this currently an exception even though the API doc clearly states that "Validity is determined via the existence of a readable manifest file"

This now adds two checks

1) the location points to a file that exits and is larger than zero bytes
2) parsing the manifest from the location do not throw an exception

This error can be seen for example here:
https://ci.eclipse.org/equinox/job/p2/job/PR-524/8/console