### PR TITLE
Fix more warnings in pde.ui and pde.ds.ui

### DIFF
--- a/ds/org.eclipse.pde.ds.ui/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.ds.ui;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ds.ui.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.30.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/editor/contentassist/TypeCompletionProposal.java
+++ b/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/editor/contentassist/TypeCompletionProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2015 Code 9 Corporation and others.
+ * Copyright (c) 2008, 2024 Code 9 Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -113,17 +113,16 @@ public class TypeCompletionProposal implements ICompletionProposal, ICompletionP
 	}
 
 	@Override
+	@SuppressWarnings("restriction")
 	public IInformationControlCreator getInformationControlCreator() {
 		if (!BrowserInformationControl.isAvailable(null))
 			return null;
 
 		if (fCreator == null) {
 			fCreator = new AbstractReusableInformationControlCreator() {
-
 				@Override
 				public IInformationControl doCreateInformationControl(Shell parent) {
-					return new BrowserInformationControl(parent,
-							JFaceResources.DIALOG_FONT, false);
+					return new BrowserInformationControl(parent, JFaceResources.DIALOG_FONT, false);
 				}
 			};
 		}

--- a/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/wizards/DSFileWizardPage.java
+++ b/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/wizards/DSFileWizardPage.java
@@ -27,7 +27,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.search.SearchEngine;
-import org.eclipse.jdt.internal.ui.packageview.ClassPathContainer;
 import org.eclipse.jdt.ui.IJavaElementSearchConstants;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.dialogs.Dialog;
@@ -110,16 +109,12 @@ public class DSFileWizardPage extends WizardNewFileCreationPage {
 	}
 
 	private IProject getProject(Object element) {
-		IProject project = null;
-		if (element instanceof IResource) {
-			project = ((IResource) element).getProject();
-		} else if (element instanceof IJavaElement) {
-			project = ((IJavaElement) element).getJavaProject().getProject();
-		} else if (element instanceof ClassPathContainer) {
-			project = ((ClassPathContainer) element).getJavaProject()
-					.getProject();
+		if (element instanceof IResource resource) {
+			return resource.getProject();
+		} else if (element instanceof IJavaElement javaElement) {
+			return javaElement.getJavaProject().getProject();
 		}
-		return project;
+		return null;
 	}
 
 	private void setComponentNameText(IProject project) {

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.15.400.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/build/BaseBuildAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/build/BaseBuildAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2018 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -165,9 +165,11 @@ public abstract class BaseBuildAction extends AbstractHandler {
 
 	public static void setDefaultValues(IFile generatedFile) {
 		try {
+			@SuppressWarnings("restriction")
 			List<ILaunchConfiguration> configs = AntLaunchShortcut.findExistingLaunchConfigurations(generatedFile);
 			ILaunchConfigurationWorkingCopy launchCopy;
 			if (configs.isEmpty()) {
+				@SuppressWarnings("restriction")
 				ILaunchConfiguration config = AntLaunchShortcut.createDefaultLaunchConfiguration(generatedFile);
 				launchCopy = config.getWorkingCopy();
 			} else {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2022 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -90,6 +90,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.dialogs.SaveAsDialog;
+import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.forms.AbstractFormPart;
 import org.eclipse.ui.forms.HyperlinkGroup;
 import org.eclipse.ui.forms.IFormPart;
@@ -100,7 +101,6 @@ import org.eclipse.ui.forms.events.IHyperlinkListener;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ImageHyperlink;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
-import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.progress.UIJob;
 import org.osgi.service.event.Event;
@@ -118,7 +118,7 @@ import org.xml.sax.SAXException;
 public class TargetEditor extends FormEditor {
 
 	private final List<IManagedForm> fManagedFormPages = new ArrayList<>(2);
-	private ExtensionBasedTextEditor fTextualEditor;
+	private TextEditor fTextualEditor;
 	private int fSourceTabIndex;
 	private IDocument fTargetDocument;
 	private IDocumentListener fTargetDocumentListener;
@@ -554,8 +554,11 @@ public class TargetEditor extends FormEditor {
 	/**
 	 * initializes fTargetDocument and fTargetDocumentListener
 	 */
+
 	private void addTextualEditorPage() throws PartInitException {
-		fTextualEditor = new ExtensionBasedTextEditor();
+		@SuppressWarnings("restriction")
+		TextEditor newEditor = new org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor();
+		fTextualEditor = newEditor;
 		fSourceTabIndex = addPage(fTextualEditor, getEditorInput());
 		Control editorControl = fTextualEditor.getAdapter(Control.class);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(editorControl, IHelpContextIds.TARGET_EDITOR_SOURCE_PAGE);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/StyledBundleLabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/StyledBundleLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -190,6 +190,7 @@ public class StyledBundleLabelProvider extends StyledCellLabelProvider implement
 		} else if (element instanceof IUWrapper) {
 			styledString = getStyledString(((IUWrapper) element).getIU());
 		} else if (element instanceof IInstallableUnit iu) {
+			@SuppressWarnings("restriction")
 			String name = fTranslations.getIUProperty(iu, IInstallableUnit.PROP_NAME);
 			if (name == null) {
 				name = iu.getId();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/BundleProjectConfigurator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/BundleProjectConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 Red Hat Inc., and others
+ * Copyright (c) 2014, 2024 Red Hat Inc., and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.internal.ui.wizards.importer.ProjectWithJavaResourcesImportConfigurator;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.pde.core.build.IBuildEntry;
 import org.eclipse.pde.internal.core.ClasspathComputer;
@@ -150,8 +149,10 @@ public class BundleProjectConfigurator implements ProjectConfigurator {
 
 	@Override
 	public Set<IFolder> getFoldersToIgnore(IProject project, IProgressMonitor monitor) {
-		Set<IFolder> res = new HashSet<>();
-		res.addAll(new ProjectWithJavaResourcesImportConfigurator().getFoldersToIgnore(project, monitor));
+		@SuppressWarnings("restriction")
+		Set<IFolder> res = new HashSet<>(
+				new org.eclipse.jdt.internal.ui.wizards.importer.ProjectWithJavaResourcesImportConfigurator()
+						.getFoldersToIgnore(project, monitor));
 		IFile buildPropertiesFile = PDEProject.getBuildProperties(project);
 		Properties buildProperties = new Properties();
 		if (!buildPropertiesFile.exists()) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/JUnitTabGroup.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/launcher/JUnitTabGroup.java
@@ -48,9 +48,11 @@ public class JUnitTabGroup extends AbstractPDELaunchConfigurationTabGroup {
 		} catch (CoreException e) {
 			vmArgs = ""; //$NON-NLS-1$
 		}
-		vmArgs = AssertionVMArg.enableAssertInArgString(vmArgs);
-		if (vmArgs.length() > 0)
-			configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, vmArgs);
+		@SuppressWarnings("restriction")
+		String extraVMArgs = AssertionVMArg.enableAssertInArgString(vmArgs);
+		if (!extraVMArgs.isEmpty()) {
+			configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, extraVMArgs);
+		}
 	}
 
 }

--- a/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/ShowSampleAction.java
+++ b/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/ShowSampleAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2018 IBM Corporation and others.
+ *  Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -250,6 +250,7 @@ public class ShowSampleAction extends Action implements IIntroAction {
 	/**
 	 * Apply the profile changes to the currently running configuration.
 	 */
+	@SuppressWarnings("restriction")
 	void applyConfiguration() throws CoreException {
 		BundleContext context = FrameworkUtil.getBundle(getClass()).getBundleContext();
 		ServiceReference<Configurator> reference = context.getServiceReference(Configurator.class);


### PR DESCRIPTION
And apply minor clean-ups in ExtensionsSection.

The branch in `DSFileWizardPage.getProject(Object)` that checks if the passed object is a `ClassPathContainer` seems to be possible anymore.
In general creating OSGI Service Components through the UI is a quite uncommon nowdays since one can simply use the Decalarative service component annotations.
