### PR TITLE
Create test case for EE baseline warnings due to missing Manifest header

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/ProjectTypeContainerTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/ProjectTypeContainerTests.java
@@ -172,6 +172,16 @@ public class ProjectTypeContainerTests extends CompatibilityTest {
 	}
 
 	/**
+	 * Tests whether missing execution environments in the manifest are detected
+	 * correctly.
+	 */
+	public void testNoExecutionEnvironment() throws CoreException {
+		IApiTypeContainer bundleC = getTypeContainer("bundle.c"); //$NON-NLS-1$
+		assertArrayEquals("Expected no EE because none is specified in the Manifest", //$NON-NLS-1$
+				new String[] {}, bundleC.getApiComponent().getExecutionEnvironments());
+	}
+
+	/**
 	 * Tests all packages are returned.
 	 */
 	public void testPackageNames() throws CoreException {

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/.classpath
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/.project
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>bundle.b</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: API Tools Tests Plug-in C
+Bundle-SymbolicName: bundle.c
+Bundle-Version: 1.0.0
+Export-Package: test

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/src/test/Stub.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/baseline/bundle.c/src/test/Stub.java
@@ -1,0 +1,2 @@
+package test;
+public class Stub {}


### PR DESCRIPTION
This checks whether no error is produced when both the Require-Capability and the Bundle-RequiredExecutionEvironment headers are missing from the manifest.

See https://github.com/eclipse-pde/eclipse.pde/issues/1386