### PR TITLE
Product file editor: Support for <bundleUrlTypes> on macOS

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/ILauncherInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/ILauncherInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2016 IBM Corporation and others.
+ *  Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -11,26 +11,29 @@
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     SAP SE - support macOS bundle URL types
  *******************************************************************************/
 package org.eclipse.pde.internal.core.iproduct;
 
+import java.util.List;
+
 public interface ILauncherInfo extends IProductObject {
 
-	public static final String LINUX_ICON = "linuxIcon"; //$NON-NLS-1$
+	String LINUX_ICON = "linuxIcon"; //$NON-NLS-1$
 
-	public static final String MACOSX_ICON = "macosxIcon"; //$NON-NLS-1$
+	String MACOSX_ICON = "macosxIcon"; //$NON-NLS-1$
 
-	public static final String WIN32_16_LOW = "winSmallLow"; //$NON-NLS-1$
-	public static final String WIN32_16_HIGH = "winSmallHigh"; //$NON-NLS-1$
-	public static final String WIN32_32_LOW = "winMediumLow"; //$NON-NLS-1$
-	public static final String WIN32_32_HIGH = "winMediumHigh"; //$NON-NLS-1$
-	public static final String WIN32_48_LOW = "winLargeLow"; //$NON-NLS-1$
-	public static final String WIN32_48_HIGH = "winLargeHigh"; //$NON-NLS-1$
-	public static final String WIN32_256_HIGH = "winExtraLargeHigh"; //$NON-NLS-1$
+	String WIN32_16_LOW = "winSmallLow"; //$NON-NLS-1$
+	String WIN32_16_HIGH = "winSmallHigh"; //$NON-NLS-1$
+	String WIN32_32_LOW = "winMediumLow"; //$NON-NLS-1$
+	String WIN32_32_HIGH = "winMediumHigh"; //$NON-NLS-1$
+	String WIN32_48_LOW = "winLargeLow"; //$NON-NLS-1$
+	String WIN32_48_HIGH = "winLargeHigh"; //$NON-NLS-1$
+	String WIN32_256_HIGH = "winExtraLargeHigh"; //$NON-NLS-1$
 
-	public static final String P_USE_ICO = "useIco"; //$NON-NLS-1$
-	public static final String P_ICO_PATH = "icoFile"; //$NON-NLS-1$
-	public static final String P_LAUNCHER = "launcher"; //$NON-NLS-1$
+	String P_USE_ICO = "useIco"; //$NON-NLS-1$
+	String P_ICO_PATH = "icoFile"; //$NON-NLS-1$
+	String P_LAUNCHER = "launcher"; //$NON-NLS-1$
 
 	String getLauncherName();
 
@@ -43,4 +46,11 @@ public interface ILauncherInfo extends IProductObject {
 	boolean usesWinIcoFile();
 
 	void setUseWinIcoFile(boolean use);
+
+	List<IMacBundleUrlType> getMacBundleUrlTypes();
+
+	void addMacBundleUrlTypes(List<IMacBundleUrlType> schemes);
+
+	void removeMacBundleUrlTypes(List<IMacBundleUrlType> schemes);
+
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IMacBundleUrlType.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IMacBundleUrlType.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ *  Copyright (c) 2024 SAP SE and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.iproduct;
+
+public interface IMacBundleUrlType extends IProductObject {
+
+	String getScheme();
+
+	void setScheme(String scheme);
+
+	String getName();
+
+	void setName(String name);
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IProductModelFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IProductModelFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2014 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Code 9 Corporation - ongoing enhancements
  *     Rapicorp Corporation - ongoing enhancements
+ *     SAP SE - support macOS bundle URL types
  *******************************************************************************/
 package org.eclipse.pde.internal.core.iproduct;
 
@@ -50,5 +51,7 @@ public interface IProductModelFactory {
 	IPreferencesInfo createPreferencesInfo();
 
 	ICSSInfo createCSSInfo();
+
+	IMacBundleUrlType createMacBundleUrlType();
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/MacBundleUrlType.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/MacBundleUrlType.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *  Copyright (c) 2024 SAP SE and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.product;
+
+import java.io.PrintWriter;
+
+import org.eclipse.pde.internal.core.iproduct.IMacBundleUrlType;
+import org.eclipse.pde.internal.core.iproduct.IProductModel;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public class MacBundleUrlType extends ProductObject implements IMacBundleUrlType {
+
+	private static final long serialVersionUID = 1L;
+	private String fScheme;
+	private String fName;
+
+	public MacBundleUrlType(IProductModel model) {
+		super(model);
+	}
+
+	@Override
+	public void parse(Node node) {
+		if (node.getNodeType() == Node.ELEMENT_NODE) {
+			Element element = (Element) node;
+			fScheme = element.getAttribute("scheme"); //$NON-NLS-1$
+			fName = element.getAttribute("name"); //$NON-NLS-1$
+		}
+	}
+
+	@Override
+	public void write(String indent, PrintWriter writer) {
+		writer.println(indent + "<bundleUrlType scheme=\"" + fScheme + "\"" + " name=\"" + fName + "\"/>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	}
+
+
+	@Override
+	public String getScheme() {
+		return fScheme;
+	}
+
+	@Override
+	public void setScheme(String scheme) {
+		fScheme = scheme;
+	}
+
+	@Override
+	public String getName() {
+		return fName;
+	}
+
+	@Override
+	public void setName(String name) {
+		fName = name;
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ProductModelFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ProductModelFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2014 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     EclipseSource Corporation - ongoing enhancements
  *     Rapicorp Corporation - ongoing enhancements
+ *     SAP SE - support macOS bundle URL types
  *******************************************************************************/
 package org.eclipse.pde.internal.core.product;
 
@@ -24,6 +25,7 @@ import org.eclipse.pde.internal.core.iproduct.IIntroInfo;
 import org.eclipse.pde.internal.core.iproduct.IJREInfo;
 import org.eclipse.pde.internal.core.iproduct.ILauncherInfo;
 import org.eclipse.pde.internal.core.iproduct.ILicenseInfo;
+import org.eclipse.pde.internal.core.iproduct.IMacBundleUrlType;
 import org.eclipse.pde.internal.core.iproduct.IPluginConfiguration;
 import org.eclipse.pde.internal.core.iproduct.IPreferencesInfo;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
@@ -126,6 +128,11 @@ public class ProductModelFactory implements IProductModelFactory {
 	@Override
 	public ICSSInfo createCSSInfo() {
 		return new CSSInfo(fModel);
+	}
+
+	@Override
+	public IMacBundleUrlType createMacBundleUrlType() {
+		return new MacBundleUrlType(fModel);
 	}
 
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@
  *     Axel Richard (Obeo) - Bug 41353 - Launch configurations prototypes
  *     Kit Lo (IBM) - Bug 244461 - Duplicating colon in error message
  *     Alexander Fedorov <alexander.fedorov@arsysop.ru> - Bug 547222
+ *     SAP SE - support macOS bundle URL types
  *******************************************************************************/
 package org.eclipse.pde.internal.ui;
 
@@ -1176,6 +1177,18 @@ public class PDEUIMessages extends NLS {
 	public static String LauncherSection_256High;
 	public static String LauncherSection_linuxLabel;
 	public static String LauncherSection_macLabel;
+	public static String LauncherSection_macBundleUrlTypes_DialogTitle;
+	public static String LauncherSection_macBundleUrlTypes_Scheme;
+	public static String LauncherSection_macBundleUrlTypes_Name;
+	public static String LauncherSection_macBundleUrlTypes_ErrorNoScheme;
+	public static String LauncherSection_macBundleUrlTypes_ErrorNoName;
+	public static String LauncherSection_macBundleUrlTypes_ErrorSchemeExists;
+	public static String LauncherSection_macBundleUrlTypes_Add;
+	public static String LauncherSection_macBundleUrlTypes_Edit;
+	public static String LauncherSection_macBundleUrlTypes_Remove;
+	public static String LauncherSection_macBundleUrlTypes_LauncherSection_macBundleUrlTypesTitle;
+	public static String LauncherSection_macBundleUrlTypes_SchemeColumn;
+	public static String LauncherSection_macBundleUrlTypes_NameColumn;
 	public static String OSGiBundlesTab_frameworkLabel;
 
 	// Preferences ####################################

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@
 #     Axel Richard (Obeo) - Bug 41353 - Launch configurations prototypes
 #     Kit Lo (IBM) - Bug 244461 - Duplicating colon in error message
 #     Alexander Fedorov <alexander.fedorov@arsysop.ru> - Bug 547222
+#     SAP SE - support macOS bundle URL types
 ###############################################################################
 #####################################
 # PDE resource strings
@@ -660,7 +661,7 @@ LauncherUtils_generateConfigIni=The config.ini template file you specified does 
 Launcher_error_displayInSystemEditor=Yes, in an editor
 LauncherSection_browse=Browse...
 LauncherSection_title=Program Launcher
-LauncherSection_label=Customizing the launcher icon varies per platform.
+LauncherSection_label=Further customization of the launcher varies per platform.
 LauncherSection_bmpImages=Specify 7 separate BMP images:
 LauncherSection_Low16=16x16 (8-bit):
 LauncherSection_High16=16x16 (32-bit):
@@ -671,6 +672,18 @@ LauncherSection_48High=48x48 (32-bit):
 LauncherSection_256High=256x256 (32-bit):
 LauncherSection_linuxLabel=A single XPM icon is required:
 LauncherSection_macLabel=A single ICNS file is required:
+LauncherSection_macBundleUrlTypes_DialogTitle=Scheme
+LauncherSection_macBundleUrlTypes_Scheme=Scheme
+LauncherSection_macBundleUrlTypes_Name=Name
+LauncherSection_macBundleUrlTypes_ErrorNoScheme=Scheme is not set
+LauncherSection_macBundleUrlTypes_ErrorNoName=Name is not set
+LauncherSection_macBundleUrlTypes_ErrorSchemeExists=Specified scheme already exists
+LauncherSection_macBundleUrlTypes_Add=Add...
+LauncherSection_macBundleUrlTypes_Edit=Edit...
+LauncherSection_macBundleUrlTypes_Remove=Remove
+LauncherSection_macBundleUrlTypes_LauncherSection_macBundleUrlTypesTitle=URL schemes to be handled by the macOS app bundle:
+LauncherSection_macBundleUrlTypes_SchemeColumn=Scheme
+LauncherSection_macBundleUrlTypes_NameColumn=Name
 OpenSchemaAction_msgUnknown=Unknown
 
 ###### Preferences ####################################


### PR DESCRIPTION
Support editing of <launcher><macosx><bundleUrlTypes> entries in the product editor.

These are translated to CFBundleURLTypes entries in the Info.plist dictionary of the macOS app bundle.

Contributes to
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901.

![image](https://github.com/eclipse-pde/eclipse.pde/assets/14908423/8138766f-04d0-406f-bfc0-2646ed011521)

![image](https://github.com/eclipse-pde/eclipse.pde/assets/14908423/0f4d59fc-973e-4978-99b9-ce8c8df0c595)

