### PR TITLE
Adjust lower bound for dependency to JDT Launching in PDE Build

### DIFF
--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.equinox.p2.repository.tools;bundle-version="[2.4.200,3.0.0)";resolution:=optional,
  org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.5.200",
  org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)",
- org.eclipse.jdt.launching;bundle-version="[3.21.0,4.0.0)"
+ org.eclipse.jdt.launching;bundle-version="[3.22.0,4.0.0)"
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.equinox.internal.p2.engine,


### PR DESCRIPTION
The PDEState class is using JavaRuntime.getProvidedVMPackages(...), which has only been added with version 3.22. But the Manifest still only requires 3.21. This causes issues when installing the latest PDE in the Eclipse 4.31, as the JDT bundles are not updated, which therefore leads to a NoSuchMethodError.

See https://github.com/eclipse-windowbuilder/windowbuilder/issues/865 for a real-life example of this problem.

Amends 00c9caf09d4a5f5be92cbb3e628ef64fa73440f6