### PR TITLE
Replace project APIs using antiquated Equinox resolver's VersionRange

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde"
       label="%featureName"
-      version="3.15.500.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.doc.user; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.16.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/org.eclipse.pde.doc.user/pom.xml
+++ b/org.eclipse.pde.doc.user/pom.xml
@@ -17,7 +17,7 @@
     <version>4.33.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.pde.doc.user</artifactId>
-  <version>3.15.300-SNAPSHOT</version>
+  <version>3.16.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.18.200.qualifier
+Bundle-Version: 3.19.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IBundleProjectService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IBundleProjectService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.ServiceCaller;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Service used to create and configure bundle project descriptions.
@@ -55,8 +55,17 @@ public interface IBundleProjectService {
 	 * @param name symbolic name of the host
 	 * @param range version constraint or <code>null</code>
 	 * @return host description
+	 * @since 3.19
 	 */
 	IHostDescription newHost(String name, VersionRange range);
+
+	/**
+	 * @deprecated Instead use {@link #newHost(String, VersionRange)}
+	 */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default IHostDescription newHost(String name, org.eclipse.osgi.service.resolver.VersionRange range) {
+		return newHost(name, (VersionRange) range);
+	}
 
 	/**
 	 * Creates and returns a new package import description.
@@ -65,8 +74,19 @@ public interface IBundleProjectService {
 	 * @param range version constraint or <code>null</code>
 	 * @param optional whether the import is optional
 	 * @return package import description
+	 * @since 3.19
 	 */
 	IPackageImportDescription newPackageImport(String name, VersionRange range, boolean optional);
+
+	/**
+	 * @deprecated Instead use
+	 *             {@link #newPackageImport(String, VersionRange, boolean)}
+	 */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default IPackageImportDescription newPackageImport(String name,
+			org.eclipse.osgi.service.resolver.VersionRange range, boolean optional) {
+		return newPackageImport(name, (VersionRange) range, optional);
+	}
 
 	/**
 	 * Constructs a new package export description.
@@ -88,8 +108,19 @@ public interface IBundleProjectService {
 	 * @param optional whether the required bundle is optional
 	 * @param export whether the required bundle is re-exported
 	 * @return required bundle description
+	 * @since 3.19
 	 */
 	IRequiredBundleDescription newRequiredBundle(String name, VersionRange range, boolean optional, boolean export);
+
+	/**
+	 * @deprecated Instead use
+	 *             {@link #newRequiredBundle(String, VersionRange, boolean, boolean)}
+	 */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default IRequiredBundleDescription newRequiredBundle(String name,
+			org.eclipse.osgi.service.resolver.VersionRange range, boolean optional, boolean export) {
+		return newRequiredBundle(name, (VersionRange) range, optional, export);
+	}
 
 	/**
 	 * Creates and returns a new bundle classpath entry defining the relationship

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IHostDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IHostDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
+import org.osgi.framework.VersionRange;
 
 /**
  * Describes a fragment host. Instances of this class can be created
@@ -30,14 +30,22 @@ public interface IHostDescription {
 	 *
 	 * @return symbolic name of the host
 	 */
-	public String getName();
+	String getName();
 
 	/**
 	 * Returns the version constraint of the host or <code>null</code>
 	 * if unspecified.
 	 *
 	 * @return version constraint or <code>null</code>
+	 * @since 3.19
 	 */
-	public VersionRange getVersionRange();
+	VersionRange getVersion();
+
+	/** @deprecated Instead use {@link #getVersion()} */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
+		VersionRange version = getVersion();
+		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;
+	}
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageImportDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageImportDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
+import org.osgi.framework.VersionRange;
 
 /**
  * Describes a package import. Instances of this class can be created
@@ -30,21 +30,29 @@ public interface IPackageImportDescription {
 	 *
 	 * @return fully qualified name of the imported package
 	 */
-	public String getName();
+	String getName();
 
 	/**
 	 * Returns the version constraint of the imported package or <code>null</code>
 	 * if unspecified.
 	 *
 	 * @return version constraint or <code>null</code>
+	 * @since 3.19
 	 */
