### PR TITLE
Modernize pde.project description interfaces

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -43,6 +43,7 @@ Bundle-Activator: org.eclipse.pde.api.tools.tests.ApiTestsPlugin
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Import-Package: junit.framework,
+ org.assertj.core.api;version="[3.26.0,4.0.0)",
  org.eclipse.equinox.frameworkadmin,
  org.junit,
  org.junit.runner,

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/tests/util/ProjectUtils.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/tests/util/ProjectUtils.java
@@ -367,7 +367,7 @@ public class ProjectUtils {
 		if (exports != null) {
 			List<IPackageExportDescription> list = new ArrayList<>();
 			for (IPackageExportDescription export : exports) {
-				if (!packagename.equals(export.getName())) {
+				if (!packagename.equals(export.name())) {
 					list.add(export);
 				}
 			}
@@ -389,7 +389,8 @@ public class ProjectUtils {
 	 * @param friends a listing of friends for this exported package
 	 * @throws CoreException if something bad happens
 	 */
-	public static void addExportedPackage(IProject project, String packagename, boolean internal, String[] friends) throws CoreException {
+	public static void addExportedPackage(IProject project, String packagename, boolean internal, List<String> friends)
+			throws CoreException {
 		if (!project.exists() || packagename == null) {
 			// do no work
 			return;

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/ApiBaselineManagerTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/ApiBaselineManagerTests.java
@@ -810,7 +810,7 @@ public class ApiBaselineManagerTests extends AbstractApiTest {
 		assertTestPackage(project, IPath.fromOSString(project.getElementName()).append(ProjectUtils.SRC_FOLDER).makeAbsolute(), "export1"); //$NON-NLS-1$
 
 		// export the package
-		ProjectUtils.addExportedPackage(project.getProject(), "export1", true, null); //$NON-NLS-1$
+		ProjectUtils.addExportedPackage(project.getProject(), "export1", true, List.of()); //$NON-NLS-1$
 
 		// check the description
 		IApiAnnotations annot = getTestProjectApiDescription().resolveAnnotations(Factory.packageDescriptor("export1")); //$NON-NLS-1$
@@ -853,7 +853,7 @@ public class ApiBaselineManagerTests extends AbstractApiTest {
 	 * sets the given package name to be an Exported-Package
 	 */
 	private void setPackageToApi(IJavaProject project, String name) throws CoreException {
-		ProjectUtils.addExportedPackage(project.getProject(), name, false, null);
+		ProjectUtils.addExportedPackage(project.getProject(), name, false, List.of());
 	}
 
 	IJavaProject getTestingProject() {

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/ProjectCreationTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/ProjectCreationTests.java
@@ -13,12 +13,14 @@
  *******************************************************************************/
 package org.eclipse.pde.api.tools.util.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -137,7 +139,7 @@ public class ProjectCreationTests extends AbstractApiTest {
 	private IPackageExportDescription getExport(IPackageExportDescription[] exports, String packageName) {
 		if (exports != null) {
 			for (IPackageExportDescription export : exports) {
-				if (export.getName().equals(packageName)) {
+				if (export.name().equals(packageName)) {
 					return export;
 				}
 			}
@@ -153,12 +155,12 @@ public class ProjectCreationTests extends AbstractApiTest {
 	 * @param friendcount the desired friend count
 	 */
 	private void assertExportedPackage(IPackageExportDescription export, boolean internalstate, int friendcount) {
-		String packagename = export.getName();
+		String packagename = export.name();
 		assertTrue("the package " + packagename + " must not be internal", export.isApi() == !internalstate); //$NON-NLS-1$ //$NON-NLS-2$
 		if (friendcount == 0) {
-			assertNull("the package should not have any friends", export.getFriends()); //$NON-NLS-1$
+			assertThat(export.friends()).isEmpty();
 		} else {
-			assertEquals("the package " + packagename + " must not have friends", friendcount, export.getFriends().length); //$NON-NLS-1$ //$NON-NLS-2$
+			assertEquals("the package " + packagename + " must not have friends", friendcount, export.friends().size()); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 
@@ -170,7 +172,7 @@ public class ProjectCreationTests extends AbstractApiTest {
 		String packagename = "org.eclipse.apitools.test"; //$NON-NLS-1$
 		IJavaProject jproject = getTestingJavaProject(TESTING_PROJECT_NAME);
 		IProject project = jproject.getProject();
-		ProjectUtils.addExportedPackage(project, packagename, false, null);
+		ProjectUtils.addExportedPackage(project, packagename, false, List.of());
 		IPackageExportDescription[] exports = ProjectUtils.getExportedPackages(project);
 		assertExportedPackage(getExport(exports, packagename), false, 0);
 	}
@@ -183,7 +185,7 @@ public class ProjectCreationTests extends AbstractApiTest {
 		String packagename = "org.eclipse.apitools.test.internal"; //$NON-NLS-1$
 		IJavaProject jproject = getTestingJavaProject(TESTING_PROJECT_NAME);
 		IProject project = jproject.getProject();
-		ProjectUtils.addExportedPackage(project, packagename, true, null);
+		ProjectUtils.addExportedPackage(project, packagename, true, List.of());
 		IPackageExportDescription[] exports = ProjectUtils.getExportedPackages(project);
 		assertExportedPackage(getExport(exports, packagename), true, 0);
 	}
@@ -196,8 +198,7 @@ public class ProjectCreationTests extends AbstractApiTest {
 		String packagename = "org.eclipse.apitools.test.4friends"; //$NON-NLS-1$
 		IJavaProject jproject = getTestingJavaProject(TESTING_PROJECT_NAME);
 		IProject project = jproject.getProject();
-		ProjectUtils.addExportedPackage(project, packagename, false, new String[] {
-				"F1", "F2", "F3", "F4" }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		ProjectUtils.addExportedPackage(project, packagename, false, List.of("F1", "F2", "F3", "F4")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		IPackageExportDescription[] exports = ProjectUtils.getExportedPackages(project);
 		assertExportedPackage(getExport(exports, packagename), true, 4);
 	}
@@ -209,8 +210,9 @@ public class ProjectCreationTests extends AbstractApiTest {
 	public void testAddMultipleExportedPackages() throws CoreException {
 		IJavaProject jproject = getTestingJavaProject(TESTING_PROJECT_NAME);
 		IProject project = jproject.getProject();
-		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.multi.friends", false, new String[] { "F1", "F2", "F3", "F4" }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.multi.internal", true, null); //$NON-NLS-1$
+		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.multi.friends", false, //$NON-NLS-1$
+				List.of("F1", "F2", "F3", "F4")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.multi.internal", true, List.of()); //$NON-NLS-1$
 		IPackageExportDescription[] exports = ProjectUtils.getExportedPackages(project);
 		assertExportedPackage(getExport(exports, "org.eclipse.apitools.test.multi.friends"), true, 4); //$NON-NLS-1$
 		assertExportedPackage(getExport(exports, "org.eclipse.apitools.test.multi.internal"), true, 0); //$NON-NLS-1$
@@ -223,8 +225,8 @@ public class ProjectCreationTests extends AbstractApiTest {
 	public void testRemoveExistingExportedPackage() throws CoreException {
 		IJavaProject jproject = getTestingJavaProject(TESTING_PROJECT_NAME);
 		IProject project = jproject.getProject();
-		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.remove1", false, new String[] { "F1" }); //$NON-NLS-1$ //$NON-NLS-2$
-		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.remove2", true, null); //$NON-NLS-1$
+		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.remove1", false, List.of("F1")); //$NON-NLS-1$ //$NON-NLS-2$
+		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.remove2", true, List.of()); //$NON-NLS-1$
 		IPackageExportDescription[] exports = ProjectUtils.getExportedPackages(project);
 		assertExportedPackage(getExport(exports, "org.eclipse.apitools.test.remove1"), true, 1); //$NON-NLS-1$
 		assertExportedPackage(getExport(exports, "org.eclipse.apitools.test.remove2"), true, 0); //$NON-NLS-1$
@@ -241,7 +243,7 @@ public class ProjectCreationTests extends AbstractApiTest {
 	public void testRemoveNonExistingExportedPackage() throws CoreException {
 		IJavaProject jproject = getTestingJavaProject(TESTING_PROJECT_NAME);
 		IProject project = jproject.getProject();
-		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.removeA", false, new String[] { "F1" }); //$NON-NLS-1$ //$NON-NLS-2$
+		ProjectUtils.addExportedPackage(project, "org.eclipse.apitools.test.removeA", false, List.of("F1")); //$NON-NLS-1$ //$NON-NLS-2$
 		IPackageExportDescription[] exports = ProjectUtils.getExportedPackages(project);
 		assertExportedPackage(getExport(exports, "org.eclipse.apitools.test.removeA"), true, 1); //$NON-NLS-1$
 		ProjectUtils.removeExportedPackage(project, "org.eclipse.apitools.test.dont.exist"); //$NON-NLS-1$

--- a/e4tools/bundles/org.eclipse.e4.tools/src/org/eclipse/e4/internal/tools/wizards/classes/AbstractNewClassWizard.java
+++ b/e4tools/bundles/org.eclipse.e4.tools/src/org/eclipse/e4/internal/tools/wizards/classes/AbstractNewClassWizard.java
@@ -173,7 +173,7 @@ public abstract class AbstractNewClassWizard extends Wizard implements INewWizar
 				descs.addAll(Arrays.asList(arTmp));
 			}
 			for (final IRequiredBundleDescription bd : descs) {
-				requiredBundles.remove(bd.getName());
+				requiredBundles.remove(bd.name());
 			}
 
 			if (requiredBundles.size() > 0) {
@@ -188,7 +188,7 @@ public abstract class AbstractNewClassWizard extends Wizard implements INewWizar
 				imDescs.addAll(Arrays.asList(currentImportPacks));
 			}
 			for (final IPackageImportDescription ds : imDescs) {
-				requiredImportPacks.remove(ds.getName());
+				requiredImportPacks.remove(ds.name());
 			}
 			if (!requiredImportPacks.isEmpty()) {
 				for (final String i : requiredImportPacks) {

--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the issue here
 Fix deprecation tag 'since' value
+Modernize pde.project description interfaces: https://github.com/eclipse-pde/eclipse.pde/pull/1341

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IBundleProjectService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IBundleProjectService.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.core.project;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -94,11 +97,22 @@ public interface IBundleProjectService {
 	 * @param name fully qualified package name
 	 * @param version version or <code>null</code>
 	 * @param api whether the package is considered API
-	 * @param friends symbolic names of bundles that are friends, or <code>null</code>; when
+	 * @param friends symbolic names of bundles that are friends; when
 	 *  friends are specified the package will not be API
 	 * @return package export description
+	 * @since 3.19
 	 */
-	IPackageExportDescription newPackageExport(String name, Version version, boolean api, String[] friends);
+	IPackageExportDescription newPackageExport(String name, Version version, boolean api, Collection<String> friends);
+
+	/**
+	 * @deprecated Instead use
+	 *             {@link #newPackageExport(String, Version, boolean, Collection)}
+	 */
+	@Deprecated(since = "3.19")
+	default IPackageExportDescription newPackageExport(String name, Version version, boolean api, String[] friends) {
+		return newPackageExport(name, version, api, friends != null ? List.of(friends) : List.of());
+	}
+
 
 	/**
 	 * Creates and returns a new required bundle description.

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IHostDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IHostDescription.java
@@ -29,8 +29,15 @@ public interface IHostDescription {
 	 * Returns the symbolic name of the host.
 	 *
 	 * @return symbolic name of the host
+	 * @since 3.19
 	 */
-	String getName();
+	String name();
+
+	/** @deprecated Instead use {@link #name()} */
+	@Deprecated(since = "3.19")
+	default String getName() {
+		return name();
+	}
 
 	/**
 	 * Returns the version constraint of the host or <code>null</code>
@@ -39,12 +46,12 @@ public interface IHostDescription {
 	 * @return version constraint or <code>null</code>
 	 * @since 3.19
 	 */
-	VersionRange getVersion();
+	VersionRange version();
 
-	/** @deprecated Instead use {@link #getVersion()} */
+	/** @deprecated Instead use {@link #version()} */
 	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
-		VersionRange version = getVersion();
+		VersionRange version = version();
 		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageExportDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageExportDescription.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.core.project;
 
+import java.util.Set;
+import java.util.SortedSet;
+
 import org.osgi.framework.Version;
 
 /**
@@ -29,28 +32,50 @@ public interface IPackageExportDescription {
 	 * Returns the fully qualified name of the exported package.
 	 *
 	 * @return fully qualified name of the exported package
+	 * @since 3.19
 	 */
-	public String getName();
+	String name();
+
+	/** @deprecated Instead use {@link #name()} */
+	@Deprecated(since = "3.19")
+	default String getName() {
+		return name();
+	}
 
 	/**
-	 * Returns the version of the exported package or <code>null</code>
-	 * if unspecified.
+	 * Returns the version of the exported package or <code>null</code> if
+	 * unspecified.
 	 *
 	 * @return version or <code>null</code>
+	 * @since 3.19
 	 */
-	public Version getVersion();
+	Version version();
+
+	/** @deprecated Instead use {@link #version()} */
+	@Deprecated(since = "3.19")
+	default Version getVersion() {
+		return version();
+	}
 
 	/**
-	 * Returns the declared friends of this package or <code>null</code> if none.
+	 * Returns the declared friends of this package.
 	 *
-	 * @return friends as bundle symbolic names or <code>null</code>
+	 * @return friends as bundle symbolic names, may be empty
+	 * @since 3.19
 	 */
-	public String[] getFriends();
+	SortedSet<String> friends();
+
+	/** @deprecated Instead use {@link #friends()} */
+	@Deprecated(since = "3.19")
+	default String[] getFriends() {
+		Set<String> friends = friends();
+		return friends.isEmpty() ? null : friends.toArray(String[]::new);
+	}
 
 	/**
 	 * Returns whether the package is exported as API, or is internal.
 	 *
 	 * @return whether the package is exported as API
 	 */
-	public boolean isApi();
+	boolean isApi();
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageImportDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageImportDescription.java
@@ -29,8 +29,15 @@ public interface IPackageImportDescription {
 	 * Returns the fully qualified name of the imported package.
 	 *
 	 * @return fully qualified name of the imported package
+	 * @since 3.19
 	 */
-	String getName();
+	String name();
+
+	/** @deprecated Instead use {@link #name()} */
+	@Deprecated(since = "3.19")
+	default String getName() {
+		return name();
+	}
 
 	/**
 	 * Returns the version constraint of the imported package or <code>null</code>
@@ -39,12 +46,12 @@ public interface IPackageImportDescription {
 	 * @return version constraint or <code>null</code>
 	 * @since 3.19
 	 */
-	VersionRange getVersion();
+	VersionRange version();
 
-	/** @deprecated Instead use {@link #getVersion()} */
+	/** @deprecated Instead use {@link #version()} */
 	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
-		VersionRange version = getVersion();
+		VersionRange version = version();
 		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IRequiredBundleDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IRequiredBundleDescription.java
@@ -29,8 +29,15 @@ public interface IRequiredBundleDescription {
 	 * Returns the symbolic name of the required bundle.
 	 *
 	 * @return symbolic name of the required bundle
+	 * @since 3.19
 	 */
-	String getName();
+	String name();
+
+	/** @deprecated Instead use {@link #name()} */
+	@Deprecated(since = "3.19")
+	default String getName() {
+		return name();
+	}
 
 	/**
 	 * Returns the version constraint of the required bundle or <code>null</code>
@@ -39,12 +46,12 @@ public interface IRequiredBundleDescription {
 	 * @return version constraint or <code>null</code>
 	 * @since 3.19
 	 */
-	VersionRange getVersion();
+	VersionRange version();
 
-	/** @deprecated Instead use {@link #getVersion()} */
+	/** @deprecated Instead use {@link #version()} */
 	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
-		VersionRange version = getVersion();
+		VersionRange version = version();
 		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectDescription.java
@@ -293,7 +293,8 @@ public class BundleProjectDescription implements IBundleProjectDescription {
 					if (directive != null) {
 						friends = ManifestElement.getArrayFromList(directive);
 					}
-					exports[i] = getBundleProjectService().newPackageExport(exp.getValue(), getVersion(pv), !internal, friends);
+					exports[i] = getBundleProjectService().newPackageExport(exp.getValue(), getVersion(pv), !internal,
+							friends != null ? List.of(friends) : List.of());
 				}
 				setPackageExports(exports);
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectService.java
@@ -19,11 +19,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -100,15 +103,6 @@ public final class BundleProjectService implements IBundleProjectService {
 	}
 
 	record HostDescription(String name, VersionRange version) implements IHostDescription {
-		@Override
-		public String getName() {
-			return name();
-		}
-
-		@Override
-		public VersionRange getVersion() {
-			return version();
-		}
 	}
 
 	@Override
@@ -118,39 +112,18 @@ public final class BundleProjectService implements IBundleProjectService {
 
 	record PackageImportDescription(String name, VersionRange version, boolean isOptional)
 			implements IPackageImportDescription {
-		@Override
-		public String getName() {
-			return name();
-		}
-
-		@Override
-		public VersionRange getVersion() {
-			return version();
-		}
 	}
 
 	@Override
-	public IPackageExportDescription newPackageExport(String name, Version version, boolean api, String[] friends) {
-		List<String> friendsList = friends != null ? List.of(friends) : List.of();
-		return new PackageExportDescription(name, version, friendsList, friendsList.isEmpty() ? api : false);
+	public IPackageExportDescription newPackageExport(String name, Version version, boolean api,
+			Collection<String> friends) {
+		return new PackageExportDescription(name, version, friends, friends.isEmpty() ? api : false);
 	}
 
-	record PackageExportDescription(String name, Version version, List<String> friends, boolean isApi)
+	record PackageExportDescription(String name, Version version, SortedSet<String> friends, boolean isApi)
 			implements IPackageExportDescription {
-
-		@Override
-		public String getName() {
-			return name();
-		}
-
-		@Override
-		public Version getVersion() {
-			return version();
-		}
-
-		@Override
-		public String[] getFriends() {
-			return friends.isEmpty() ? null : friends.toArray(String[]::new);
+		public PackageExportDescription(String name, Version version, Collection<String> friends, boolean isApi) {
+			this(name, version, Collections.unmodifiableSortedSet(new TreeSet<>(friends)), isApi);
 		}
 	}
 
@@ -161,15 +134,6 @@ public final class BundleProjectService implements IBundleProjectService {
 
 	record RequiredBundleDescription(String name, VersionRange version, boolean isExported, boolean isOptional)
 			implements IRequiredBundleDescription {
-		@Override
-		public String getName() {
-			return name();
-		}
-
-		@Override
-		public VersionRange getVersion() {
-			return version();
-		}
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
@@ -518,9 +518,9 @@ public class ProjectModifyOperation {
 			// host specification
 			IHostDescription host = description.getHost();
 			if (!isEqual(host, before.getHost())) {
-				fragment.setPluginId(host.getName());
-				if (host.getVersion() != null) {
-					fragment.setPluginVersion(host.getVersion().toString());
+				fragment.setPluginId(host.name());
+				if (host.version() != null) {
+					fragment.setPluginVersion(host.version().toString());
 				} else {
 					// must explicitly set to null, else it appears as 0.0.0
 					fragment.setPluginVersion(null);
@@ -548,9 +548,9 @@ public class ProjectModifyOperation {
 			}
 			if (dependencies != null) {
 				for (IRequiredBundleDescription req : dependencies) {
-					VersionRange range = req.getVersion();
+					VersionRange range = req.version();
 					IPluginImport iimport = fModel.getPluginFactory().createImport();
-					iimport.setId(req.getName());
+					iimport.setId(req.name());
 					if (range != null) {
 						iimport.setVersion(range.toString());
 						iimport.setMatch(IMatchRules.COMPATIBLE);
@@ -603,8 +603,8 @@ public class ProjectModifyOperation {
 				} else {
 					ImportPackageHeader header = (ImportPackageHeader) factory.createHeader(Constants.IMPORT_PACKAGE, ""); //$NON-NLS-1$
 					for (IPackageImportDescription pkg : packages) {
-						ImportPackageObject ip = header.addPackage(pkg.getName());
-						VersionRange range = pkg.getVersion();
+						ImportPackageObject ip = header.addPackage(pkg.name());
+						VersionRange range = pkg.version();
 						if (range != null) {
 							ip.setVersion(range.toString());
 						}
@@ -622,13 +622,13 @@ public class ProjectModifyOperation {
 				} else {
 					ExportPackageHeader header = (ExportPackageHeader) factory.createHeader(Constants.EXPORT_PACKAGE, ""); //$NON-NLS-1$
 					for (IPackageExportDescription pkg : exports) {
-						ExportPackageObject epo = header.addPackage(pkg.getName());
-						Version version = pkg.getVersion();
+						ExportPackageObject epo = header.addPackage(pkg.name());
+						Version version = pkg.version();
 						if (version != null) {
 							epo.setVersion(version.toString());
 						}
-						String[] friends = pkg.getFriends();
-						if (friends != null) {
+						Set<String> friends = pkg.friends();
+						if (!friends.isEmpty()) {
 							for (String friend : friends) {
 								epo.addFriend(new PackageFriend(epo, friend));
 							}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/ProjectCreationTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/ProjectCreationTests.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -519,12 +520,11 @@ public class ProjectCreationTests {
 		IBundleProjectService service = getBundleProjectService();
 		IBundleClasspathEntry spec = service.newBundleClasspathEntry(src, null, IPath.fromOSString("."));
 		description.setBundleClasspath(new IBundleClasspathEntry[] { spec });
-		IPackageExportDescription ex0 = service.newPackageExport("a.b.c", new Version("2.0.0"), true, null);
-		IPackageExportDescription ex1 = service.newPackageExport("a.b.c.interal", null, false, null);
-		IPackageExportDescription ex2 = service.newPackageExport("a.b.c.interal.x", null, false,
-				new String[] { "x.y.z" });
+		IPackageExportDescription ex0 = service.newPackageExport("a.b.c", new Version("2.0.0"), true, List.of());
+		IPackageExportDescription ex1 = service.newPackageExport("a.b.c.interal", null, false, List.of());
+		IPackageExportDescription ex2 = service.newPackageExport("a.b.c.interal.x", null, false, List.of("x.y.z"));
 		IPackageExportDescription ex3 = service.newPackageExport("a.b.c.interal.y", new Version("1.2.3"), false,
-				new String[] { "d.e.f", "g.h.i" });
+				List.of("d.e.f", "g.h.i"));
 		description.setPackageExports(new IPackageExportDescription[] { ex0, ex1, ex2, ex3 });
 		description.setActivationPolicy(Constants.ACTIVATION_LAZY);
 		description.apply(null);
@@ -716,12 +716,11 @@ public class ProjectCreationTests {
 		IPath src = IPath.fromOSString("srcA");
 		IBundleClasspathEntry spec = service.newBundleClasspathEntry(src, null, IPath.fromOSString("a.jar"));
 		description.setBundleClasspath(new IBundleClasspathEntry[] { spec });
-		IPackageExportDescription ex0 = service.newPackageExport("a.b.c", new Version("2.0.0"), true, null);
-		IPackageExportDescription ex1 = service.newPackageExport("a.b.c.interal", null, false, null);
-		IPackageExportDescription ex2 = service.newPackageExport("a.b.c.interal.x", null, false,
-				new String[] { "x.y.z" });
+		IPackageExportDescription ex0 = service.newPackageExport("a.b.c", new Version("2.0.0"), true, List.of());
+		IPackageExportDescription ex1 = service.newPackageExport("a.b.c.interal", null, false, List.of());
+		IPackageExportDescription ex2 = service.newPackageExport("a.b.c.interal.x", null, false, List.of("x.y.z"));
 		IPackageExportDescription ex3 = service.newPackageExport("a.b.c.interal.y", new Version("1.2.3"), false,
-				new String[] { "d.e.f", "g.h.i" });
+				List.of("d.e.f", "g.h.i"));
 		description.setPackageExports(new IPackageExportDescription[] { ex0, ex1, ex2, ex3 });
 		description.apply(null);
 
@@ -730,8 +729,7 @@ public class ProjectCreationTests {
 		IPath srcB = IPath.fromOSString("srcB");
 		IBundleClasspathEntry specB = service.newBundleClasspathEntry(srcB, null, IPath.fromOSString("b.jar"));
 		modify.setBundleClasspath(new IBundleClasspathEntry[] { specB });
-		IPackageExportDescription ex4 = service.newPackageExport("x.y.z.interal", null, false,
-				new String[] { "zz.top" });
+		IPackageExportDescription ex4 = service.newPackageExport("x.y.z.interal", null, false, List.of("zz.top"));
 		modify.setPackageExports(new IPackageExportDescription[] { ex0, ex2, ex4, ex3 }); // remove,
 		// add,
 		// re-order
@@ -803,12 +801,11 @@ public class ProjectCreationTests {
 		description.setRequiredBundles(
 				new IRequiredBundleDescription[] { requireDesc, requireDesc2, requireDesc3, requireDesc4 });
 
-		IPackageExportDescription ex0 = service.newPackageExport("a.b.c", new Version("2.0.0"), true, null);
-		IPackageExportDescription ex1 = service.newPackageExport("a.b.c.interal", null, false, null);
-		IPackageExportDescription ex2 = service.newPackageExport("a.b.c.interal.x", null, false,
-				new String[] { "x.y.z" });
+		IPackageExportDescription ex0 = service.newPackageExport("a.b.c", new Version("2.0.0"), true, List.of());
+		IPackageExportDescription ex1 = service.newPackageExport("a.b.c.interal", null, false, List.of());
+		IPackageExportDescription ex2 = service.newPackageExport("a.b.c.interal.x", null, false, List.of("x.y.z"));
 		IPackageExportDescription ex3 = service.newPackageExport("a.b.c.interal.y", new Version("1.2.3"), false,
-				new String[] { "d.e.f", "g.h.i" });
+				List.of("d.e.f", "g.h.i"));
 		description.setPackageExports(new IPackageExportDescription[] { ex0, ex1, ex2, ex3 });
 
 		IPackageImportDescription importDesc = service.newPackageImport("importPkgOne", NO_VERSION, false);
@@ -833,10 +830,9 @@ public class ProjectCreationTests {
 		description.setRequiredBundles(new IRequiredBundleDescription[] { requireDesc, requireDesc2, requireDesc3,
 				requireDesc4, requireDesc5, requireDesc6 });
 
-		IPackageExportDescription ex4 = service.newPackageExport("a.b.c.interal.x2", null, false,
-				new String[] { "x.y.z" });
+		IPackageExportDescription ex4 = service.newPackageExport("a.b.c.interal.x2", null, false, List.of("x.y.z"));
 		IPackageExportDescription ex5 = service.newPackageExport("a.b.c.interal.y2", new Version("1.2.3"), false,
-				new String[] { "d.e.f", "g.h.i" });
+				List.of("d.e.f", "g.h.i"));
 		description.setPackageExports(new IPackageExportDescription[] { ex0, ex1, ex2, ex3, ex4, ex5 });
 
 		IPackageImportDescription importDesc5 = service.newPackageImport("importPkgFive", NO_VERSION, true);
@@ -945,8 +941,8 @@ public class ProjectCreationTests {
 		IBundleClasspathEntry one = service.newBundleClasspathEntry(null, null, IPath.fromOSString("one.jar"));
 		IBundleClasspathEntry two = service.newBundleClasspathEntry(null, null, IPath.fromOSString("lib/two.jar"));
 		description.setBundleClasspath(new IBundleClasspathEntry[] { one, two });
-		IPackageExportDescription exp1 = service.newPackageExport("org.eclipse.one", new Version("1.0.0"), true, null);
-		IPackageExportDescription exp2 = service.newPackageExport("org.eclipse.two", new Version("1.0.0"), true, null);
+		IPackageExportDescription exp1 = service.newPackageExport("org.eclipse.one", new Version("1.0.0"), true, List.of());
+		IPackageExportDescription exp2 = service.newPackageExport("org.eclipse.two", new Version("1.0.0"), true, List.of());
 		description.setPackageExports(new IPackageExportDescription[] { exp1, exp2 });
 		description.setBundleVersion(new Version("1.0.0"));
 		description.setExecutionEnvironments(new String[] { "J2SE-1.5" });
@@ -1026,8 +1022,8 @@ public class ProjectCreationTests {
 		IBundleClasspathEntry one = service.newBundleClasspathEntry(null, IPath.fromOSString("bin1"), IPath.fromOSString("one.jar"));
 		IBundleClasspathEntry two = service.newBundleClasspathEntry(null, IPath.fromOSString("bin2"), IPath.fromOSString("two.jar"));
 		description.setBundleClasspath(new IBundleClasspathEntry[] { one, two });
-		IPackageExportDescription exp1 = service.newPackageExport("org.eclipse.one", new Version("1.0.0"), true, null);
-		IPackageExportDescription exp2 = service.newPackageExport("org.eclipse.two", new Version("1.0.0"), true, null);
+		IPackageExportDescription exp1 = service.newPackageExport("org.eclipse.one", new Version("1.0.0"), true, List.of());
+		IPackageExportDescription exp2 = service.newPackageExport("org.eclipse.two", new Version("1.0.0"), true, List.of());
 		description.setPackageExports(new IPackageExportDescription[] { exp1, exp2 });
 		description.setBundleVersion(new Version("1.0.0"));
 		description.setExecutionEnvironments(new String[] { "J2SE-1.5" });
@@ -1472,9 +1468,9 @@ public class ProjectCreationTests {
 		IPackageImportDescription imp2 = getBundleProjectService().newPackageImport("org.eclipse.core.runtime", NO_VERSION, false);
 		IPackageImportDescription imp3 = getBundleProjectService().newPackageImport("org.eclipse.core.resources", NO_VERSION, false);
 		description.setPackageImports(new IPackageImportDescription[] { imp1, imp2, imp3 });
-		IPackageExportDescription ex1 = getBundleProjectService().newPackageExport("a.b.c", null, true, null);
-		IPackageExportDescription ex2 = getBundleProjectService().newPackageExport("a.b.c.d", null, true, null);
-		IPackageExportDescription ex3 = getBundleProjectService().newPackageExport("a.b.c.e", null, true, null);
+		IPackageExportDescription ex1 = getBundleProjectService().newPackageExport("a.b.c", null, true, List.of());
+		IPackageExportDescription ex2 = getBundleProjectService().newPackageExport("a.b.c.d", null, true, List.of());
+		IPackageExportDescription ex3 = getBundleProjectService().newPackageExport("a.b.c.e", null, true, List.of());
 		description.setPackageExports(new IPackageExportDescription[] { ex1, ex2, ex3 });
 		IProject project = description.getProject();
 		description.apply(null);
@@ -1613,8 +1609,8 @@ public class ProjectCreationTests {
 		IBundleClasspathEntry one = service.newBundleClasspathEntry(IPath.fromOSString("src"),
 				IPath.fromOSString("WebContent/WEB-INF/classes"), IPath.fromOSString("WebContent/WEB-INF/classes"));
 		description.setBundleClasspath(new IBundleClasspathEntry[] { one });
-		IPackageExportDescription exp1 = service.newPackageExport("org.eclipse.one", new Version("1.0.0"), true, null);
-		IPackageExportDescription exp2 = service.newPackageExport("org.eclipse.two", new Version("1.0.0"), true, null);
+		IPackageExportDescription exp1 = service.newPackageExport("org.eclipse.one", new Version("1.0.0"), true, List.of());
+		IPackageExportDescription exp2 = service.newPackageExport("org.eclipse.two", new Version("1.0.0"), true, List.of());
 		description.setPackageExports(new IPackageExportDescription[] { exp1, exp2 });
 		description.setBundleVersion(new Version("1.0.0"));
 		description.setExecutionEnvironments(new String[] { "J2SE-1.5" });
@@ -1675,12 +1671,12 @@ public class ProjectCreationTests {
 		IBundleProjectService service = getBundleProjectService();
 		IBundleProjectDescription description = newProject();
 		IProject project = description.getProject();
-		IPackageExportDescription e1 = service.newPackageExport("a.b.c", null, true, null);
+		IPackageExportDescription e1 = service.newPackageExport("a.b.c", null, true, List.of());
 		description.setPackageExports(new IPackageExportDescription[] { e1 });
 		description.apply(null);
 
 		IBundleProjectDescription d2 = service.getDescription(project);
-		IPackageExportDescription e2 = service.newPackageExport("a.b.c.internal", null, false, null);
+		IPackageExportDescription e2 = service.newPackageExport("a.b.c.internal", null, false, List.of());
 		d2.setPackageExports(new IPackageExportDescription[] { e1, e2 });
 		d2.apply(null);
 


### PR DESCRIPTION
Based on the discussion in https://github.com/eclipse-pde/eclipse.pde/pull/1340, this is a draft to explore a possible modernization of the pde.project description API interfaces. The main changes are:

1. Rename getters starting with `getX()` by record-component style methods just naming what is returned (i.e. `X()`)
2. Use Lists instead of Arrays

This allows to simplify the implementations of these interfaces to be simple records where the required methods are implemented implicitly, which is also used in this PR.

Because point one does not have a great benefit for consumers, the existing methods are kept as deprecated (but not for removal) so consumers are not forced to update.

While the new methods are in a nice and modern style, I'm not sure if the change is worth the effort for consumers.
Instead of going the full path, we could also only apply parts of this. For example only use records as implementations and implement the getters explicitly and only do the Array-to-List method change.