### PR TITLE
IApiAnnotations.isExact for CompositeApiDescription.resolveAnnotations

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotations.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiAnnotations.java
@@ -72,6 +72,7 @@ public class ApiAnnotations implements IApiAnnotations {
 		isExact = equals;
 	}
 
+	@Override
 	public boolean isExact() {
 		return isExact;
 	}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/CompositeApiDescription.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/CompositeApiDescription.java
@@ -63,17 +63,12 @@ public class CompositeApiDescription implements IApiDescription {
 		IApiAnnotations bestMatchAnnotation = null;
 		for (IApiDescription fDescription : fDescriptions) {
 			IApiAnnotations ann = fDescription.resolveAnnotations(element);
-			boolean isExact = false;
 			if (ann != null) {
 				bestMatchAnnotation = ann;
+				if (ann.isExact()) {
+					return ann; // if exact, return else keep looking for best match
+				}
 			}
-			if (ann instanceof ApiAnnotations) {
-				isExact = ((ApiAnnotations) ann).isExact();
-			}
-			if (isExact) {
-				return ann; // if exact, return else keep looking for best match
-			}
-
 		}
 		return bestMatchAnnotation;
 	}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/TypeAnnotations.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/TypeAnnotations.java
@@ -42,4 +42,8 @@ public class TypeAnnotations implements IApiAnnotations {
 		return fAnnotations.getRestrictions();
 	}
 
+	@Override
+	public boolean isExact() {
+		return fAnnotations != null && fAnnotations.isExact();
+	}
 }

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/IApiAnnotations.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/IApiAnnotations.java
@@ -35,4 +35,17 @@ public interface IApiAnnotations {
 	 */
 	public int getRestrictions();
 
+	/**
+	 * Returns whether these API annotations are based on an exact match of the
+	 * originating element.
+	 *
+	 * @return whether these API annotations are based on an exact match of the
+	 *         originating element.
+	 *
+	 * @since 1.3.600
+	 */
+	default boolean isExact() {
+		return false;
+	}
+
 }


### PR DESCRIPTION
- CompositeApiDescription.resolveAnnotations should be able to properly find the best match annotation using IApiAnnotations.isExact which is now also implemented by TypeAnnotations.isExact.

https://github.com/eclipse-pde/eclipse.pde/issues/1386