### PR TITLE
Remove old 1.x Java compiler versions support from PDE tests

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.api.tools.tests
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.pde.api.tools;bundle-version="1.0.600",

--- a/apitools/org.eclipse.pde.api.tools.tests/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools.tests/pom.xml
@@ -18,7 +18,7 @@
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.pde.api.tools.tests</artifactId>
-	<version>1.3.500-SNAPSHOT</version>
+	<version>1.3.600-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
@@ -419,7 +419,7 @@ public abstract class ApiBuilderTest extends BuilderTests {
 	 * @return the default compiler compliance to use for the test
 	 */
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_4;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**
@@ -449,7 +449,19 @@ public abstract class ApiBuilderTest extends BuilderTests {
 				String[] messageArgs = args[i];
 				int messageId = ApiProblemFactory.getProblemMessageId(expectedProblemIds[i]);
 				String message = ApiProblemFactory.getLocalizedMessage(messageId, messageArgs);
-				assertTrue("Missing expected problem: " + message, messages.remove(message)); //$NON-NLS-1$
+
+				boolean match = messages.remove(message);
+				if (!match) {
+					System.err.println("Observed problems:"); //$NON-NLS-1$
+					for (ApiProblem p : problems) {
+						System.err.println(p);
+					}
+					System.err.println("Expected massages:"); //$NON-NLS-1$
+					for (String p : messages) {
+						System.err.println(p);
+					}
+				}
+				assertTrue("Missing expected problem: " + message, match); //$NON-NLS-1$
 			}
 			if (messages.size() > 0) {
 				StringBuilder buffer = new StringBuilder();

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiTestingEnvironment.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiTestingEnvironment.java
@@ -100,22 +100,10 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	public void setProjectCompliance(IJavaProject project, String compliance) {
 		int requiredComplianceFlag = 0;
 		String compilerVersion = null;
-		if (JavaCore.VERSION_1_4.equals(compliance)) {
-			requiredComplianceFlag = AbstractCompilerTest.F_1_4;
-			compilerVersion = JavaCore.VERSION_1_4;
-		} else if (JavaCore.VERSION_1_5.equals(compliance)) {
-			requiredComplianceFlag = AbstractCompilerTest.F_1_5;
-			compilerVersion = JavaCore.VERSION_1_5;
-		} else if (JavaCore.VERSION_1_6.equals(compliance)) {
-			requiredComplianceFlag = AbstractCompilerTest.F_1_6;
-			compilerVersion = JavaCore.VERSION_1_6;
-		} else if (JavaCore.VERSION_1_7.equals(compliance)) {
-			requiredComplianceFlag = AbstractCompilerTest.F_1_7;
-			compilerVersion = JavaCore.VERSION_1_7;
-		} else if (JavaCore.VERSION_1_8.equals(compliance)) {
+		if (JavaCore.VERSION_1_8.equals(compliance)) {
 			requiredComplianceFlag = AbstractCompilerTest.F_1_8;
 			compilerVersion = JavaCore.VERSION_1_8;
-		} else if (!JavaCore.VERSION_1_4.equals(compliance) && !JavaCore.VERSION_1_3.equals(compliance)) {
+		} else {
 			throw new UnsupportedOperationException("Test framework doesn't support compliance level: " + compliance); //$NON-NLS-1$
 		}
 		if (requiredComplianceFlag != 0) {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/annotations/AnnotationTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/annotations/AnnotationTest.java
@@ -134,7 +134,7 @@ public abstract class AnnotationTest extends ApiBuilderTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/leak/ClassExtendsLeak.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/leak/ClassExtendsLeak.java
@@ -59,7 +59,7 @@ public class ClassExtendsLeak extends LeakTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/performance/EnumIncrementalBuildTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/performance/EnumIncrementalBuildTests.java
@@ -41,7 +41,7 @@ public class EnumIncrementalBuildTests extends IncrementalBuildTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidAnnotationFieldTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidAnnotationFieldTagTests.java
@@ -44,7 +44,7 @@ public class InvalidAnnotationFieldTagTests extends InvalidFieldTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public void testInvalidAnnotationFieldTag1I() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidAnnotationMethodTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidAnnotationMethodTagTests.java
@@ -32,7 +32,7 @@ public class InvalidAnnotationMethodTagTests extends InvalidMethodTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidAnnotationTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidAnnotationTagTests.java
@@ -52,7 +52,7 @@ public class InvalidAnnotationTagTests extends TagTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public void testInvalidAnnotationTag3I() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidDuplicateTagsTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidDuplicateTagsTests.java
@@ -60,7 +60,7 @@ public class InvalidDuplicateTagsTests extends TagTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumConstantTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumConstantTagTests.java
@@ -44,7 +44,7 @@ public class InvalidEnumConstantTagTests extends InvalidFieldTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public void testInvalidEnumConstantTag1I() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumFieldTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumFieldTagTests.java
@@ -44,7 +44,7 @@ public class InvalidEnumFieldTagTests extends InvalidFieldTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public void testInvalidEnumFieldTag1I() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumMethodTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumMethodTagTests.java
@@ -32,7 +32,7 @@ public class InvalidEnumMethodTagTests extends InvalidMethodTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/InvalidEnumTagTests.java
@@ -52,7 +52,7 @@ public class InvalidEnumTagTests extends TagTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public void testInvalidEnumTag1I() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/ValidAnnotationTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/ValidAnnotationTagTests.java
@@ -41,7 +41,7 @@ public class ValidAnnotationTagTests extends InvalidAnnotationTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/ValidEnumFieldTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/ValidEnumFieldTagTests.java
@@ -43,7 +43,7 @@ public class ValidEnumFieldTagTests extends ValidFieldTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/ValidEnumMethodTagTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/ValidEnumMethodTagTests.java
@@ -31,7 +31,7 @@ public class ValidEnumMethodTagTests extends ValidMethodTagTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/AnnotationUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/AnnotationUsageTests.java
@@ -46,7 +46,7 @@ public class AnnotationUsageTests extends UsageTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public static Test suite() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/ClassUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/ClassUsageTests.java
@@ -336,13 +336,17 @@ public class ClassUsageTests extends UsageTest {
 	private void x19(boolean inc) {
 		int localId = getProblemId(IApiProblem.ILLEGAL_IMPLEMENT, IApiProblem.LOCAL_TYPE);
 		int indId = getProblemId(IApiProblem.ILLEGAL_IMPLEMENT, IApiProblem.INDIRECT_LOCAL_REFERENCE);
-		setExpectedProblemIds(new int[] {localId, indId});
+		setExpectedProblemIds(new int[] {localId, indId, localId, indId});
 		String typename = "testC11"; //$NON-NLS-1$
 		setExpectedLineMappings(new LineMapping[] {
+				new LineMapping(24, localId, new String[] { "local3", "x.y.z.testC11.inner1.method2()", "INoImpl3" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				new LineMapping(26, indId, new String[] { "local4", "x.y.z.testC11.inner1.method2()", "INoImpl6", "INoImpl2" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 				new LineMapping(32, localId, new String[] { "local1", "x.y.z.testC11.method1()", "INoImpl2" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				new LineMapping(34, indId, new String[] { "local2", "x.y.z.testC11.method1()", "INoImpl5", "INoImpl2" }) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		});
 		setExpectedMessageArgs(new String[][] {
+				{"local3", "x.y.z.testC11.inner1.method2()", "INoImpl3"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				{"local4", "x.y.z.testC11.inner1.method2()", "INoImpl6", "INoImpl2"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 				{"local1", "x.y.z.testC11.method1()", "INoImpl2"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				{"local2", "x.y.z.testC11.method1()", "INoImpl5", "INoImpl2"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		});
@@ -375,12 +379,15 @@ public class ClassUsageTests extends UsageTest {
 
 	private void x20(boolean inc) {
 		int indId = getProblemId(IApiProblem.ILLEGAL_IMPLEMENT, IApiProblem.INDIRECT_LOCAL_REFERENCE);
-		setExpectedProblemIds(new int[] {indId});
+		setExpectedProblemIds(new int[] {indId, indId});
 		setExpectedLineMappings(new LineMapping[] {
+				new LineMapping(21, indId,
+						new String[] { "local4", "x.y.z.testC12.inner1.method2()", "INoImpl5", "INoImpl2" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 				new LineMapping(27, indId,
 						new String[] { "local2", "x.y.z.testC12.method1()", "INoImpl5", "INoImpl2" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			});
 		setExpectedMessageArgs(new String[][] {
+				{"local4", "x.y.z.testC12.inner1.method2()", "INoImpl5", "INoImpl2"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 				{"local2", "x.y.z.testC12.method1()", "INoImpl5", "INoImpl2"} //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		});
 		String typename = "testC12"; //$NON-NLS-1$
@@ -412,11 +419,13 @@ public class ClassUsageTests extends UsageTest {
 
 	private void x21(boolean inc) {
 		int indId = getProblemId(IApiProblem.ILLEGAL_IMPLEMENT, IApiProblem.ANONYMOUS_TYPE);
-		setExpectedProblemIds(new int[] {indId});
+		setExpectedProblemIds(new int[] { indId, indId });
 		setExpectedLineMappings(new LineMapping[] {
+				new LineMapping(22, indId, new String[] { "x.y.z.testC13.inner.method()", "INoImpl2" }), //$NON-NLS-1$ //$NON-NLS-2$
 				new LineMapping(28, indId, new String[] { "x.y.z.testC13.testC13()", "INoImpl2" }) //$NON-NLS-1$ //$NON-NLS-2$
 			});
 		setExpectedMessageArgs(new String[][] {
+				{ "x.y.z.testC13.inner.method()", "INoImpl2" }, //$NON-NLS-1$ //$NON-NLS-2$
 				{"x.y.z.testC13.testC13()", "INoImpl2"} //$NON-NLS-1$ //$NON-NLS-2$
 		});
 		String typename = "testC13"; //$NON-NLS-1$

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/EnumUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/EnumUsageTests.java
@@ -41,7 +41,7 @@ public class EnumUsageTests extends UsageTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	public static Test suite() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/FragmentUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/FragmentUsageTests.java
@@ -36,7 +36,7 @@ public class FragmentUsageTests extends UsageTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java5ClassUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java5ClassUsageTests.java
@@ -33,7 +33,7 @@ public class Java5ClassUsageTests extends ClassUsageTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	/**

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java5FieldUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java5FieldUsageTests.java
@@ -39,7 +39,7 @@ public class Java5FieldUsageTests extends FieldUsageTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java5MethodUsageTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java5MethodUsageTests.java
@@ -42,7 +42,7 @@ public class Java5MethodUsageTests extends MethodUsageTests {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_5;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java7UsageTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/usage/Java7UsageTest.java
@@ -42,7 +42,7 @@ public abstract class Java7UsageTest extends ApiBuilderTest {
 
 	@Override
 	protected String getTestCompliance() {
-		return JavaCore.VERSION_1_7;
+		return JavaCore.VERSION_1_8;
 	}
 
 	@Override

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/TagScannerTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/TagScannerTests.java
@@ -1117,9 +1117,9 @@ public class TagScannerTests {
 	public void testEnumMethodWithNoReference() {
 		IApiDescription manifest = newDescription();
 		Map<String, String> options = JavaCore.getDefaultOptions();
-		options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_5);
-		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
-		options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
+		options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+		options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
 		doScan("a/b/c/TestMethod21.java", manifest, options); //$NON-NLS-1$
 	}
 

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/tests/util/ProjectUtils.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/tests/util/ProjectUtils.java
@@ -186,7 +186,7 @@ public class ProjectUtils {
 		description.setExtensionRegistry(true);
 		description.setEquinox(true);
 		description.setBundleVersion(new Version("1.0.0")); //$NON-NLS-1$
-		description.setExecutionEnvironments(new String[] { "J2SE-1.5" }); //$NON-NLS-1$
+		description.setExecutionEnvironments(new String[] { "JavaSE-1.8" }); //$NON-NLS-1$
 		description.apply(null);
 		AbstractApiTest.waitForAutoBuild();
 		return JavaCore.create(project);

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PDE JUnit Tests
 Bundle-SymbolicName: org.eclipse.pde.ui.tests; singleton:=true
-Bundle-Version: 3.12.500.qualifier
+Bundle-Version: 3.12.600.qualifier
 Bundle-ClassPath: tests.jar
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.pde.ui,

--- a/ui/org.eclipse.pde.ui.tests/plugin.xml
+++ b/ui/org.eclipse.pde.ui.tests/plugin.xml
@@ -19,9 +19,9 @@
    <extension
          point="org.eclipse.jdt.launching.executionEnvironments">
       <environment
-            description="Java 1.3 without sound APIs (PDE test suite)"
-            id="J2SE-1.3-NO-SOUND"
-            profileProperties="profiles/J2SE-1.3-NO-SOUND.profile">
+            description="Java 1.8 without sound APIs (PDE test suite)"
+            id="J2SE-1.8-NO-SOUND"
+            profileProperties="profiles/J2SE-1.8-NO-SOUND.profile">
       </environment>
       <analyzer
             class="org.eclipse.pde.ui.tests.ee.EnvironmentAnalyzerDelegate"

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.tests</artifactId>
-  <version>3.12.500-SNAPSHOT</version>
+  <version>3.12.600-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.tests/profiles/J2SE-1.8-NO-SOUND.profile
+++ b/ui/org.eclipse.pde.ui.tests/profiles/J2SE-1.8-NO-SOUND.profile
@@ -58,10 +58,10 @@ org.osgi.framework.executionenvironment = \
  OSGi/Minimum-1.1,\
  JRE-1.1,\
  J2SE-1.2,\
- J2SE-1.3-NO-SOUND
-osgi.java.profile.name = J2SE-1.3-NO-SOUND
-org.eclipse.jdt.core.compiler.compliance=1.3
-org.eclipse.jdt.core.compiler.source=1.3
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.3
+ J2SE-1.8-NO-SOUND
+osgi.java.profile.name = J2SE-1.8-NO-SOUND
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/EnvironmentAnalyzerDelegate.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/EnvironmentAnalyzerDelegate.java
@@ -34,7 +34,7 @@ public class EnvironmentAnalyzerDelegate implements IExecutionEnvironmentAnalyze
 	/**
 	 * Environment identifier
 	 */
-	public static final String EE_NO_SOUND = "J2SE-1.3-NO-SOUND";
+	public static final String EE_NO_SOUND = "J2SE-1.8-NO-SOUND";
 
 	@Override
 	public CompatibleEnvironment[] analyze(IVMInstall vm, IProgressMonitor monitor) throws CoreException {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExecutionEnvironmentTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExecutionEnvironmentTests.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.util.IClassFileReader;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -134,9 +135,9 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 			IJavaProject project = ProjectUtils.createPluginProject("no.sound", env);
 			assertTrue("Project was not created", project.exists());
 
-			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_3);
+			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
 			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
 			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
@@ -147,39 +148,39 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 			waitForBuild();
 			IFile file = project.getProject().getFile("/bin/no/sound/Activator.class");
 			assertTrue("Activator class missing", file.exists());
-			validateTargetLevel(file.getLocation().toOSString(), 47);
+			validateTargetLevel(file.getLocation().toOSString(), ClassFileConstants.MAJOR_VERSION_1_8);
 		} finally {
 			deleteProject("no.sound");
 		}
 	}
 
 	/**
-	 * Creates a plug-in project with a J2SE-1.4 execution environment.
+	 * Creates a plug-in project with a JavaSE-17 execution environment.
 	 * Validates that compiler compliance settings and build path are correct
 	 * and that class files are generated with correct target level.
 	 */
 	@Test
-	public void testJava4Environment() throws Exception {
+	public void testJava8Environment() throws Exception {
 		try {
-			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("J2SE-1.4");
-			IJavaProject project = ProjectUtils.createPluginProject("j2se14.plug", env);
+			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8");
+			IJavaProject project = ProjectUtils.createPluginProject("j2se18.plug", env);
 			assertTrue("Project was not created", project.exists());
 
-			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
-			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
-			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.WARNING);
-			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.WARNING);
+			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
+			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
 			validateSystemLibrary(project, JavaRuntime.newJREContainerPath(env));
 
 			project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
 			waitForBuild();
-			IFile file = project.getProject().getFile("/bin/j2se14/plug/Activator.class");
+			IFile file = project.getProject().getFile("/bin/j2se18/plug/Activator.class");
 			assertTrue("Activator class missing", file.exists());
-			validateTargetLevel(file.getLocation().toOSString(), 46);
+			validateTargetLevel(file.getLocation().toOSString(), ClassFileConstants.MAJOR_VERSION_1_8);
 		} finally {
-			deleteProject("j2se14.plug");
+			deleteProject("j2se18.plug");
 		}
 	}
 
@@ -211,7 +212,7 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 	}
 
 	/**
-	 * Creates a plug-in project with a J2SE-1.4 execution environment.
+	 * Creates a plug-in project with a JavaSE-1.8 execution environment.
 	 * Validates that compiler compliance settings and build path are correct.
 	 * Modifies the compliance options and then updates the class path again.
 	 * Ensures that the enum and assert identifier options get overwritten with
@@ -220,15 +221,15 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 	@Test
 	public void testMinimumComplianceOverwrite() throws Exception {
 		try {
-			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("J2SE-1.4");
-			IJavaProject project = ProjectUtils.createPluginProject("j2se14.ignore", env);
+			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8");
+			IJavaProject project = ProjectUtils.createPluginProject("j2se18.ignore", env);
 			assertTrue("Project was not created", project.exists());
 
-			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
-			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
-			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.WARNING);
-			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.WARNING);
+			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
+			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
 			validateSystemLibrary(project, JavaRuntime.newJREContainerPath(env));
 
@@ -238,23 +239,23 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.IGNORE);
 			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.IGNORE);
 
-			// updating class path should increase severity to warning
+			// updating class path should increase severity to error
 			IPluginModelBase model = PluginRegistry.findModel(project.getProject());
 			UpdateClasspathJob.scheduleFor(List.of(model), false).join();
 			// re-validate options
-			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
-			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
-			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.WARNING);
-			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.WARNING);
+			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
+			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
 		} finally {
-			deleteProject("j2se14.ignore");
+			deleteProject("j2se18.ignore");
 		}
 	}
 
 	/**
-	 * Creates a plug-in project with a J2SE-1.4 execution environment.
+	 * Creates a plug-in project with a JavaSE-1.8 execution environment.
 	 * Validates that compiler compliance settings and build path are correct.
 	 * Modifies the compliance options and then updates the class path again.
 	 * Ensures that the enum and assert identifier options do not overwrite
@@ -263,15 +264,15 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 	@Test
 	public void testMinimumComplianceNoOverwrite() throws Exception {
 		try {
-			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("J2SE-1.4");
-			IJavaProject project = ProjectUtils.createPluginProject("j2se14.error", env);
+			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8");
+			IJavaProject project = ProjectUtils.createPluginProject("j2se18.error", env);
 			assertTrue("Project was not created", project.exists());
 
-			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
-			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
-			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.WARNING);
-			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.WARNING);
+			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
+			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
 			validateSystemLibrary(project, JavaRuntime.newJREContainerPath(env));
 
@@ -281,19 +282,19 @@ public class ExecutionEnvironmentTests extends PDETestCase {
 			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
 			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
-			// updating class path should increase severity to warning
+			// updating class path should increase severity to error
 			IPluginModelBase model = PluginRegistry.findModel(project.getProject());
 			UpdateClasspathJob.scheduleFor(List.of(model), false).join();
 
 			// re-validate options
-			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
-			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
+			validateOption(project, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+			validateOption(project, JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
 			validateOption(project, JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
 			validateOption(project, JavaCore.COMPILER_PB_ENUM_IDENTIFIER, JavaCore.ERROR);
 
 		} finally {
-			deleteProject("j2se14.error");
+			deleteProject("j2se18.error");
 		}
 	}
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExportBundleTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/ee/ExportBundleTests.java
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.util.IClassFileReader;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.pde.core.plugin.PluginRegistry;
@@ -130,7 +131,7 @@ public class ExportBundleTests extends PDETestCase {
 			}
 
 			assertTrue("Missing exported bundle", Files.exists(path));
-			validateTargetLevel(path.toString(), "no/sound/export/Activator.class", 47);
+			validateTargetLevel(path.toString(), "no/sound/export/Activator.class", ClassFileConstants.MAJOR_VERSION_1_8);
 		} finally {
 			TestUtils.waitForJobs(name.getMethodName(), 10, 5000);
 			deleteProject("no.sound.export");
@@ -139,14 +140,14 @@ public class ExportBundleTests extends PDETestCase {
 	}
 
 	/**
-	 * Exports a plug-in project with a J2SE-1.4 execution environment and
+	 * Exports a plug-in project with a JavaSE-1.8 execution environment and
 	 * validates class file target level.
 	 */
 	@Test
-	public void testExport14Environment() throws Exception {
+	public void testExport18Environment() throws Exception {
 		try {
-			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("J2SE-1.4");
-			IJavaProject project = ProjectUtils.createPluginProject("j2se14.export", env);
+			IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8");
+			IJavaProject project = ProjectUtils.createPluginProject("j2se18.export", env);
 			assertTrue("Project was not created", project.exists());
 
 			final FeatureExportInfo info = new FeatureExportInfo();
@@ -177,7 +178,7 @@ public class ExportBundleTests extends PDETestCase {
 			long l6 = System.currentTimeMillis();
 
 			// veriry exported bundle exists
-			Path path = EXPORT_PATH.resolve("plugins/j2se14.export_1.0.0.jar");
+			Path path = EXPORT_PATH.resolve("plugins/j2se18.export_1.0.0.jar");
 			long l7 = System.currentTimeMillis();
 
 			TestUtils.processUIEvents(100);
@@ -231,10 +232,10 @@ public class ExportBundleTests extends PDETestCase {
 			System.out.println("================================\nEnd of BUG 424597");
 
 			assertTrue("Missing exported bundle", Files.exists(path));
-			validateTargetLevel(path.toString(), "j2se14/export/Activator.class", 46);
+			validateTargetLevel(path.toString(), "j2se18/export/Activator.class", ClassFileConstants.MAJOR_VERSION_1_8);
 		} finally {
 			TestUtils.waitForJobs(name.getMethodName(), 10, 5000);
-			deleteProject("j2se14.export");
+			deleteProject("j2se18.export");
 			delete(EXPORT_PATH.toFile());
 		}
 	}


### PR DESCRIPTION
Basically moves tests that used various old 1.x JDK compiler settings to use 1.8 target (only supported 1.x Java compiler target in the future).

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536