### PR TITLE
Fix @Deprecated tag's 'since' value and add removal date.

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+# To force a version qualifier update add the issue here
+Fix deprecation tag 'since' value

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IBundleProjectService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IBundleProjectService.java
@@ -62,7 +62,7 @@ public interface IBundleProjectService {
 	/**
 	 * @deprecated Instead use {@link #newHost(String, VersionRange)}
 	 */
-	@Deprecated(forRemoval = true, since = "4.19")
+	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default IHostDescription newHost(String name, org.eclipse.osgi.service.resolver.VersionRange range) {
 		return newHost(name, (VersionRange) range);
 	}
@@ -82,7 +82,7 @@ public interface IBundleProjectService {
 	 * @deprecated Instead use
 	 *             {@link #newPackageImport(String, VersionRange, boolean)}
 	 */
-	@Deprecated(forRemoval = true, since = "4.19")
+	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default IPackageImportDescription newPackageImport(String name,
 			org.eclipse.osgi.service.resolver.VersionRange range, boolean optional) {
 		return newPackageImport(name, (VersionRange) range, optional);
@@ -116,7 +116,7 @@ public interface IBundleProjectService {
 	 * @deprecated Instead use
 	 *             {@link #newRequiredBundle(String, VersionRange, boolean, boolean)}
 	 */
-	@Deprecated(forRemoval = true, since = "4.19")
+	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default IRequiredBundleDescription newRequiredBundle(String name,
 			org.eclipse.osgi.service.resolver.VersionRange range, boolean optional, boolean export) {
 		return newRequiredBundle(name, (VersionRange) range, optional, export);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IHostDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IHostDescription.java
@@ -42,7 +42,7 @@ public interface IHostDescription {
 	VersionRange getVersion();
 
 	/** @deprecated Instead use {@link #getVersion()} */
-	@Deprecated(forRemoval = true, since = "4.19")
+	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
 		VersionRange version = getVersion();
 		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageImportDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IPackageImportDescription.java
@@ -42,7 +42,7 @@ public interface IPackageImportDescription {
 	VersionRange getVersion();
 
 	/** @deprecated Instead use {@link #getVersion()} */
-	@Deprecated(forRemoval = true, since = "4.19")
+	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
 		VersionRange version = getVersion();
 		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IRequiredBundleDescription.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/project/IRequiredBundleDescription.java
@@ -42,7 +42,7 @@ public interface IRequiredBundleDescription {
 	VersionRange getVersion();
 
 	/** @deprecated Instead use {@link #getVersion()} */
-	@Deprecated(forRemoval = true, since = "4.19")
+	@Deprecated(forRemoval = true, since = "3.19 (removal in 2026-09 or later)")
 	default org.eclipse.osgi.service.resolver.VersionRange getVersionRange() {
 		VersionRange version = getVersion();
 		return version != null ? new org.eclipse.osgi.service.resolver.VersionRange(version.toString()) : null;


### PR DESCRIPTION
The 'since' value was set wrong in https://github.com/eclipse-pde/eclipse.pde/pull/1340.

Having the earliest removal mentioned in the deprecation notice as SimRel date makes it simpler for consumers to understand when the actual removal will happen (earliest). 