### PR TITLE
[PDE-Build] Use Path instead of URL to represent local files

### DIFF
--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/ScriptGenerationTests.java
@@ -290,7 +290,7 @@ public class ScriptGenerationTests extends PDETestCase {
 		assertResourceFile(buildFolder, "features/sdk/feature.xml");
 		IFile feature = buildFolder.getFile("features/sdk/feature.xml");
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature model = factory.parseBuildFeature(feature.getLocationURI().toURL());
+		BuildTimeFeature model = factory.parseBuildFeature(feature.getLocation().toPath());
 
 		FeatureEntry[] included = model.getIncludedFeatureReferences();
 		assertEquals(included.length, 3);
@@ -485,7 +485,7 @@ public class ScriptGenerationTests extends PDETestCase {
 				buildFolder.getLocation().toOSString(), null);
 
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature feature = factory.parseBuildFeature(featureXML.getLocationURI().toURL());
+		BuildTimeFeature feature = factory.parseBuildFeature(featureXML.getLocation().toPath());
 		FeatureEntry[] pluginEntryModels = feature.getPluginEntries();
 		assertEquals(pluginEntryModels[0].getId(), "foo");
 		assertEquals(pluginEntryModels[0].getVersion(), "1.0.0.vA");
@@ -532,7 +532,7 @@ public class ScriptGenerationTests extends PDETestCase {
 
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
 		try {
-			factory.parseBuildFeature(featureXML.getLocationURI().toURL());
+			factory.parseBuildFeature(featureXML.getLocation().toPath());
 		} catch (CoreException e) {
 			assertTrue(e.getStatus().toString().indexOf(Messages.feature_parse_emptyRequires) > 0);
 			return;

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/SourceTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/SourceTests.java
@@ -75,7 +75,7 @@ public class SourceTests extends PDETestCase {
 		IFolder jdtSource = buildFolder.getFolder("features").getFolder("jdt.source");
 		IFile featureXML = jdtSource.getFile("feature.xml");
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature feature = factory.parseBuildFeature(featureXML.getLocationURI().toURL());
+		BuildTimeFeature feature = factory.parseBuildFeature(featureXML.getLocation().toPath());
 		assertTrue(feature.getDescription() != null);
 	}
 
@@ -175,7 +175,7 @@ public class SourceTests extends PDETestCase {
 		IFile feature = buildFolder.getFile("features/a.feature.source/feature.xml");
 
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		factory.parseBuildFeature(feature.getLocationURI().toURL());
+		factory.parseBuildFeature(feature.getLocation().toPath());
 	}
 
 	// test that source can come before the feature it is based on
@@ -302,7 +302,7 @@ public class SourceTests extends PDETestCase {
 		IFile featureFile = buildFolder.getFile("features/source/feature.xml");
 
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature feature = factory.parseBuildFeature(featureFile.getLocationURI().toURL());
+		BuildTimeFeature feature = factory.parseBuildFeature(featureFile.getLocation().toPath());
 		FeatureEntry[] entries = feature.getRawIncludedFeatureReferences();
 		assertTrue(entries.length == 1);
 		assertEquals(entries[0].getId(), "org.eclipse.rcp");
@@ -374,7 +374,7 @@ public class SourceTests extends PDETestCase {
 
 		IFile feature = buildFolder.getFile("features/rcp.source/feature.xml");
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature model = factory.parseBuildFeature(feature.getLocationURI().toURL());
+		BuildTimeFeature model = factory.parseBuildFeature(feature.getLocation().toPath());
 
 		FeatureEntry[] included = model.getPluginEntries();
 		assertEquals(included.length, 2);
@@ -661,7 +661,7 @@ public class SourceTests extends PDETestCase {
 		IFile feature = buildFolder.getFile("tmp/eclipse/features/f.source_1.0.0/feature.xml");
 		assertResourceFile(feature);
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature model = factory.parseBuildFeature(feature.getLocationURI().toURL());
+		BuildTimeFeature model = factory.parseBuildFeature(feature.getLocation().toPath());
 		FeatureEntry[] included = model.getPluginEntries();
 		assertEquals(1, included.length);
 		for (FeatureEntry element : included) {

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/LicenseTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/LicenseTests.java
@@ -118,10 +118,10 @@ public class LicenseTests extends P2TestCase {
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
 
 		IFile licenseFeatureFile = buildFolder.getFile("features/L1/feature.xml");
-		BuildTimeFeature licenseFeature = factory.parseBuildFeature(licenseFeatureFile.getLocationURI().toURL());
+		BuildTimeFeature licenseFeature = factory.parseBuildFeature(licenseFeatureFile.getLocation().toPath());
 
 		IFile originalFeatureFile = buildFolder.getFile("features/F1/feature.xml");
-		BuildTimeFeature originalFeature = factory.parseBuildFeature(originalFeatureFile.getLocationURI().toURL());
+		BuildTimeFeature originalFeature = factory.parseBuildFeature(originalFeatureFile.getLocation().toPath());
 
 		assertEquals(licenseFeature.getLicenseURL(), URIUtil.toUnencodedString(actualLicense.getLocation()));
 		assertEquals(licenseFeature.getLicense(), actualLicense.getBody());
@@ -130,7 +130,7 @@ public class LicenseTests extends P2TestCase {
 		IFile actualFeatureFile = buildFolder.getFile("checkFeature.xml");
 		Utils.extractFromZip(buildFolder, "I.TestBuild/F1-TestBuild.zip", "eclipse/features/F1_1.0.0/feature.xml",
 				actualFeatureFile);
-		BuildTimeFeature actualFeature = factory.parseBuildFeature(actualFeatureFile.getLocationURI().toURL());
+		BuildTimeFeature actualFeature = factory.parseBuildFeature(actualFeatureFile.getLocation().toPath());
 
 		assertNotNull(actualFeature.getLicense());
 		assertEquals(licenseFeature.getLicense(), actualFeature.getLicense());
@@ -435,13 +435,13 @@ public class LicenseTests extends P2TestCase {
 		IFile actualFeatureFile = buildFolder.getFile("checkFeature.xml");
 		assertTrue(Utils.extractFromZip(buildFolder, "I.TestBuild/F1-TestBuild.zip",
 				"eclipse/features/F1_1.0.0/feature.xml", actualFeatureFile));
-		BuildTimeFeature actualFeature = factory.parseBuildFeature(actualFeatureFile.getLocationURI().toURL());
+		BuildTimeFeature actualFeature = factory.parseBuildFeature(actualFeatureFile.getLocation().toPath());
 
 		IFile licenseFeatureFile = buildFolder.getFile("features/L1/feature.xml");
-		BuildTimeFeature licenseFeature = factory.parseBuildFeature(licenseFeatureFile.getLocationURI().toURL());
+		BuildTimeFeature licenseFeature = factory.parseBuildFeature(licenseFeatureFile.getLocation().toPath());
 
 		IFile originalFeatureFile = buildFolder.getFile("features/F1/feature.xml");
-		BuildTimeFeature originalFeature = factory.parseBuildFeature(originalFeatureFile.getLocationURI().toURL());
+		BuildTimeFeature originalFeature = factory.parseBuildFeature(originalFeatureFile.getLocation().toPath());
 
 		assertNotNull(errorMessage + "license was null", actualFeature.getLicense());
 		assertEquals(errorMessage + "license text not equal", licenseFeature.getLicense(), actualFeature.getLicense());
@@ -529,7 +529,7 @@ public class LicenseTests extends P2TestCase {
 		runAntScript(buildXml.getLocation().toOSString(), new String[] { "test" },
 				buildFolder.getLocation().toOSString(), null);
 		BuildTimeFeature feature = new BuildTimeFeatureFactory()
-				.parseBuildFeature(featureFolder.getFile("feature.xml").getLocationURI().toURL());
+				.parseBuildFeature(featureFolder.getFile("feature.xml").getLocation().toPath());
 
 		assertEquals(feature.getLicense().trim(), "This is legal stuff");
 	}

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
@@ -309,7 +309,7 @@ public class PublishingTests extends P2TestCase {
 		assertFalse(hasZipped);
 
 		BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-		BuildTimeFeature model = factory.parseBuildFeature(featureXML.getLocationURI().toURL());
+		BuildTimeFeature model = factory.parseBuildFeature(featureXML.getLocation().toPath());
 		assertEquals("1.0.0.12345", model.getVersion());
 		assertEquals("1.0.0.12345", model.getPluginEntries()[0].getVersion());
 	}

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/FetchScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/FetchScriptGenerator.java
@@ -490,7 +490,7 @@ public class FetchScriptGenerator extends AbstractScriptGenerator {
 			File featuresFolder = new File(root, DEFAULT_FEATURE_LOCATION);
 			File featureLocation = new File(featuresFolder, elementName);
 			try {
-				feature = factory.createFeature(featureLocation.toURL(), null);
+				feature = factory.createFeature(featureLocation.toPath(), null);
 				featureProperties = new Properties();
 				try (InputStream featureStream = new BufferedInputStream(new FileInputStream(new File(featureLocation, PROPERTIES_FILE)))) {
 					featureProperties.load(featureStream);
@@ -555,8 +555,8 @@ public class FetchScriptGenerator extends AbstractScriptGenerator {
 		}
 		try {
 			BuildTimeFeatureFactory factory = BuildTimeFeatureFactory.getInstance();
-			File featureFolder = new File(destination.toString());
-			feature = factory.createFeature(featureFolder.toURL(), null);
+			File featureFolder = destination.toFile();
+			feature = factory.createFeature(featureFolder.toPath(), null);
 
 			//We only delete here, so if an exception is thrown the user can still see the retrieve.xml 
 			target.delete();

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/IPDEBuildConstants.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/IPDEBuildConstants.java
@@ -107,7 +107,6 @@ public interface IPDEBuildConstants {
 	public final static int EXCEPTION_STATE_PROBLEM = 15;
 	public final static int EXCEPTION_GENERIC = 16;
 	public final static int EXCEPTION_FEATURE_PARSE = Constants.EXCEPTION_FEATURE_PARSE;
-	public final static int WARNING_MISSING_SOURCE = 20;
 	public final static int WARNING_ELEMENT_NOT_FETCHED = 21;
 	public final static int EXCEPTION_CONFIG_FORMAT = 22;
 	public final static int EXCEPTION_PRODUCT_FORMAT = 23;

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/packager/PackageConfigScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/packager/PackageConfigScriptGenerator.java
@@ -80,8 +80,7 @@ public class PackageConfigScriptGenerator extends AssembleConfigScriptGenerator 
 
 	private String getFinalName(BuildTimeFeature feature) {
 		if (!AbstractScriptGenerator.getPropertyAsBoolean(IBuildPropertiesConstants.PROPERTY_PACKAGER_AS_NORMALIZER)) {
-			IPath featurePath = IPath.fromOSString(feature.getURL().getPath());
-			return featurePath.segment(featurePath.segmentCount() - 2);
+			return feature.getPath().getParent().getFileName().toString();
 		}
 		return feature.getId() + "_" + feature.getVersion(); //$NON-NLS-1$
 	}

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/BuildTimeFeatureParser.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/BuildTimeFeatureParser.java
@@ -17,7 +17,8 @@ package org.eclipse.pde.internal.build.site;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.equinox.internal.p2.publisher.eclipse.FeatureManifestParser;
 import org.eclipse.equinox.p2.publisher.eclipse.Feature;
@@ -30,10 +31,9 @@ public class BuildTimeFeatureParser extends FeatureManifestParser {
 		return new BuildTimeFeature(id, version);
 	}
 
-	public Feature parse(URL featureURL) throws SAXException, IOException {
-		InputStream in = featureURL.openStream();
-		try (in) {
-			return super.parse(in, featureURL);
+	public Feature parse(Path featurePath) throws SAXException, IOException {
+		try (InputStream in = Files.newInputStream(featurePath)) {
+			return super.parse(in, featurePath.toUri().toURL());
 		}
 	}
 }

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/BuildTimeSiteFactory.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/BuildTimeSiteFactory.java
@@ -13,8 +13,6 @@
 package org.eclipse.pde.internal.build.site;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -25,7 +23,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.build.Constants;
-import org.eclipse.pde.internal.build.BundleHelper;
 import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.build.Messages;
 import org.eclipse.pde.internal.build.PDEUIStateWrapper;
@@ -96,23 +93,13 @@ public class BuildTimeSiteFactory /*extends BaseSiteFactory*/ implements IPDEBui
 
 		}
 
-		URL featureURL;
-		FeatureReference featureRef;
-
 		for (File featureXML : featureXMLs) {
 			if (featureXML.exists()) {
-				// Here we could not use toURL() on currentFeatureDir, because the URL has a slash after the colons (file:/c:/foo) whereas the plugins don't
-				// have it (file:d:/eclipse/plugins) and this causes problems later to compare URLs... and compute relative paths
-				try {
-					featureURL = new URL("file:" + featureXML.getAbsolutePath()); //$NON-NLS-1$
-					featureRef = createFeatureReferenceModel();
-					featureRef.setSiteModel(site);
-					featureRef.setURLString(featureURL.toExternalForm());
-					//featureRef.setType(BuildTimeFeatureFactory.BUILDTIME_FEATURE_FACTORY_ID);
-					site.addFeatureReferenceModel(featureRef);
-				} catch (MalformedURLException e) {
-					BundleHelper.getDefault().getLog().log(new Status(IStatus.WARNING, PI_PDEBUILD, WARNING_MISSING_SOURCE, NLS.bind(Messages.warning_cannotLocateSource, featureXML.getAbsolutePath()), e));
-				}
+				FeatureReference featureRef = createFeatureReferenceModel();
+				featureRef.setSiteModel(site);
+				featureRef.setPath(featureXML.toPath().toAbsolutePath());
+				//featureRef.setType(BuildTimeFeatureFactory.BUILDTIME_FEATURE_FACTORY_ID);
+				site.addFeatureReferenceModel(featureRef);
 			}
 		}
 		BuildTimeSiteContentProvider contentProvider = new BuildTimeSiteContentProvider(sitePaths, installedBaseURL, pdeUIState);

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/compatibility/FeatureReference.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/compatibility/FeatureReference.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.build.site.compatibility;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.nio.file.Path;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.equinox.p2.publisher.eclipse.Feature;
@@ -23,39 +22,31 @@ import org.eclipse.pde.internal.build.site.BuildTimeSite;
 
 public class FeatureReference {
 	private BuildTimeSite site;
-	private String urlString;
-	private URL url;
+	private Path path;
 	private Feature feature;
 
 	public void setSiteModel(BuildTimeSite site) {
 		this.site = site;
 	}
 
-	public void setURLString(String externalForm) {
-		urlString = externalForm;
+	public void setPath(Path path) {
+		this.path = path;
 	}
 
 	public Feature getFeature() throws CoreException {
-		if (feature != null)
+		if (feature != null) {
 			return feature;
-
-		if (site != null)
-			feature = site.createFeature(getURL());
-		else {
+		}
+		if (site != null) {
+			feature = site.createFeature(path);
+		} else {
 			BuildTimeFeatureFactory factory = BuildTimeFeatureFactory.getInstance();
-			feature = factory.createFeature(getURL(), null);
+			feature = factory.createFeature(path, null);
 		}
 		return feature;
 	}
 
-	public URL getURL() {
-		if (url == null)
-			try {
-				url = new URL(urlString);
-			} catch (MalformedURLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-		return url;
+	public Path getPath() {
+		return path;
 	}
 }

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/BuildManifestTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/BuildManifestTask.java
@@ -189,7 +189,7 @@ public class BuildManifestTask extends Task implements IPDEBuildConstants, IXMLC
 		root = root.append(element);
 		try {
 			BuildTimeFeatureFactory factory = new BuildTimeFeatureFactory();
-			return factory.createFeature(root.toFile().toURL(), null);
+			return factory.createFeature(root.toPath(), null);
 		} catch (Exception e) {
 			String message = NLS.bind(TaskMessages.error_creatingFeature, element);
 			throw new CoreException(new Status(IStatus.ERROR, PI_PDEBUILD, EXCEPTION_FEATURE_MISSING, message, e));


### PR DESCRIPTION
This avoids unnecessary conversations that also uses deprecated methods like File.toURL()