### PR TITLE
Fix: Unable to open Advanced Search Dialog more than once

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/repository/AdvancedSearchDialog.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/repository/AdvancedSearchDialog.java
@@ -17,8 +17,6 @@ package org.eclipse.pde.bnd.ui.views.repository;
 
 import java.beans.PropertyChangeListener;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -70,8 +68,6 @@ public class AdvancedSearchDialog extends TitleAreaDialog implements IPersistabl
 
 		PropertyChangeListener changeListener = evt -> updateFromPanel();
 
-		final List<Image> images = new LinkedList<>();
-
 		for (Entry<String, SearchPanel> panelEntry : panelMap.entrySet()) {
 			String title = panelEntry.getKey();
 			SearchPanel panel = panelEntry.getValue();
@@ -91,19 +87,11 @@ public class AdvancedSearchDialog extends TitleAreaDialog implements IPersistabl
 
 			Image image = panel.createImage(tabFolder.getDisplay());
 			if (image != null) {
-				images.add(image);
 				item.setImage(image);
 			}
 
 			panel.addPropertyChangeListener(changeListener);
 		}
-
-		tabFolder.addDisposeListener(e -> {
-			for (Image image : images) {
-				if (!image.isDisposed())
-					image.dispose();
-			}
-		});
 
 		tabFolder.setSelection(activeTabIndex);
 		SearchPanel currentPanel = (SearchPanel) tabFolder.getItem(activeTabIndex)


### PR DESCRIPTION
When opening this dialog, the tab items are decorated with images created by the individual search panels. When the dialog is closed, those images are disposed again.

Problem arises because the search panels don't create new images, but instead use shared images. Meaning when the dialog is opened a second time, those images have already been disposed, preventing the dialog from showing up.

Reason for this regression is the switch from the Icons class of the bndtools project to the PDE Resources class. Former has an explicit "isDisposed()" check, which would've created a new image on-the-fly, while latter doesn't. Given that the images are not owned by this dialog, the solution to this problem is to simply not have them be disposed by the dialog.

See https://github.com/eclipse-pde/eclipse.pde/issues/1365