### PR TITLE
[Build] Handle license check and vetting request in one workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
   check-merge-commits:
     if: github.event_name == 'pull_request'
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
-  check-dash-licenses:
-    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
-    with:
-      projectId: eclipse.pde
   build:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@master
 

--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,6 +1,12 @@
-name: Request license-review
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License status
 
 on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   issue_comment:
     types: [created]
 
@@ -12,4 +18,4 @@ jobs:
     with:
       projectId: eclipse.pde
     secrets:
-      gitlabAPIToken: ${{ secrets.PDE_GITLAB_API_TOKEN }}
+      gitlabAPIToken: ${{ github.event_name == 'issue_comment' && secrets.PDE_GITLAB_API_TOKEN || '' }}


### PR DESCRIPTION
This simplifies maintenance since the license handling is not distributed over multiple workflows.