### PR TITLE
remove unnecessary casts

### DIFF
--- a/ds/org.eclipse.pde.ds.ui/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.ds.ui;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ds.ui.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.30.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/editor/contentassist/DSContentAssistProcessor.java
+++ b/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/editor/contentassist/DSContentAssistProcessor.java
@@ -567,10 +567,10 @@ public class DSContentAssistProcessor extends TypePackageCompletionProcessor
 				fRange = ((IDocumentAttributeNode) fRange)
 						.getEnclosingElement();
 		} else if (fRange instanceof IDocumentElementNode) {
-			if (((IDocumentElementNode) fRange).getOffset() == offset)
+			if (fRange.getOffset() == offset)
 				fRange = ((IDocumentElementNode) fRange).getParentNode();
 		} else if (fRange instanceof IDocumentTextNode) {
-			if (((IDocumentTextNode) fRange).getOffset() == offset)
+			if (fRange.getOffset() == offset)
 				fRange = ((IDocumentTextNode) fRange).getEnclosingElement();
 		}
 	}

--- a/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/parts/ComboPart.java
+++ b/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/parts/ComboPart.java
@@ -126,7 +126,7 @@ public class ComboPart {
 
 	public void setEnabled(boolean enabled) {
 		if (combo instanceof Combo)
-			((Combo) combo).setEnabled(enabled);
+			combo.setEnabled(enabled);
 		else
 			((CCombo) combo).setEnabled(enabled);
 	}

--- a/ua/org.eclipse.pde.ua.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.pde.ua.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.ua.ui;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ua.ui.PDEUserAssistanceUIPlugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.205.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.30.0,4.0.0)",

