### PR TITLE
[APITools] Handle multiple version correct when obtaining prerequisites

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -381,14 +380,14 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 		Element celement = null;
 		IApiComponent[] components = baseline.getApiComponents();
 		for (IApiComponent component : components) {
-			Set<IApiComponent> allComponentSet = new HashSet<>();
+			Set<IApiComponent> allComponentSet;
 			// if the baseline has multiple versions, persist all versions
 			Set<IApiComponent> multipleComponents = baseline.getAllApiComponents(component.getSymbolicName());
 			if (multipleComponents.isEmpty()) {
 				// no multiple version - add the current component
-				allComponentSet.add(component);
+				allComponentSet = Set.of(component);
 			} else {
-				allComponentSet.addAll(multipleComponents);
+				allComponentSet = multipleComponents;
 			}
 			for (IApiComponent iApiComponent : allComponentSet) {
 				if (!iApiComponent.isSystemComponent()) {
@@ -399,8 +398,6 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 					root.appendChild(celement);
 				}
 			}
-			// clear the temporary hashset
-			allComponentSet.clear();
 		}
 		return document;
 	}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ApiAnalysisBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ApiAnalysisBuilder.java
@@ -895,22 +895,9 @@ public class ApiAnalysisBuilder extends IncrementalProjectBuilder {
 			localMonitor.subTask(NLS.bind(BuilderMessages.building_workspace_profile, currentproject.getName()));
 			localMonitor.split(1);
 			String id = currentModel.getBundleDescription().getSymbolicName();
+			Version version = currentModel.getBundleDescription().getVersion();
 			// Compatibility checks
-			IApiComponent apiComponent = wbaseline.getApiComponent(id);
-			Set<IApiComponent> apiComponentMultiple = wbaseline.getAllApiComponents(id);
-			if (!apiComponentMultiple.isEmpty()) {
-				// add the exact match
-				for (IApiComponent iApiComponent : apiComponentMultiple) {
-					Version workspaceBaselineVersion = new Version(iApiComponent.getVersion());// removes
-																								// qualifier
-					Version currentProjectVersion = currentModel.getBundleDescription().getVersion();
-					if (new Version(currentProjectVersion.getMajor(), currentProjectVersion.getMinor(),
-							currentProjectVersion.getMicro()).compareTo(workspaceBaselineVersion) == 0) {
-						apiComponent = iApiComponent;
-						break;
-					}
-				}
-			}
+			IApiComponent apiComponent = wbaseline.getApiComponent(id, version);
 			if (apiComponent != null) {
 				if (getAnalyzer() instanceof BaseApiAnalyzer) {
 					((BaseApiAnalyzer) getAnalyzer()).checkBaselineMismatch(baseline, wbaseline);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/IncrementalApiBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/IncrementalApiBuilder.java
@@ -263,20 +263,8 @@ public class IncrementalApiBuilder {
 			IPluginModelBase currentModel = this.builder.getCurrentModel();
 			if (currentModel != null) {
 				String id = currentModel.getBundleDescription().getSymbolicName();
-				IApiComponent comp = wbaseline.getApiComponent(id);
-				Set<IApiComponent> apiComponentMultiple = wbaseline.getAllApiComponents(id);
-				if (!apiComponentMultiple.isEmpty()) {
-					// add the exact match
-					for (IApiComponent iApiComponent : apiComponentMultiple) {
-						Version workspaceBaselineVersion = new Version(iApiComponent.getVersion());// removes
-																									// qualifier
-						Version currentProjectVersion = currentModel.getBundleDescription().getVersion();
-						if (new Version(currentProjectVersion.getMajor(), currentProjectVersion.getMinor(), currentProjectVersion.getMicro()).compareTo(workspaceBaselineVersion) == 0) {
-							comp = iApiComponent;
-							break;
-						}
-					}
-				}
+				Version version = currentModel.getBundleDescription().getVersion();
+				IApiComponent comp = wbaseline.getApiComponent(id, version);
 				if (comp == null) {
 					return;
 				}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/model/IApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/model/IApiBaseline.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.osgi.framework.Version;
 
 /**
  * A collection of related API components that together make up an
@@ -77,6 +78,15 @@ public interface IApiBaseline extends IApiElement {
 	 * @return API component or <code>null</code>
 	 */
 	public IApiComponent getApiComponent(String id);
+
+	/**
+	 * Returns the API component in this baseline with the given symbolic name and
+	 * version or <code>null</code> if none.
+	 *
+	 * @param id component symbolic name
+	 * @return API component or <code>null</code>
+	 */
+	public IApiComponent getApiComponent(String id, Version version);
 
 	/**
 	 * Returns all the API components in this baseline (sorted from higher to


### PR DESCRIPTION
`ApiBaseline.getPrerequisiteComponents()` didn't consider multiple versions of a component.
Besides fixing that, this also unifies and simplifies the handling of multiple versions.

I noticed that while working on https://github.com/eclipse-pde/eclipse.pde/pull/1336.