### PR TITLE
Prevent multiple execution of junit.runtime.tests and always clear workspace

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PDE JUnit Runtime Tests
 Bundle-SymbolicName: org.eclipse.pde.junit.runtime.tests;singleton:=true
-Bundle-Version: 3.7.300.qualifier
+Bundle-Version: 3.7.400.qualifier
 Automatic-Module-Name: org.eclipse.pde.junit.runtime.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org

--- a/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
+++ b/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.pde.junit.runtime.tests</artifactId>
-	<version>3.7.300-SNAPSHOT</version>
+	<version>3.7.400-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>
 		<plugins>

--- a/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
+++ b/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
@@ -32,6 +32,7 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
+					<testClass>org.eclipse.pde.junit.runtime.tests.JUnitRuntimeTests</testClass>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>true</useUIThread>
 				</configuration>

--- a/ui/org.eclipse.pde.junit.runtime.tests/src/org/eclipse/pde/junit/runtime/tests/JUnit5SuiteExecutionTest.java
+++ b/ui/org.eclipse.pde.junit.runtime.tests/src/org/eclipse/pde/junit/runtime/tests/JUnit5SuiteExecutionTest.java
@@ -24,11 +24,17 @@ import org.eclipse.jdt.internal.junit.model.TestElement;
 import org.eclipse.jdt.junit.model.ITestElement;
 import org.eclipse.jdt.junit.model.ITestElementContainer;
 import org.eclipse.jdt.junit.model.ITestRunSession;
+import org.eclipse.pde.ui.tests.util.ProjectUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 public class JUnit5SuiteExecutionTest {
+
+	@ClassRule
+	public static final TestRule CLEAR_WORKSPACE = ProjectUtils.DELETE_ALL_WORKSPACE_PROJECTS_BEFORE_AND_AFTER;
 
 	private static IJavaProject project;
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1360