--- a/ua/org.eclipse.pde.ua.ui/src/org/eclipse/pde/internal/ua/ui/editor/cheatsheet/comp/CompCSMasterTreeSection.java
+++ b/ua/org.eclipse.pde.ua.ui/src/org/eclipse/pde/internal/ua/ui/editor/cheatsheet/comp/CompCSMasterTreeSection.java
@@ -421,7 +421,7 @@ public class CompCSMasterTreeSection extends TreeSection implements ICSMaster {
 					.getCurrentPage();
 			// Replace the current dirty model with the model reloaded from
 			// file
-			fModel = ((ICompCS) object).getModel();
+			fModel = object.getModel();
 			// Reset the treeviewer using the new model as input
 			// TODO: MP: CompCS: This is redundant and should be deleted
 			fTreeViewer.setInput(fModel);

--- a/ua/org.eclipse.pde.ua.ui/src/org/eclipse/pde/internal/ua/ui/editor/cheatsheet/simple/details/SimpleCSCommandComboPart.java
+++ b/ua/org.eclipse.pde.ua.ui/src/org/eclipse/pde/internal/ua/ui/editor/cheatsheet/simple/details/SimpleCSCommandComboPart.java
@@ -20,7 +20,6 @@ import org.eclipse.pde.internal.ua.ui.editor.cheatsheet.simple.ISimpleCSCommandK
 import org.eclipse.pde.internal.ua.ui.editor.cheatsheet.simple.NewCommandKeyEvent;
 import org.eclipse.pde.internal.ua.ui.editor.cheatsheet.simple.SimpleCSCommandManager;
 import org.eclipse.pde.internal.ui.parts.ComboPart;
-import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.widgets.Combo;
@@ -43,9 +42,9 @@ public class SimpleCSCommandComboPart extends ComboPart implements ISimpleCSComm
 		if (combo == null) {
 			return;
 		} else if (combo instanceof Combo) {
-			((Combo) combo).addDisposeListener(listener);
+			combo.addDisposeListener(listener);
 		} else {
-			((CCombo) combo).addDisposeListener(listener);
+			combo.addDisposeListener(listener);
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.18.100.qualifier
+Bundle-Version: 3.18.200.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestErrorReporter.java
@@ -94,7 +94,7 @@ public abstract class ManifestErrorReporter extends XMLErrorReporter {
 		for (int i = 0; i < children.getLength(); i++) {
 			Node child = children.item(i);
 			if (child instanceof Text) {
-				textFound = ((Text) child).getNodeValue().trim().length() > 0;
+				textFound = child.getNodeValue().trim().length() > 0;
 			} else if (child instanceof Element) {
 				reportIllegalElement((Element) child, CompilerFlags.ERROR);
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaAttribute.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaAttribute.java
@@ -266,7 +266,7 @@ public class SchemaAttribute extends SchemaObject implements ISchemaAttribute {
 		}
 		String elementName = null;
 		if (getParent() instanceof ISchemaElement) {
-			elementName = ((ISchemaElement) getParent()).getName();
+			elementName = getParent().getName();
 			if (elementName == null) {
 				return null;
 			}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/ValidationDialogTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/ValidationDialogTest.java
@@ -61,7 +61,7 @@ public class ValidationDialogTest {
 
 	private void isEditLaunchConfigurationLinkAvilable(Control[] element, Control control) {
 		Control editConfigLink = element[0];
-		((Link) control).notifyListeners(SWT.Selection, new Event());
+		control.notifyListeners(SWT.Selection, new Event());
 		assertNotNull(editConfigLink.isVisible());
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/ManifestContentMergeViewer.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/ManifestContentMergeViewer.java
@@ -57,7 +57,7 @@ public class ManifestContentMergeViewer extends TextMergeViewer {
 
 			Font font = JFaceResources.getFont(ManifestContentMergeViewer.class.getName());
 			if (font != null) {
-				((SourceViewer) textViewer).getTextWidget().setFont(font);
+				textViewer.getTextWidget().setFont(font);
 			}
 		}
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/PluginContentMergeViewer.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/compare/PluginContentMergeViewer.java
@@ -69,7 +69,7 @@ public class PluginContentMergeViewer extends TextMergeViewer {
 			((SourceViewer) textViewer).configure(configuration);
 			Font font = JFaceResources.getFont(PluginContentMergeViewer.class.getName());
 			if (font != null)
-				((SourceViewer) textViewer).getTextWidget().setFont(font);
+				textViewer.getTextWidget().setFont(font);
 		}
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildContentsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildContentsSection.java
@@ -505,7 +505,7 @@ public abstract class BuildContentsSection extends TableSection implements IReso
 				fDoRefresh = true;
 				return false;
 			}
-		} else if (resource instanceof IProject && ((IProject) resource).equals(project)) {
+		} else if (resource instanceof IProject && resource.equals(project)) {
 			return delta.getKind() != IResourceDelta.REMOVED;
 		}
 		return true;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/XMLCompletionProposal.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/XMLCompletionProposal.java
@@ -239,13 +239,13 @@ public class XMLCompletionProposal implements ICompletionProposal, ICompletionPr
 
 	private void applyElement(String indent, String delim, StringBuilder documentInsertBuffer) {
 		documentInsertBuffer.append('<');
-		documentInsertBuffer.append(((ISchemaElement) fSchemaObject).getName());
+		documentInsertBuffer.append(fSchemaObject.getName());
 		documentInsertBuffer.append('>');
 		documentInsertBuffer.append(delim);
 		documentInsertBuffer.append(indent);
 		documentInsertBuffer.append('<');
 		documentInsertBuffer.append('/');
-		documentInsertBuffer.append(((ISchemaElement) fSchemaObject).getName());
+		documentInsertBuffer.append(fSchemaObject.getName());
 		documentInsertBuffer.append('>');
 	}
 
@@ -368,7 +368,7 @@ public class XMLCompletionProposal implements ICompletionProposal, ICompletionPr
 			return;
 		}
 		// Get the offset of the extension element
-		int targetOffset = ((IDocumentElementNode) range).getOffset();
+		int targetOffset = range.getOffset();
 		// Search this plug-ins extensions for the proper one
 		IPluginExtension[] extensions = base.getExtensions();
 		for (IPluginExtension extension : extensions) {
@@ -388,7 +388,7 @@ public class XMLCompletionProposal implements ICompletionProposal, ICompletionPr
 	private void setSelectionOffsets(IDocument document, ISchemaElement schemaElement, IPluginParent pluginParent) {
 		if (pluginParent instanceof IPluginExtension) {
 			String point = ((IPluginExtension) pluginParent).getPoint();
-			IPluginObject[] children = ((IPluginExtension) pluginParent).getChildren();
+			IPluginObject[] children = pluginParent.getChildren();
 			if (children != null && children.length > 0 && children[0] instanceof IPluginParent) {
 				pluginParent = (IPluginParent) children[0];
 				schemaElement = XMLUtil.getSchemaElement((IDocumentElementNode) pluginParent, point);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/XMLContentAssistProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/contentassist/XMLContentAssistProcessor.java
@@ -205,10 +205,10 @@ public class XMLContentAssistProcessor extends TypePackageCompletionProcessor im
 			if (((IDocumentAttributeNode) fRange).getNameOffset() == offset)
 				fRange = ((IDocumentAttributeNode) fRange).getEnclosingElement();
 		} else if (fRange instanceof IDocumentElementNode) {
-			if (((IDocumentElementNode) fRange).getOffset() == offset)
+			if (fRange.getOffset() == offset)
 				fRange = ((IDocumentElementNode) fRange).getParentNode();
 		} else if (fRange instanceof IDocumentTextNode) {
-			if (((IDocumentTextNode) fRange).getOffset() == offset)
+			if (fRange.getOffset() == offset)
 				fRange = ((IDocumentTextNode) fRange).getEnclosingElement();
 		}
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/LauncherSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/LauncherSection.java
@@ -410,7 +410,7 @@ public class LauncherSection extends PDESection {
 	public void commit(boolean onSave) {
 		fNameEntry.commit();
 		for (int i = 0; i < fIcons.size(); i++)
-			((FormEntry) fIcons.get(i)).commit();
+			fIcons.get(i).commit();
 		super.commit(onSave);
 	}
 
@@ -418,7 +418,7 @@ public class LauncherSection extends PDESection {
 	public void cancelEdit() {
 		fNameEntry.cancelEdit();
 		for (int i = 0; i < fIcons.size(); i++)
-			((FormEntry) fIcons.get(i)).commit();
+			fIcons.get(i).commit();
 		super.cancelEdit();
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/schema/NewClassCreationWizard.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/schema/NewClassCreationWizard.java
@@ -54,19 +54,19 @@ public class NewClassCreationWizard extends JavaAttributeWizard {
 		if (fIsInterface) {
 			((NewInterfaceWizardPage) fMainPage).init(StructuredSelection.EMPTY);
 			if (className != null)
-				((NewInterfaceWizardPage) fMainPage).setTypeName(className, true);
+				fMainPage.setTypeName(className, true);
 			if (packageRoot != null)
-				((NewInterfaceWizardPage) fMainPage).setPackageFragmentRoot(packageRoot, true);
+				fMainPage.setPackageFragmentRoot(packageRoot, true);
 			if (packageName != null)
-				((NewInterfaceWizardPage) fMainPage).setPackageFragment(packageName, true);
+				fMainPage.setPackageFragment(packageName, true);
 		} else {
 			((NewClassWizardPage) fMainPage).init(StructuredSelection.EMPTY);
 			if (className != null)
-				((NewClassWizardPage) fMainPage).setTypeName(className, true);
+				fMainPage.setTypeName(className, true);
 			if (packageRoot != null)
-				((NewClassWizardPage) fMainPage).setPackageFragmentRoot(packageRoot, true);
+				fMainPage.setPackageFragmentRoot(packageRoot, true);
 			if (packageName != null)
-				((NewClassWizardPage) fMainPage).setPackageFragment(packageName, true);
+				fMainPage.setPackageFragment(packageName, true);
 		}
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/PluginXMLTextHover.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/PluginXMLTextHover.java
@@ -120,7 +120,7 @@ public class PluginXMLTextHover extends PDETextHover {
 
 	private ISchemaObject getSchemaObject(ISchema schema, IPluginObject object) {
 		if (object instanceof IPluginElement)
-			return schema.findElement(((IPluginElement) object).getName());
+			return schema.findElement(object.getName());
 		if (object instanceof IPluginExtension)
 			return schema.findElement("extension"); //$NON-NLS-1$
 		if (object instanceof IDocumentAttributeNode)

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/XMLUtil.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/XMLUtil.java
@@ -73,9 +73,9 @@ public abstract class XMLUtil {
 		if (range instanceof IDocumentAttributeNode)
 			return withinRange(((IDocumentAttributeNode) range).getValueOffset(), ((IDocumentAttributeNode) range).getValueLength(), offset);
 		if (range instanceof IDocumentElementNode)
-			return withinRange(((IDocumentElementNode) range).getOffset(), ((IDocumentElementNode) range).getLength(), offset);
+			return withinRange(range.getOffset(), range.getLength(), offset);
 		if (range instanceof IDocumentTextNode)
-			return withinRange(((IDocumentTextNode) range).getOffset(), ((IDocumentTextNode) range).getLength(), offset);
+			return withinRange(range.getOffset(), range.getLength(), offset);
 		return false;
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ComboPart.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ComboPart.java
@@ -124,7 +124,7 @@ public class ComboPart {
 
 	public void setEnabled(boolean enabled) {
 		if (combo instanceof Combo)
-			((Combo) combo).setEnabled(enabled);
+			combo.setEnabled(enabled);
 		else
 			((CCombo) combo).setEnabled(enabled);
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/PluginManifestChange.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/PluginManifestChange.java
@@ -98,7 +98,7 @@ public class PluginManifestChange {
 					if (textChange != null) {
 						TextEdit edit = textChange.getEdit();
 						if (edit instanceof MultiTextEdit) {
-							((MultiTextEdit) edit).addChild(multiEdit);
+							edit.addChild(multiEdit);
 							multiEdit = ((MultiTextEdit) edit);
 						} else
 							multiEdit.addChild(edit);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/target/StateViewPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/target/StateViewPage.java
@@ -367,7 +367,7 @@ public class StateViewPage extends Page implements IStateDeltaListener, IPluginM
 		if (obj instanceof BundleSpecification)
 			obj = ((BundleSpecification) obj).getSupplier();
 		else if (obj instanceof ImportPackageSpecification)
-			obj = ((ExportPackageDescription) ((ImportPackageSpecification) obj).getSupplier()).getSupplier();
+			obj = ((ImportPackageSpecification) obj).getSupplier().getSupplier();
 		if (obj instanceof BundleDescription)
 			return (BundleDescription) obj;
 		return null;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/imports/PluginImportOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/imports/PluginImportOperation.java
@@ -382,7 +382,7 @@ public class PluginImportOperation extends WorkspaceJob {
 					IResource resource = content.getAdapter(IResource.class);
 					if (resource instanceof IProject) {
 						// TODO For now just list everything in the map
-						String id = ((IProject) resource).getName();
+						String id = resource.getName();
 						List<IWorkingSet> workingSets = fProjectWorkingSets.get(id);
 						if (workingSets == null) {
 							workingSets = new ArrayList<>();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewLibraryPluginCreationOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/NewLibraryPluginCreationOperation.java
@@ -572,7 +572,7 @@ public class NewLibraryPluginCreationOperation extends NewProjectCreationOperati
 							for (IResource child : children) {
 								if (child instanceof IContainer)
 									stack.push(child);
-								else if ("class".equals(((IFile) child).getFileExtension())) { //$NON-NLS-1$
+								else if ("class".equals(child.getFileExtension())) { //$NON-NLS-1$
 									String path = folder.getProjectRelativePath().toString();
 									ignorePkgs.add(path.replace('/', '.'));
 								}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/PluginContentPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/PluginContentPage.java
@@ -344,7 +344,7 @@ public class PluginContentPage extends ContentPage {
 	 * @return if the field data is using the OSGi framework
 	 */
 	private boolean isPureOSGi() {
-		return ((PluginFieldData) fData).getOSGiFramework() != null;
+		return fData.getOSGiFramework() != null;
 	}
 
 	@Override


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new errors/warnings will show up in the build.