### PR TITLE
Migrate from equinox.resolver.VersionRange to osgi.VersionRange

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/ApiBaselineTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/model/tests/ApiBaselineTests.java
@@ -37,7 +37,6 @@ import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiComponent;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiTypeContainer;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiTypeRoot;
-import org.eclipse.pde.api.tools.internal.util.Util;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -70,12 +69,12 @@ public class ApiBaselineTests {
 			fBaseline = TestSuiteHelper.createTestingBaseline(TEST_PLUGINS);
 			assertNotNull("the testing baseline should exist", fBaseline); //$NON-NLS-1$
 			List<IRequiredComponentDescription> reqs = new ArrayList<>();
-			reqs.add(new RequiredComponentDescription("org.eclipse.core.runtime", new BundleVersionRange(Util.EMPTY_STRING))); //$NON-NLS-1$
+			reqs.add(new RequiredComponentDescription("org.eclipse.core.runtime", new BundleVersionRange("0.0.0"))); //$NON-NLS-1$ //$NON-NLS-2$
 			validateComponent(fBaseline, COMPONENT_A, "A Plug-in", _1_0_0, "J2SE-1.5", reqs); //$NON-NLS-1$ //$NON-NLS-2$
 
 			reqs = new ArrayList<>();
-			reqs.add(new RequiredComponentDescription("org.eclipse.core.runtime", new BundleVersionRange(Util.EMPTY_STRING))); //$NON-NLS-1$
-			reqs.add(new RequiredComponentDescription(COMPONENT_A, new BundleVersionRange(Util.EMPTY_STRING)));
+			reqs.add(new RequiredComponentDescription("org.eclipse.core.runtime", new BundleVersionRange("0.0.0"))); //$NON-NLS-1$ //$NON-NLS-2$
+			reqs.add(new RequiredComponentDescription(COMPONENT_A, new BundleVersionRange("0.0.0"))); //$NON-NLS-1$
 			validateComponent(fBaseline, COMPONENT_B, "B Plug-in", _1_0_0, "J2SE-1.4", reqs); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/BundleVersionRange.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/BundleVersionRange.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.api.tools.internal;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.api.tools.internal.provisional.IVersionRange;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Implementation of a required component description based on OSGi bundles.
@@ -48,22 +48,23 @@ public class BundleVersionRange implements IVersionRange {
 
 	@Override
 	public String getMaximumVersion() {
-		return fRange.getMaximum().toString();
+		Version right = fRange.getRight();
+		return right != null ? right.toString() : null;
 	}
 
 	@Override
 	public String getMinimumVersion() {
-		return fRange.getMinimum().toString();
+		return fRange.getLeft().toString();
 	}
 
 	@Override
 	public boolean isIncludeMaximum() {
-		return fRange.getIncludeMaximum();
+		return fRange.getRightType() == VersionRange.RIGHT_CLOSED;
 	}
 
 	@Override
 	public boolean isIncludeMinimum() {
-		return fRange.getIncludeMinimum();
+		return fRange.getLeftType() == VersionRange.LEFT_CLOSED;
 	}
 
 	@Override
@@ -86,7 +87,7 @@ public class BundleVersionRange implements IVersionRange {
 
 	@Override
 	public boolean isIncluded(String version) {
-		return fRange.isIncluded(new Version(version));
+		return fRange.includes(new Version(version));
 	}
 
 }

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
@@ -70,7 +70,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.osgi.service.resolver.ResolverError;
 import org.eclipse.osgi.service.resolver.VersionConstraint;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.api.tools.internal.ApiBaselineManager;
 import org.eclipse.pde.api.tools.internal.ApiFilterStore;
@@ -116,6 +115,7 @@ import org.eclipse.pde.api.tools.internal.util.SinceTagVersion;
 import org.eclipse.pde.api.tools.internal.util.Util;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Base implementation of the analyzer used in the {@link ApiAnalysisBuilder}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/IVersionRange.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/IVersionRange.java
@@ -37,7 +37,7 @@ public interface IVersionRange {
 	/**
 	 * Returns the maximum version in this range.
 	 *
-	 * @return maximum version
+	 * @return maximum version, {@code null} if no explicit upper bound is exists.
 	 */
 	public String getMaximumVersion();
 

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
@@ -59,7 +59,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.Messages;
 import org.eclipse.equinox.p2.publisher.eclipse.FeatureEntry;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.build.internal.tests.ant.AntUtils;
 import org.eclipse.pde.build.tests.BuildConfiguration;
 import org.eclipse.pde.build.tests.PDETestCase;
@@ -76,6 +75,7 @@ import org.eclipse.pde.internal.build.site.QualifierReplacer;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class ScriptGenerationTests extends PDETestCase {
 
@@ -704,45 +704,45 @@ public class ScriptGenerationTests extends PDETestCase {
 	@Test
 	public void testBug247091_2() throws Exception {
 		VersionRange range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0");
-		assertTrue(range.getIncludeMinimum());
-		assertTrue(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_CLOSED, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0"));
 		assertEquals(range.getRight(), new Version("1.0.0"));
 
 		range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0.qualifier");
-		assertTrue(range.getIncludeMinimum());
-		assertFalse(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_OPEN, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0"));
 		assertEquals(range.getRight(), new Version("1.0.1"));
 
 		range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0.zqualifier");
-		assertTrue(range.getIncludeMinimum());
-		assertFalse(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0.z"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_OPEN, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0.z"));
 		assertEquals(range.getRight(), new Version("1.0.1"));
 
 		range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0.abcqualifier");
-		assertTrue(range.getIncludeMinimum());
-		assertFalse(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0.abc"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_OPEN, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0.abc"));
 		assertEquals(range.getRight(), new Version("1.0.0.abd"));
 
 		range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0.abzqualifier");
-		assertTrue(range.getIncludeMinimum());
-		assertFalse(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0.abz"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_OPEN, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0.abz"));
 		assertEquals(range.getRight(), new Version("1.0.0.ac"));
 
 		range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0.abzzqualifier");
-		assertTrue(range.getIncludeMinimum());
-		assertFalse(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0.abzz"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_OPEN, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0.abzz"));
 		assertEquals(range.getRight(), new Version("1.0.0.ac"));
 
 		range = org.eclipse.pde.internal.build.Utils.createVersionRange("1.0.0.abzz_qualifier");
-		assertTrue(range.getIncludeMinimum());
-		assertFalse(range.getIncludeMaximum());
-		assertEquals(range.getMinimum(), new Version("1.0.0.abzz_"));
+		assertEquals(VersionRange.LEFT_CLOSED, range.getLeftType());
+		assertEquals(VersionRange.RIGHT_OPEN, range.getRightType());
+		assertEquals(range.getLeft(), new Version("1.0.0.abzz_"));
 		assertEquals(range.getRight(), new Version("1.0.0.abzza"));
 
 	}

--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.build;singleton:=true
-Bundle-Version: 3.12.400.qualifier
+Bundle-Version: 3.12.500.qualifier
 Bundle-ClassPath: pdebuild.jar
 Bundle-Activator: org.eclipse.pde.internal.build.BuildActivator
 Bundle-Vendor: %providerName

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/P2ConfigScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/P2ConfigScriptGenerator.java
@@ -39,15 +39,15 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.internal.build.ant.FileSet;
 import org.eclipse.pde.internal.build.builder.BuildDirector;
 import org.eclipse.pde.internal.build.builder.ModelBuildScriptGenerator;
 import org.eclipse.pde.internal.build.site.BuildTimeFeature;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class P2ConfigScriptGenerator extends AssembleConfigScriptGenerator {
-	private static final VersionRange OLD_EXECUTABLE_RANGE = new VersionRange(Version.emptyVersion, true, new Version(3, 3, 200, "v20090306-1900"), false); //$NON-NLS-1$
+	private static final VersionRange OLD_EXECUTABLE_RANGE = new VersionRange(VersionRange.LEFT_CLOSED, Version.emptyVersion, new Version(3, 3, 200, "v20090306-1900"), VersionRange.RIGHT_OPEN); //$NON-NLS-1$
 	private AssemblyInformation assemblyInformation = null;
 	private boolean assembling = false;
 	private boolean versionsList = false;
@@ -505,9 +505,9 @@ public class P2ConfigScriptGenerator extends AssembleConfigScriptGenerator {
 		if (!feature.getId().equals(FEATURE_EQUINOX_EXECUTABLE))
 			return false;
 
-		if (feature.isBinary() || !OLD_EXECUTABLE_RANGE.isIncluded(new Version(feature.getVersion())))
+		if (feature.isBinary() || !OLD_EXECUTABLE_RANGE.includes(new Version(feature.getVersion()))) {
 			return false;
-
+		}
 		Properties properties = getFeatureBuildProperties(feature);
 		return properties != null && Boolean.valueOf((String) properties.get(PROPERTY_CUSTOM)).booleanValue();
 	}

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/P2InfUtils.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/P2InfUtils.java
@@ -12,8 +12,8 @@
  ******************************************************************************/
 package org.eclipse.pde.internal.build;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class P2InfUtils {
 	public static final int INSTRUCTION_INSTALL = 0;
@@ -33,7 +33,7 @@ public class P2InfUtils {
 	}
 
 	public static void printBundleCU(StringBuffer buffer, int i, String name, String cuVersion, Version hostVersion, String filter, String[] instructions) {
-		VersionRange hostRange = new VersionRange(hostVersion, true, hostVersion, true);
+		VersionRange hostRange = Utils.createExactVersionRange(hostVersion);
 		//cuVersion may not be a proper OSGi version at this point (ie 1.0.0.$qualifier$)
 		String cuRange = "[" + cuVersion + "," + cuVersion + "]"; //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
 		String prefix = "units." + i + '.'; //$NON-NLS-1$

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ProductGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ProductGenerator.java
@@ -42,12 +42,12 @@ import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
 import org.eclipse.equinox.p2.publisher.eclipse.FeatureEntry;
 import org.eclipse.equinox.simpleconfigurator.manipulator.SimpleConfiguratorManipulator;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.internal.build.site.BuildTimeFeature;
 import org.eclipse.pde.internal.build.site.P2Utils;
 import org.eclipse.pde.internal.build.site.PDEState;
 import org.osgi.framework.Filter;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class ProductGenerator extends AbstractScriptGenerator {
 	private static final String SIMPLE_CONFIGURATOR_CONFIG_URL = "org.eclipse.equinox.simpleconfigurator.configUrl"; //$NON-NLS-1$
@@ -219,7 +219,7 @@ public class ProductGenerator extends AbstractScriptGenerator {
 			productVersionString = productVersion.getMajor() + "." + productVersion.getMinor() + "." + productVersion.getMicro() + ".$qualifier$"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			productRangeString = "[" + productVersionString + "," + productVersionString + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		} else {
-			productRangeString = new VersionRange(new Version(productVersionString), true, new Version(productVersionString), true).toString();
+			productRangeString = Utils.createExactVersionRange(new Version(productVersionString)).toString();
 		}
 
 		if (cus) {
@@ -251,7 +251,7 @@ public class ProductGenerator extends AbstractScriptGenerator {
 
 		BundleDescription launcher = assembly.getPlugin(BUNDLE_EQUINOX_LAUNCHER, null);
 		if (launcher != null && launchers) {
-			VersionRange launcherRange = new VersionRange(launcher.getVersion(), true, launcher.getVersion(), true);
+			VersionRange launcherRange = Utils.createExactVersionRange(launcher.getVersion());
 
 			// include the launcher jar
 			P2InfUtils.printRequires(buffer, null, index++, P2InfUtils.NAMESPACE_IU, BUNDLE_EQUINOX_LAUNCHER, launcherRange, launcher.getPlatformFilter(), true);
@@ -272,7 +272,7 @@ public class ProductGenerator extends AbstractScriptGenerator {
 			//in case of no version on the product, the branding defaults to the version of the launcher provider
 			if (executableFeature != null && productVersionString.equals(Version.emptyVersion.toString())) {
 				String brandedVersion = executableFeature.getVersion();
-				brandedRange = new VersionRange(new Version(brandedVersion), true, new Version(brandedVersion), true).toString();
+				brandedRange = Utils.createExactVersionRange(new Version(brandedVersion)).toString();
 			}
 
 			List<Config> configs = getConfigInfos();
@@ -284,7 +284,7 @@ public class ProductGenerator extends AbstractScriptGenerator {
 					fragmentName += '.' + config.getArch();
 				BundleDescription fragment = assembly.getPlugin(fragmentName, null);
 				if (fragment != null) {
-					VersionRange fragmentRange = new VersionRange(fragment.getVersion(), true, fragment.getVersion(), true);
+					VersionRange fragmentRange = Utils.createExactVersionRange(fragment.getVersion());
 					//include the launcher fragment
 					P2InfUtils.printRequires(buffer, null, index++, P2InfUtils.NAMESPACE_IU, fragmentName, fragmentRange, fragment.getPlatformFilter(), true);
 

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/BuildTimeSite.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/BuildTimeSite.java
@@ -47,7 +47,6 @@ import org.eclipse.osgi.service.resolver.NativeCodeSpecification;
 import org.eclipse.osgi.service.resolver.ResolverError;
 import org.eclipse.osgi.service.resolver.StateHelper;
 import org.eclipse.osgi.service.resolver.VersionConstraint;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.internal.build.AbstractScriptGenerator;
 import org.eclipse.pde.internal.build.BundleHelper;
@@ -60,6 +59,7 @@ import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.build.site.compatibility.FeatureReference;
 import org.osgi.framework.Filter;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * This site represent a site at build time. A build time site is made of code
@@ -304,9 +304,9 @@ public class BuildTimeSite /*extends Site*/ implements IPDEBuildConstants, IXMLC
 	}
 
 	private BuildTimeFeature findFeature(String featureId, VersionRange range, boolean throwsException) throws CoreException {
-		if (range == null)
-			range = VersionRange.emptyRange;
-
+		if (range == null) {
+			range = Utils.EMPTY_RANGE;
+		}
 		if (!featuresResolved)
 			resolveFeatureReferences();
 
@@ -315,7 +315,7 @@ public class BuildTimeSite /*extends Site*/ implements IPDEBuildConstants, IXMLC
 			Set<BuildTimeFeature> featureSet = featureCache.get(featureId);
 			for (BuildTimeFeature feature : featureSet) {
 				Version featureVersion = new Version(feature.getVersion());
-				if (range.isIncluded(featureVersion)) {
+				if (range.includes(featureVersion)) {
 					return feature;
 				}
 			}
@@ -323,7 +323,7 @@ public class BuildTimeSite /*extends Site*/ implements IPDEBuildConstants, IXMLC
 
 		if (throwsException) {
 			String message = null;
-			if (range.equals(VersionRange.emptyRange))
+			if (range.equals(Utils.EMPTY_RANGE))
 				message = NLS.bind(Messages.exception_missingFeature, featureId);
 			else
 				message = NLS.bind(Messages.exception_missingFeatureInRange, featureId, range);
@@ -422,7 +422,7 @@ public class BuildTimeSite /*extends Site*/ implements IPDEBuildConstants, IXMLC
 								expanded[includedRefs.length] = added;
 								includedRefs = expanded;
 							} else if (extraEntries[j].startsWith("plugin@")) { //$NON-NLS-1$
-								VersionRange range = new VersionRange(version, true, version.equals(Version.emptyVersion) ? (Version) null : version, true);
+								VersionRange range = version.equals(Version.emptyVersion) ? Utils.EMPTY_RANGE : Utils.createExactVersionRange(version);
 								allPlugins.add(new ReachablePlugin(id, range));
 							}
 						}

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/FilteringState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/FilteringState.java
@@ -32,7 +32,7 @@ public class FilteringState extends PDEState {
 
 		SortedSet<ReachablePlugin> includedMatches = allPlugins.subSet(new ReachablePlugin(toAdd.getSymbolicName(), ReachablePlugin.WIDEST_RANGE), new ReachablePlugin(toAdd.getSymbolicName(), ReachablePlugin.NARROWEST_RANGE));
 		for (ReachablePlugin constraint : includedMatches) {
-			if (constraint.getRange().isIncluded(toAdd.getVersion()))
+			if (constraint.getRange().includes(toAdd.getVersion()))
 				return super.addBundleDescription(toAdd);
 		}
 		return false;

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -53,7 +53,6 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.internal.build.AbstractScriptGenerator;
@@ -68,6 +67,7 @@ import org.eclipse.pde.internal.build.Utils;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 // This class provides a higher level API on the state
 public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
@@ -692,7 +692,7 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 			VersionRange qualifierRange = Utils.createVersionRange(version);
 			//bundles are sorted, start at the high end
 			for (int i = bundles.length - 1; i >= 0; i--) {
-				if (qualifierRange.isIncluded(bundles[i].getVersion()) && (!resolved || bundles[i].isResolved()))
+				if (qualifierRange.includes(bundles[i].getVersion()) && (!resolved || bundles[i].isResolved()))
 					return bundles[i];
 			}
 		}

--- a/e4tools/bundles/org.eclipse.e4.tools/META-INF/MANIFEST.MF
+++ b/e4tools/bundles/org.eclipse.e4.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.tools;singleton:=true
-Bundle-Version: 4.10.400.qualifier
+Bundle-Version: 4.10.500.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/e4tools/bundles/org.eclipse.e4.tools/src/org/eclipse/e4/internal/tools/wizards/classes/AbstractNewClassWizard.java
+++ b/e4tools/bundles/org.eclipse.e4.tools/src/org/eclipse/e4/internal/tools/wizards/classes/AbstractNewClassWizard.java
@@ -41,7 +41,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.project.IBundleProjectDescription;
 import org.eclipse.pde.core.project.IBundleProjectService;
 import org.eclipse.pde.core.project.IPackageImportDescription;
@@ -53,6 +52,7 @@ import org.eclipse.ui.ide.IDE;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.VersionRange;
 
 public abstract class AbstractNewClassWizard extends Wizard implements INewWizard {
 	private static final String JAVA = ".java"; //$NON-NLS-1$
@@ -178,7 +178,7 @@ public abstract class AbstractNewClassWizard extends Wizard implements INewWizar
 
 			if (requiredBundles.size() > 0) {
 				for (final String b : requiredBundles) {
-					descs.add(service.newRequiredBundle(b, null, false, false));
+					descs.add(service.newRequiredBundle(b, (VersionRange) null, false, false));
 				}
 				description.setRequiredBundles(descs.toArray(new IRequiredBundleDescription[0]));
 				description.apply(new NullProgressMonitor());
@@ -212,7 +212,7 @@ public abstract class AbstractNewClassWizard extends Wizard implements INewWizar
 		for (final String p : parts) {
 			if (p.startsWith("version=")) { //$NON-NLS-1$
 				final String version = p.substring("version=".length() + 1, p.length() - 1); //$NON-NLS-1$
-				return new VersionRange(version.trim());
+				return new VersionRange(version.isBlank() ? "0.0.0" : version.trim()); //$NON-NLS-1$
 			}
 		}
 		return null;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/P2Utils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/P2Utils.java
@@ -80,6 +80,7 @@ import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.build.BundleHelper;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ifeature.IEnvironment;
 import org.eclipse.pde.internal.core.ifeature.IFeature;
 import org.eclipse.pde.internal.core.ifeature.IFeatureChild;
@@ -895,11 +896,14 @@ public class P2Utils {
 		return Version.createOSGi(version.getMajor(), version.getMinor(), version.getMicro(), version.getQualifier());
 	}
 
-	private static VersionRange fromOSGiVersionRange(org.eclipse.osgi.service.resolver.VersionRange range) {
-		if (range.equals(org.eclipse.osgi.service.resolver.VersionRange.emptyRange)) {
+	private static VersionRange fromOSGiVersionRange(org.osgi.framework.VersionRange range) {
+		if (range.equals(Utils.EMPTY_RANGE)) {
 			return VersionRange.emptyRange;
 		}
-		return new VersionRange(fromOSGiVersion(range.getMinimum()), range.getIncludeMinimum(), fromOSGiVersion(range.getRight()), range.getIncludeMaximum());
+		return new VersionRange(fromOSGiVersion(range.getLeft()),
+				range.getLeftType() == org.osgi.framework.VersionRange.LEFT_CLOSED,
+				fromOSGiVersion(range.getRight()),
+				range.getRightType() == org.osgi.framework.VersionRange.RIGHT_CLOSED);
 	}
 
 	public static record ProductInfo(String id, String version, String name) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
@@ -511,9 +511,7 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 					}
 					if (supplier.isResolved()) {
 						Version version = supplier.getVersion();
-						// use fully qualified name to avoid conflict with other VersionRange class
-						org.eclipse.osgi.service.resolver.VersionRange range = host.getVersionRange();
-						if (!range.isIncluded(version)) {
+						if (!host.getVersionRange().includes(version)) {
 							String versionRange = host.getVersionRange().toString();
 							report(NLS.bind(PDECoreMessages.BundleErrorReporter_BundleRangeInvalidInBundleVersion, versionRange), getLine(header, versionRange), CompilerFlags.P_UNRESOLVED_IMPORTS, PDEMarkerFactory.CAT_FATAL);
 							return;
@@ -1201,8 +1199,8 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 				if (export != null) {
 					if (export.getSupplier().isResolved()) {
 						Version version = export.getVersion();
-						org.eclipse.osgi.service.resolver.VersionRange range = importSpec.getVersionRange();
-						if (range != null && !range.isIncluded(version)) {
+						VersionRange range = importSpec.getVersionRange();
+						if (range != null && !range.includes(version)) {
 							VirtualMarker marker = report(NLS.bind(PDECoreMessages.BundleErrorReporter_unsatisfiedConstraint,importSpec.toString()),getPackageLine(header, element), severity, PDEMarkerFactory.CAT_FATAL);
 							addMarkerAttribute(marker,PDEMarkerFactory.compilerKey,CompilerFlags.P_UNRESOLVED_IMPORTS);
 							return;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundleFragment.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundleFragment.java
@@ -14,8 +14,8 @@
 package org.eclipse.pde.internal.core.bundle;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.ManifestElement;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.ibundle.IBundle;
 import org.eclipse.pde.internal.core.ibundle.IBundleFragment;
@@ -24,6 +24,7 @@ import org.eclipse.pde.internal.core.plugin.PluginBase;
 import org.eclipse.pde.internal.core.text.bundle.FragmentHostHeader;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
+import org.osgi.framework.VersionRange;
 
 public class BundleFragment extends BundlePluginBase implements IBundleFragment {
 
@@ -38,8 +39,8 @@ public class BundleFragment extends BundlePluginBase implements IBundleFragment 
 	public String getPluginVersion() {
 		String version = getAttribute(Constants.FRAGMENT_HOST, Constants.BUNDLE_VERSION_ATTRIBUTE);
 		try {
-			VersionRange versionRange = new VersionRange(version);
-			return versionRange.getMinimum() != null ? versionRange.getMinimum().toString() : version;
+			VersionRange versionRange = Utils.parseVersionRange(version);
+			return versionRange.getLeft().toString();
 		} catch (IllegalArgumentException e) {
 		}
 		return version;
@@ -48,7 +49,7 @@ public class BundleFragment extends BundlePluginBase implements IBundleFragment 
 	@Override
 	public int getRule() {
 		String version = getAttribute(Constants.FRAGMENT_HOST, Constants.BUNDLE_VERSION_ATTRIBUTE);
-		VersionRange versionRange = new VersionRange(version);
+		VersionRange versionRange = Utils.parseVersionRange(version);
 		return PluginBase.getMatchRule(versionRange);
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/Fragment.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/Fragment.java
@@ -18,12 +18,12 @@ import java.io.PrintWriter;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.HostSpecification;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.plugin.IFragment;
 import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginExtension;
 import org.eclipse.pde.core.plugin.IPluginExtensionPoint;
 import org.eclipse.pde.internal.core.PDEState;
+import org.osgi.framework.VersionRange;
 import org.w3c.dom.Node;
 
 public class Fragment extends PluginBase implements IFragment {
@@ -70,7 +70,7 @@ public class Fragment extends PluginBase implements IFragment {
 		fPluginId = host.getName();
 		VersionRange versionRange = host.getVersionRange();
 		if (versionRange != null) {
-			fPluginVersion = versionRange.getMinimum() != null ? versionRange.getMinimum().toString() : null;
+			fPluginVersion = versionRange.getLeft().toString();
 			fMatchRule = PluginBase.getMatchRule(versionRange);
 		}
 		fPatch = state.isPatchFragment(bundleDescription.getBundleId());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginBase.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginBase.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.BundleSpecification;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.IModelChangedEvent;
 import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginBase;
@@ -32,6 +31,7 @@ import org.eclipse.pde.internal.core.PDECoreMessages;
 import org.eclipse.pde.internal.core.PDEState;
 import org.eclipse.pde.internal.core.bundle.BundlePluginBase;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -398,7 +398,7 @@ public abstract class PluginBase extends AbstractExtensions implements IPluginBa
 	}
 
 	public static int getMatchRule(VersionRange versionRange) {
-		if (versionRange == null || versionRange.getMinimum() == null) {
+		if (versionRange == null || versionRange.getLeft() == null) {
 			return IMatchRules.NONE;
 		}
 
@@ -409,7 +409,7 @@ public abstract class PluginBase extends AbstractExtensions implements IPluginBa
 			return IMatchRules.GREATER_OR_EQUAL;
 		} else if (minimum.equals(maximum)) {
 			return IMatchRules.PERFECT;
-		} else if (!versionRange.isIncluded(minimum) || versionRange.isIncluded(maximum)) {
+		} else if (!versionRange.includes(minimum) || versionRange.includes(maximum)) {
 			return IMatchRules.NONE; // no real match rule for this
 		} else if (minimum.getMajor() == maximum.getMajor() - 1) {
 			return IMatchRules.COMPATIBLE;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginImport.java
@@ -20,13 +20,13 @@ import java.util.Locale;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.BundleSpecification;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginImport;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginObject;
 import org.eclipse.pde.core.plugin.ISharedPluginModel;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.bundle.BundlePluginBase;
 import org.eclipse.pde.internal.core.ibundle.IBundle;
@@ -36,6 +36,7 @@ import org.eclipse.pde.internal.core.ibundle.IManifestHeader;
 import org.eclipse.pde.internal.core.text.bundle.ManifestHeader;
 import org.eclipse.pde.internal.core.text.bundle.RequireBundleObject;
 import org.osgi.framework.Constants;
+import org.osgi.framework.VersionRange;
 import org.w3c.dom.Node;
 
 public class PluginImport extends IdentifiablePluginObject implements IPluginImport, Serializable {
@@ -99,7 +100,7 @@ public class PluginImport extends IdentifiablePluginObject implements IPluginImp
 		String bundleVersion = element.getAttribute(Constants.BUNDLE_VERSION_ATTRIBUTE);
 		if (bundleVersion != null) {
 			try {
-				VersionRange versionRange = new VersionRange(bundleVersion);
+				VersionRange versionRange = Utils.parseVersionRange(bundleVersion);
 				this.version = bundleVersion;
 				this.match = PluginBase.getMatchRule(versionRange);
 			} catch (IllegalArgumentException e) {
@@ -112,11 +113,11 @@ public class PluginImport extends IdentifiablePluginObject implements IPluginImp
 		this.reexported = importModel.isExported();
 		this.optional = importModel.isOptional();
 		VersionRange versionRange = importModel.getVersionRange();
-		if (versionRange == null || VersionRange.emptyRange.equals(versionRange)) {
+		if (versionRange == null || Utils.EMPTY_RANGE.equals(versionRange)) {
 			this.version = null;
 			match = IMatchRules.NONE;
 		} else {
-			this.version = versionRange.getMinimum() != null ? versionRange.getMinimum().toString() : null;
+			this.version = versionRange.getLeft() != null ? versionRange.getLeft().toString() : null;
 			match = PluginBase.getMatchRule(versionRange);
 		}
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/BundleProjectDescription.java
@@ -33,7 +33,6 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.pde.core.build.IBuild;
 import org.eclipse.pde.core.build.IBuildEntry;
@@ -47,6 +46,7 @@ import org.eclipse.pde.core.project.IHostDescription;
 import org.eclipse.pde.core.project.IPackageExportDescription;
 import org.eclipse.pde.core.project.IPackageImportDescription;
 import org.eclipse.pde.core.project.IRequiredBundleDescription;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
@@ -54,6 +54,7 @@ import org.eclipse.pde.internal.core.build.WorkspaceBuildModel;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * A bundle project description contains the meta-data required to define
@@ -444,7 +445,7 @@ public class BundleProjectDescription implements IBundleProjectDescription {
 	 */
 	private VersionRange getRange(String version) {
 		if (version != null) {
-			return new VersionRange(version);
+			return Utils.parseVersionRange(version);
 		}
 		return null;
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/project/ProjectModifyOperation.java
@@ -38,7 +38,6 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.JavaRuntime;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.build.IBuild;
 import org.eclipse.pde.core.build.IBuildEntry;
 import org.eclipse.pde.core.build.IBuildModelFactory;
@@ -81,6 +80,7 @@ import org.eclipse.pde.internal.core.text.bundle.PackageFriend;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 import org.osgi.service.prefs.BackingStoreException;
 
 /**
@@ -519,8 +519,8 @@ public class ProjectModifyOperation {
 			IHostDescription host = description.getHost();
 			if (!isEqual(host, before.getHost())) {
 				fragment.setPluginId(host.getName());
-				if (host.getVersionRange() != null) {
-					fragment.setPluginVersion(host.getVersionRange().toString());
+				if (host.getVersion() != null) {
+					fragment.setPluginVersion(host.getVersion().toString());
 				} else {
 					// must explicitly set to null, else it appears as 0.0.0
 					fragment.setPluginVersion(null);
@@ -548,7 +548,7 @@ public class ProjectModifyOperation {
 			}
 			if (dependencies != null) {
 				for (IRequiredBundleDescription req : dependencies) {
-					VersionRange range = req.getVersionRange();
+					VersionRange range = req.getVersion();
 					IPluginImport iimport = fModel.getPluginFactory().createImport();
 					iimport.setId(req.getName());
 					if (range != null) {
@@ -604,7 +604,7 @@ public class ProjectModifyOperation {
 					ImportPackageHeader header = (ImportPackageHeader) factory.createHeader(Constants.IMPORT_PACKAGE, ""); //$NON-NLS-1$
 					for (IPackageImportDescription pkg : packages) {
 						ImportPackageObject ip = header.addPackage(pkg.getName());
-						VersionRange range = pkg.getVersionRange();
+						VersionRange range = pkg.getVersion();
 						if (range != null) {
 							ip.setVersion(range.toString());
 						}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
@@ -15,9 +15,9 @@ package org.eclipse.pde.internal.core.util;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.plugin.IMatchRules;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class VersionUtil {
 

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/BundleVersionHeader.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/BundleVersionHeader.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.text.bundle;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.internal.core.ibundle.IBundle;
+import org.osgi.framework.VersionRange;
 
 public class BundleVersionHeader extends SingleManifestHeader {
 

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/FragmentHostHeader.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/FragmentHostHeader.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.text.bundle;
 
-import org.eclipse.osgi.service.resolver.VersionRange;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ibundle.IBundle;
 import org.osgi.framework.Constants;
+import org.osgi.framework.VersionRange;
 
 public class FragmentHostHeader extends SingleManifestHeader {
 
@@ -38,7 +39,7 @@ public class FragmentHostHeader extends SingleManifestHeader {
 	}
 
 	public VersionRange getHostRange() {
-		return new VersionRange(getAttribute(Constants.BUNDLE_VERSION_ATTRIBUTE));
+		return Utils.parseVersionRange(getAttribute(Constants.BUNDLE_VERSION_ATTRIBUTE));
 	}
 
 }

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
@@ -17,8 +17,8 @@ import java.io.PrintWriter;
 import java.util.Arrays;
 
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.osgi.util.ManifestElement;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEState;
@@ -26,6 +26,7 @@ import org.eclipse.pde.internal.core.bundle.BundlePluginBase;
 import org.eclipse.pde.internal.core.ibundle.IBundleModel;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class ImportPackageObject extends PackageObject {
 
@@ -102,10 +103,10 @@ public class ImportPackageObject extends PackageObject {
 		PDEState pdeState = PDECore.getDefault().getModelManager().getState();
 		ExportPackageDescription[] exportedPackages = pdeState.getState().getExportedPackages();
 
-		VersionRange versionRange = new VersionRange(getVersion());
+		VersionRange versionRange = Utils.parseVersionRange(getVersion());
 		return Arrays.stream(exportedPackages)
 				.filter(p -> p.getName().equals(getName()))
-				.anyMatch(p -> versionRange.isIncluded(p.getVersion()));
+				.anyMatch(p -> versionRange.includes(p.getVersion()));
 	}
 
 }

--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.runtime; singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Activator: org.eclipse.pde.internal.runtime.PDERuntimePlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/MessageHelper.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/MessageHelper.java
@@ -17,6 +17,7 @@ import org.eclipse.osgi.service.resolver.BundleSpecification;
 import org.eclipse.osgi.service.resolver.ImportPackageSpecification;
 import org.eclipse.osgi.service.resolver.VersionConstraint;
 import org.eclipse.osgi.util.NLS;
+import org.osgi.framework.VersionRange;
 
 public class MessageHelper {
 	public static String getResolutionFailureMessage(VersionConstraint unsatisfied) {
@@ -33,7 +34,7 @@ public class MessageHelper {
 	}
 
 	private static String toString(VersionConstraint constraint) {
-		org.eclipse.osgi.service.resolver.VersionRange versionRange = constraint.getVersionRange();
+		VersionRange versionRange = constraint.getVersionRange();
 		if (versionRange == null)
 			return constraint.getName();
 		return constraint.getName() + '_' + versionRange;

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/RegistryModel.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/RegistryModel.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Model entry point for Eclipse runtime. Provides information about runtime bundles, services and extension points.
@@ -386,25 +386,12 @@ public class RegistryModel {
 		if (versionOrRange == null) {
 			return true;
 		}
-
 		try {
-			Version version = Version.parseVersion(versionOrRange);
-			if (hostVersion.compareTo(version) >= 0)
-				return true;
-
-		} catch (IllegalArgumentException e) {
-			// wrong formatting, try VersionRange
-		}
-
-		try {
-			VersionRange range = new VersionRange(versionOrRange);
-			if (range.isIncluded(hostVersion))
-				return true;
-
+			// only versions are parsed as right open range without upper limit
+			return new VersionRange(versionOrRange).includes(hostVersion);
 		} catch (IllegalArgumentException e2) {
 			// wrong range formatting
 		}
-
 		return false;
 	}
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/DependencyManagerTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/DependencyManagerTest.java
@@ -44,10 +44,10 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.target.NameVersionDescriptor;
+import org.eclipse.pde.internal.build.Utils;
 import org.eclipse.pde.internal.core.ClasspathComputer;
 import org.eclipse.pde.internal.core.PluginModelManager;
 import org.eclipse.pde.ui.tests.launcher.AbstractLaunchTest;
@@ -358,7 +358,7 @@ public class DependencyManagerTest {
 			boolean setTestAttribute) throws CoreException {
 
 		IProject project = ProjectUtils.createPluginProject(projectName, projectName, "1.0.0", (d, s) -> {
-			d.setHost(s.newHost(hostName, VersionRange.emptyRange));
+			d.setHost(s.newHost(hostName, Utils.EMPTY_RANGE));
 		});
 		IPluginModelBase model = PluginRegistry.findModel(project);
 		if (setTestAttribute) { // set test attribute in classpath

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/ProjectCreationTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/project/ProjectCreationTests.java
@@ -45,7 +45,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jface.text.Document;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.build.IBuildEntry;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -73,6 +72,7 @@ import org.junit.rules.TestName;
 import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Test project creation API.
@@ -81,11 +81,9 @@ import org.osgi.framework.Version;
  */
 public class ProjectCreationTests {
 
-	protected static final IBundleClasspathEntry DEFAULT_BUNDLE_CLASSPATH_ENTRY;
-
-	static {
-		DEFAULT_BUNDLE_CLASSPATH_ENTRY = getBundleProjectService().newBundleClasspathEntry(null, null, IPath.fromOSString("."));
-	}
+	protected static final IBundleClasspathEntry DEFAULT_BUNDLE_CLASSPATH_ENTRY = getBundleProjectService()
+			.newBundleClasspathEntry(null, null, IPath.fromOSString("."));
+	private static final VersionRange NO_VERSION = null;
 
 	@Rule
 	public TestName testName = new TestName();
@@ -263,7 +261,7 @@ public class ProjectCreationTests {
 		IBundleProjectDescription description = newProject();
 		IProject project = description.getProject();
 		IBundleProjectService service = getBundleProjectService();
-		IHostDescription host = service.newHost("some.host", null);
+		IHostDescription host = service.newHost("some.host", NO_VERSION);
 		description.setHost(host);
 		description.apply(null);
 
@@ -312,7 +310,7 @@ public class ProjectCreationTests {
 		description.setBundleVersion(new Version("1.2.2"));
 		IBundleProjectService service = getBundleProjectService();
 		IHostDescription host = service.newHost("some.host",
-				new VersionRange(new Version("1.0.0"), true, new Version("2.0.0"), false));
+				new VersionRange(VersionRange.LEFT_CLOSED, new Version("1.0.0"), new Version("2.0.0"), VersionRange.RIGHT_OPEN));
 		description.setHost(host);
 		description.setActivationPolicy(Constants.ACTIVATION_LAZY);
 		IBundleClasspathEntry e1 = service.newBundleClasspathEntry(IPath.fromOSString("frag"), IPath.fromOSString("bin"),
@@ -647,10 +645,10 @@ public class ProjectCreationTests {
 		description.setExtensionRegistry(true);
 		description.setExecutionEnvironments(new String[] { "J2SE-1.4" });
 		IRequiredBundleDescription rb1 = service.newRequiredBundle("org.eclipse.core.resources",
-				new VersionRange(new Version(3, 5, 0), true, new Version(4, 0, 0), false), true, false);
-		IRequiredBundleDescription rb2 = service.newRequiredBundle("org.eclipse.core.variables", null, false, false);
+				new VersionRange(VersionRange.LEFT_CLOSED, new Version(3, 5, 0), new Version(4, 0, 0), VersionRange.RIGHT_OPEN), true, false);
+		IRequiredBundleDescription rb2 = service.newRequiredBundle("org.eclipse.core.variables", NO_VERSION, false, false);
 		description.setRequiredBundles(new IRequiredBundleDescription[] { rb1, rb2 });
-		IPackageImportDescription pi1 = service.newPackageImport("com.ibm.icu.text", null, false);
+		IPackageImportDescription pi1 = service.newPackageImport("com.ibm.icu.text", NO_VERSION, false);
 		description.setPackageImports(new IPackageImportDescription[] { pi1 });
 		description.setHeader("SomeHeader", "something");
 		// test version override with explicit header setting
@@ -797,11 +795,11 @@ public class ProjectCreationTests {
 		IProject project = description.getProject();
 		IBundleProjectService service = getBundleProjectService();
 
-		IRequiredBundleDescription requireDesc = service.newRequiredBundle("requiredBundleOne", null, false, false);
+		IRequiredBundleDescription requireDesc = service.newRequiredBundle("requiredBundleOne", NO_VERSION, false, false);
 		IRequiredBundleDescription requireDesc2 = service.newRequiredBundle("requiredBundleTwo",
 				new VersionRange("[1.0.0,2.0.0)"), false, false);
-		IRequiredBundleDescription requireDesc3 = service.newRequiredBundle("requiredBundleThree", null, true, false);
-		IRequiredBundleDescription requireDesc4 = service.newRequiredBundle("requiredBundleFour", null, false, true);
+		IRequiredBundleDescription requireDesc3 = service.newRequiredBundle("requiredBundleThree", NO_VERSION, true, false);
+		IRequiredBundleDescription requireDesc4 = service.newRequiredBundle("requiredBundleFour", NO_VERSION, false, true);
 		description.setRequiredBundles(
 				new IRequiredBundleDescription[] { requireDesc, requireDesc2, requireDesc3, requireDesc4 });
 
@@ -813,11 +811,11 @@ public class ProjectCreationTests {
 				new String[] { "d.e.f", "g.h.i" });
 		description.setPackageExports(new IPackageExportDescription[] { ex0, ex1, ex2, ex3 });
 
-		IPackageImportDescription importDesc = service.newPackageImport("importPkgOne", null, false);
+		IPackageImportDescription importDesc = service.newPackageImport("importPkgOne", NO_VERSION, false);
 		IPackageImportDescription importDesc2 = service.newPackageImport("importPkgTwo",
 				new VersionRange("[1.0.0,2.0.0)"), false);
-		IPackageImportDescription importDesc3 = service.newPackageImport("importPkgThree", null, true);
-		IPackageImportDescription importDesc4 = service.newPackageImport("importPkgFour", null, false);
+		IPackageImportDescription importDesc3 = service.newPackageImport("importPkgThree", NO_VERSION, true);
+		IPackageImportDescription importDesc4 = service.newPackageImport("importPkgFour", NO_VERSION, false);
 		description.setPackageImports(
 				new IPackageImportDescription[] { importDesc, importDesc2, importDesc3, importDesc4 });
 
@@ -830,8 +828,8 @@ public class ProjectCreationTests {
 		assertEquals("Wrong number of package imports", 4, d2.getPackageImports().length);
 
 		// add entries
-		IRequiredBundleDescription requireDesc5 = service.newRequiredBundle("requiredBundleFive", null, false, false);
-		IRequiredBundleDescription requireDesc6 = service.newRequiredBundle("requiredBundleSix", null, false, false);
+		IRequiredBundleDescription requireDesc5 = service.newRequiredBundle("requiredBundleFive", NO_VERSION, false, false);
+		IRequiredBundleDescription requireDesc6 = service.newRequiredBundle("requiredBundleSix", NO_VERSION, false, false);
 		description.setRequiredBundles(new IRequiredBundleDescription[] { requireDesc, requireDesc2, requireDesc3,
 				requireDesc4, requireDesc5, requireDesc6 });
 
@@ -841,8 +839,8 @@ public class ProjectCreationTests {
 				new String[] { "d.e.f", "g.h.i" });
 		description.setPackageExports(new IPackageExportDescription[] { ex0, ex1, ex2, ex3, ex4, ex5 });
 
-		IPackageImportDescription importDesc5 = service.newPackageImport("importPkgFive", null, true);
-		IPackageImportDescription importDesc6 = service.newPackageImport("importPkgSix", null, false);
+		IPackageImportDescription importDesc5 = service.newPackageImport("importPkgFive", NO_VERSION, true);
+		IPackageImportDescription importDesc6 = service.newPackageImport("importPkgSix", NO_VERSION, false);
 		description.setPackageImports(new IPackageImportDescription[] { importDesc, importDesc2, importDesc3,
 				importDesc4, importDesc5, importDesc6 });
 
@@ -887,7 +885,7 @@ public class ProjectCreationTests {
 		IBundleProjectDescription description = newProject();
 		IProject project = description.getProject();
 		IBundleProjectService service = getBundleProjectService();
-		IHostDescription host = service.newHost("some.host", null);
+		IHostDescription host = service.newHost("some.host", NO_VERSION);
 		description.setHeader("HeaderOne", "one"); // arbitrary header
 		description.setHost(host);
 		description.apply(null);
@@ -1152,10 +1150,10 @@ public class ProjectCreationTests {
 		description.setExtensionRegistry(true);
 		description.setExecutionEnvironments(new String[] { "J2SE-1.4" });
 		IRequiredBundleDescription rb1 = service.newRequiredBundle("org.eclipse.core.resources",
-				new VersionRange(new Version(3, 5, 0), true, new Version(4, 0, 0), false), true, false);
-		IRequiredBundleDescription rb2 = service.newRequiredBundle("org.eclipse.core.variables", null, false, false);
+				new VersionRange(VersionRange.LEFT_CLOSED, new Version(3, 5, 0), new Version(4, 0, 0), VersionRange.RIGHT_OPEN), true, false);
+		IRequiredBundleDescription rb2 = service.newRequiredBundle("org.eclipse.core.variables", NO_VERSION, false, false);
 		description.setRequiredBundles(new IRequiredBundleDescription[] { rb1, rb2 });
-		IPackageImportDescription pi1 = service.newPackageImport("com.ibm.icu.text", null, false);
+		IPackageImportDescription pi1 = service.newPackageImport("com.ibm.icu.text", NO_VERSION, false);
 		description.setPackageImports(new IPackageImportDescription[] { pi1 });
 		description.apply(null);
 
@@ -1470,11 +1468,9 @@ public class ProjectCreationTests {
 	@Test
 	public void testHeaderFormatting() throws CoreException, IOException {
 		IBundleProjectDescription description = newProject();
-		IPackageImportDescription imp1 = getBundleProjectService().newPackageImport("org.eclipse.osgi", null, false);
-		IPackageImportDescription imp2 = getBundleProjectService().newPackageImport("org.eclipse.core.runtime", null,
-				false);
-		IPackageImportDescription imp3 = getBundleProjectService().newPackageImport("org.eclipse.core.resources", null,
-				false);
+		IPackageImportDescription imp1 = getBundleProjectService().newPackageImport("org.eclipse.osgi", NO_VERSION, false);
+		IPackageImportDescription imp2 = getBundleProjectService().newPackageImport("org.eclipse.core.runtime", NO_VERSION, false);
+		IPackageImportDescription imp3 = getBundleProjectService().newPackageImport("org.eclipse.core.resources", NO_VERSION, false);
 		description.setPackageImports(new IPackageImportDescription[] { imp1, imp2, imp3 });
 		IPackageExportDescription ex1 = getBundleProjectService().newPackageExport("a.b.c", null, true, null);
 		IPackageExportDescription ex2 = getBundleProjectService().newPackageExport("a.b.c.d", null, true, null);

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/TestBundleCreator.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/TestBundleCreator.java
@@ -34,6 +34,7 @@ import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.exports.FeatureExportInfo;
 import org.eclipse.pde.internal.core.exports.PluginExportOperation;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class TestBundleCreator {
 
@@ -74,7 +75,7 @@ public class TestBundleCreator {
 
 			List<IRequiredBundleDescription> requiredBundles = new ArrayList<>();
 			for (int j = 1; j < Math.max(j, 200); j++) {
-				IRequiredBundleDescription req = service.newRequiredBundle(TEST_BUNDLE_NAME + Integer.toString(j), null, false, false);
+				IRequiredBundleDescription req = service.newRequiredBundle(TEST_BUNDLE_NAME + j, (VersionRange) null, false, false);
 				requiredBundles.add(req);
 			}
 			description.setRequiredBundles(requiredBundles.toArray(new IRequiredBundleDescription[requiredBundles.size()]));

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/dialogs/PluginSelectionDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/dialogs/PluginSelectionDialog.java
@@ -27,7 +27,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
-import org.eclipse.osgi.service.resolver.VersionRange;
 import org.eclipse.pde.core.plugin.IFragment;
 import org.eclipse.pde.core.plugin.IFragmentModel;
 import org.eclipse.pde.core.plugin.IPluginBase;
@@ -49,6 +48,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.FilteredItemsSelectionDialog;
 import org.osgi.framework.Constants;
+import org.osgi.framework.VersionRange;
 
 public class PluginSelectionDialog extends FilteredItemsSelectionDialog {
 
@@ -211,12 +211,13 @@ public class PluginSelectionDialog extends FilteredItemsSelectionDialog {
 				String version = ipo.getVersion();
 				if (version != null) {
 					try {
-						if (!new VersionRange(version).isIncluded(exported[i].getVersion()))
-						 {
+						if (!new VersionRange(version).includes(exported[i].getVersion())) {
 							continue;
-						// NFE if ImportPackageObject's version is improperly formatted - ignore any matching imported packages since version is invalid
 						}
-					} catch (NumberFormatException e) {
+					} catch (IllegalArgumentException e) {
+						// if ImportPackageObject's version is improperly
+						// formatted - ignore any matching imported packages
+						// since version is invalid
 						continue;
 					}
 				}


### PR DESCRIPTION
This adapts PDE's code base to use `org.osgi.framework.VersionRange` instead of `org.eclipse.osgi.service.resolver.VersionRange`.
Many changes are only possible after https://github.com/eclipse-pde/eclipse.pde/pull/1340. This also replaces the usage of the methods deprecated there. At the moment this also contains the changes intended for that PR.

Part of https://github.com/eclipse-pde/eclipse.pde/issues/1069