-	public VersionRange getVersionRange();
+	VersionRange getVersion();
+
+	/** @deprecated Instead use {@link #getVersion()} */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
+		VersionRange version = getVersion();
+		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;
+	}
 
 	/**
 	 * Returns whether the package import is optional.
 	 *
 	 * @return whether optional
 	 */
-	public boolean isOptional();
+	boolean isOptional();
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IRequiredBundleDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IRequiredBundleDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
+import org.osgi.framework.VersionRange;
 
 /**
  * Describes a required bundle. Instances of this class can be created
@@ -30,28 +30,36 @@ public interface IRequiredBundleDescription {
 	 *
 	 * @return symbolic name of the required bundle
 	 */
-	public String getName();
+	String getName();
 
 	/**
 	 * Returns the version constraint of the required bundle or <code>null</code>
 	 * if unspecified.
 	 *
 	 * @return version constraint or <code>null</code>
+	 * @since 3.19
 	 */
-	public VersionRange getVersionRange();
+	VersionRange getVersion();
+
+	/** @deprecated Instead use {@link #getVersion()} */
+	@Deprecated(forRemoval = true, since = "4.19")
+	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
+		VersionRange version = getVersion();
+		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;
+	}
 
 	/**
 	 * Returns whether the required bundle is re-exported.
 	 *
 	 * @return whether re-exported
 	 */
-	public boolean isExported();
+	boolean isExported();
 
 	/**
 	 * Returns whether the required bundle is optional.
 	 *
 	 * @return whether optional
 	 */
-	public boolean isOptional();
+	boolean isOptional();
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -50,6 +49,7 @@ import org.eclipse.team.core.Team;
 import org.eclipse.team.core.importing.provisional.IBundleImporter;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Factory class for creating bundle project descriptions and associated artifacts.

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/HostDescriptoin.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/HostDescriptoin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.project.IHostDescription;
+import org.osgi.framework.VersionRange;
 
 /**
  * Describes a host

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PackageImportDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/PackageImportDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.project.IPackageImportDescription;
+import org.osgi.framework.VersionRange;
 
 /**
  * Describes a package import

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/RequiredBundleDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/RequiredBundleDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.project.IRequiredBundleDescription;
+import org.osgi.framework.VersionRange;
 
 /**
  * Describes a required bundle.

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/RequirementSpecification.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/RequirementSpecification.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.project;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
+import java.util.Objects;
+
+import org.osgi.framework.VersionRange;
 
 /**
  * Common implementation for a requirement specification - host, required bundle,
@@ -40,7 +42,7 @@ public abstract class RequirementSpecification {
 		return fName;
 	}
 
-	public VersionRange getVersionRange() {
+	public VersionRange getVersion() {
 		return fRange;
 	}
 
@@ -50,10 +52,9 @@ public abstract class RequirementSpecification {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof RequirementSpecification spec) {
-			return getName().equals(spec.getName()) && isExported() == spec.isExported() && isOptional() == spec.isOptional() && equalOrNull(getVersionRange(), spec.getVersionRange());
-		}
-		return false;
+		return obj instanceof RequirementSpecification spec //
+				&& getName().equals(spec.getName()) && isExported() == spec.isExported()
+				&& isOptional() == spec.isOptional() && Objects.equals(getVersion(), spec.getVersion());
 	}
 
 	@Override
@@ -69,13 +70,6 @@ public abstract class RequirementSpecification {
 			code = code + 2;
 		}
 		return code;
-	}
-
-	private boolean equalOrNull(Object o1, Object o2) {
-		if (o1 == null) {
-			return o2 == null;
-		}
-		return o1.equals(o2);
 	}
 
 	public boolean isOptional() {


### PR DESCRIPTION
Provide alternatives that are using `org.osgi.framework.VersionRange` and deprecate the existing methods for removal.

This is extracted from https://github.com/eclipse-pde/eclipse.pde/pull/1163 handling only the `simple` cases.

Part of https://github.com/eclipse-pde/eclipse.pde/issues/1069.