### PR TITLE
Fail on javadoc errors and fix remaining javadoc errors

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiTestingEnvironment.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiTestingEnvironment.java
@@ -183,7 +183,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all API usage problem markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#API_USAGE_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#API_USAGE_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllUsageMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -241,7 +241,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all unsupported tag problem markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#UNSUPPORTED_TAG_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#UNSUPPORTED_TAG_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllUnsupportedTagMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -277,7 +277,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all compatibility problem markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#COMPATIBILITY_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#COMPATIBILITY_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllCompatibilityMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -296,7 +296,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all API baseline problem markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#DEFAULT_API_BASELINE_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#DEFAULT_API_BASELINE_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllApiBaselineMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -315,7 +315,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all since tag problem markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#SINCE_TAGS_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#SINCE_TAGS_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllSinceTagMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -333,7 +333,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all version problem markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#VERSION_NUMBERING_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#VERSION_NUMBERING_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllVersionMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -352,7 +352,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	 * @return all unused problem filter markers
 	 * @throws CoreException
 	 *
-	 * @see {@link IApiMarkerConstants#UNUSED_FILTER_PROBLEM_MARKER}
+	 * @see IApiMarkerConstants#UNUSED_FILTER_PROBLEM_MARKER
 	 */
 	protected IMarker[] getAllUnusedApiProblemFilterMarkers(IResource resource) throws CoreException {
 		if (resource == null) {
@@ -456,7 +456,7 @@ public class ApiTestingEnvironment extends TestingEnvironment {
 	}
 
 	/**
-	 * Returns the current workspace {@link IApiProfile}
+	 * Returns the current workspace {@link IApiBaseline}
 	 *
 	 * @return the workspace baseline
 	 */

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/annotations/AnnotationTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/annotations/AnnotationTest.java
@@ -154,10 +154,10 @@ public abstract class AnnotationTest extends ApiBuilderTest {
 
 	/**
 	 * Returns an array composed only of the specified number of
-	 * {@link #PROBLEM_ID}
+	 * {@link #getDefaultProblemId()}
 	 *
-	 * @return an array of {@link #PROBLEM_ID} of the specified size, or an
-	 *         empty array if the specified size is < 1
+	 * @return an array of {@link #getDefaultProblemId()} of the specified size,
+	 *         or an empty array if the specified size is smaller 1
 	 */
 	protected int[] getDefaultProblemSet(int problemcount) {
 		if (problemcount < 1) {
@@ -183,7 +183,7 @@ public abstract class AnnotationTest extends ApiBuilderTest {
 
 	/**
 	 * Deploys a build test for API Javadoc tags using the given source file,
-	 * looking for problems specified from {@link #getExpectedProblemIds()()}
+	 * looking for problems specified from {@link #getExpectedProblemIds()}
 	 *
 	 * @param incremental if an incremental build should take place
 	 * @param usedefault if the default package should be used or not

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/TagTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/tags/TagTest.java
@@ -146,10 +146,10 @@ public abstract class TagTest extends ApiBuilderTest {
 
 	/**
 	 * Returns an array composed only of the specified number of
-	 * {@link #PROBLEM_ID}
+	 * {@link #getDefaultProblemId()}
 	 *
-	 * @return an array of {@link #PROBLEM_ID} of the specified size, or an
-	 *         empty array if the specified size is < 1
+	 * @return an array of {@link #getDefaultProblemId()} of the specified size,
+	 *         or an empty array if the specified size is smaller 1
 	 */
 	protected int[] getDefaultProblemSet(int problemcount) {
 		if (problemcount < 1) {
@@ -175,7 +175,7 @@ public abstract class TagTest extends ApiBuilderTest {
 
 	/**
 	 * Deploys a build test for API Javadoc tags using the given source file,
-	 * looking for problems specified from {@link #getExpectedProblemIds()()}
+	 * looking for problems specified from {@link #getExpectedProblemIds()}
 	 *
 	 * @param incremental if an incremental build should take place
 	 * @param usedefault if the default package should be used or not

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/search/tests/TestCompositeSearchReporter.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/search/tests/TestCompositeSearchReporter.java
@@ -19,10 +19,11 @@ import org.eclipse.pde.api.tools.internal.provisional.builder.IReference;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiElement;
 import org.eclipse.pde.api.tools.internal.provisional.search.IApiSearchReporter;
 import org.eclipse.pde.api.tools.internal.provisional.search.IMetadata;
+import org.eclipse.pde.api.tools.internal.search.XmlSearchReporter;
 
 /**
- * Test implementation of a search reporter that delegates to two
- * reporters: The {@link TestReporter} and the {@link XMLApiSearchReporter}
+ * Test implementation of a search reporter that delegates to two reporters: The
+ * {@link TestReporter} and the {@link XmlSearchReporter}
  *
  * <p>The {@link TestReporter} is always called first to validate we are getting the references / skipped
  * components that we are expecting to see</p>

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/SignaturesTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/util/tests/SignaturesTests.java
@@ -140,7 +140,7 @@ public class SignaturesTests {
 	}
 
 	/**
-	 * Tests the {@link Signatures#getQualifiedMethodSignature(org.eclipse.pde.api.tools.internal.provisional.descriptors.IMethodDescriptor, boolean)} method
+	 * Tests the {@link Signatures#getQualifiedMethodSignature(IMethodDescriptor, boolean, boolean)} method
 	 */
 	@Test
 	public void testGetQualifiedMethodSignature2() throws Exception {

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/ApiToolsLabelProvider.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/ApiToolsLabelProvider.java
@@ -52,7 +52,7 @@ import org.eclipse.ui.ide.IDE.SharedImages;
 public class ApiToolsLabelProvider extends BaseLabelProvider implements ILabelProvider, IFontProvider {
 
 	/**
-	 * Font for the default {@link IApiProfile}
+	 * Font for the default {@link IApiBaseline}
 	 */
 	private Font font = null;
 
@@ -237,7 +237,7 @@ public class ApiToolsLabelProvider extends BaseLabelProvider implements ILabelPr
 	}
 
 	/**
-	 * Returns if the specified {@link IApiProfile} is the default profile or
+	 * Returns if the specified {@link IApiBaseline} is the default profile or
 	 * not
 	 *
 	 * @return if the profile is the default or not

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/ApiUIPlugin.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/ApiUIPlugin.java
@@ -150,7 +150,7 @@ public class ApiUIPlugin extends AbstractUIPlugin {
 
 	/**
 	 * @return the id of this plugin. Value is
-	 *         <code><org.eclipse.pde.api.tools.ui></code>
+	 *         {@code org.eclipse.pde.api.tools.ui}
 	 */
 	public static String getPluginIdentifier() {
 		return PLUGIN_ID;

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/CreateApiFilterOperation.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/CreateApiFilterOperation.java
@@ -63,7 +63,9 @@ public class CreateApiFilterOperation extends Job {
 	/**
 	 * Constructor
 	 *
-	 * @see IApiProblemFilter#getKinds()
+	 * @see IApiProblemFilter#getUnderlyingProblem()
+	 * @see IApiProblem#getKind()
+	 * @see IApiProblem#getElementKind()
 	 */
 	public CreateApiFilterOperation(IMarker[] markers, boolean addingcomments) {
 		super(MarkerMessages.CreateApiFilterOperation_0);

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/preferences/ApiBaselinePreferencePage.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/preferences/ApiBaselinePreferencePage.java
@@ -74,8 +74,8 @@ public class ApiBaselinePreferencePage extends PreferencePage implements IWorkbe
 	public static final String ID = "org.eclipse.pde.api.tools.ui.apiprofiles.prefpage"; //$NON-NLS-1$
 
 	/**
-	 * Override to tell the label provider about uncommitted {@link IApiProfile}
-	 * s that might have been set to be the new default
+	 * Override to tell the label provider about uncommitted
+	 * {@link IApiBaseline}s that might have been set to be the new default
 	 */
 	class BaselineLabelProvider extends ApiToolsLabelProvider {
 		@Override
@@ -206,11 +206,12 @@ public class ApiBaselinePreferencePage extends PreferencePage implements IWorkbe
 	}
 
 	/**
-	 * Returns if the {@link IApiProfile} with the given name has been removed,
+	 * Returns if the {@link IApiBaseline} with the given name has been removed,
 	 * but not yet committed back to the manager
 	 *
-	 * @param name the name of the {@link IApiProfile}
-	 * @return true if the {@link IApiProfile} has been removed from the page,
+	 * @param name
+	 *            the name of the {@link IApiBaseline}
+	 * @return true if the {@link IApiBaseline} has been removed from the page,
 	 *         false otherwise
 	 */
 	public static boolean isRemovedBaseline(String name) {
@@ -267,7 +268,7 @@ public class ApiBaselinePreferencePage extends PreferencePage implements IWorkbe
 	}
 
 	/**
-	 * Returns if the specified {@link IApiProfile} is the default profile or
+	 * Returns if the specified {@link IApiBaseline} is the default profile or
 	 * not
 	 *
 	 * @return if the profile is the default or not
@@ -314,7 +315,7 @@ public class ApiBaselinePreferencePage extends PreferencePage implements IWorkbe
 
 	/**
 	 * Applies the changes from the current change set to the
-	 * {@link ApiProfileManager}. When done the current change set is cleared.
+	 * {@link IApiBaselineManager}. When done the current change set is cleared.
 	 */
 	protected void applyChanges() {
 		if (!dirty) {

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/refactoring/FilterChange.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/refactoring/FilterChange.java
@@ -96,26 +96,6 @@ public abstract class FilterChange extends Change {
 		return NLS.bind(RefactoringMessages.FilterChange_remove_used_filter, problem.getMessage());
 	}
 
-	/**
-	 * Returns the name to use for a {@link #RENAME} change operation
-	 *
-	 * @return the name for a {@link #RENAME} change
-	 */
-	protected String getRenameName() {
-		IApiProblem problem = this.filter.getUnderlyingProblem();
-		return NLS.bind(RefactoringMessages.FilterChange_remove_used_filter, new Object[] { problem.getMessage() });
-	}
-
-	/**
-	 * Returns the name to use for a {@link #MOVE} change operation
-	 *
-	 * @return the name for a {@link #MOVE} change
-	 */
-	protected String getMoveName() {
-		IApiProblem problem = this.filter.getUnderlyingProblem();
-		return NLS.bind(RefactoringMessages.FilterChange_remove_used_filter, new Object[] { problem.getMessage() });
-	}
-
 	@Override
 	public String getName() {
 		switch (this.kind) {

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/wizards/ApiBaselineWizardPage.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/wizards/ApiBaselineWizardPage.java
@@ -107,8 +107,8 @@ public abstract class ApiBaselineWizardPage extends WizardPage {
 	}
 
 	/**
-	 * Operation that creates a new working copy for an {@link IApiProfile} that
-	 * is being edited
+	 * Operation that creates a new working copy for an {@link IApiBaseline}
+	 * that is being edited
 	 */
 	static class WorkingCopyOperation implements IRunnableWithProgress {
 
@@ -146,8 +146,8 @@ public abstract class ApiBaselineWizardPage extends WizardPage {
 		}
 
 		/**
-		 * Returns the newly created {@link IApiProfile} working copy or
-		 * <code>null</code>
+		 * Returns the newly created {@link IApiBaseline} working copy or
+		 * {@code null}
 		 *
 		 * @return the working copy or <code>null</code>
 		 */
@@ -231,7 +231,7 @@ public abstract class ApiBaselineWizardPage extends WizardPage {
 	/**
 	 * Creates or edits the profile and returns it
 	 *
-	 * @return a new {@link IApiProfile} or <code>null</code> if an error was
+	 * @return a new {@link IApiBaseline} or {@code null} if an error was
 	 *         encountered creating the new profile
 	 */
 	public abstract IApiBaseline finish() throws IOException, CoreException;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescriptionXmlCreator.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescriptionXmlCreator.java
@@ -137,8 +137,6 @@ public class ApiDescriptionXmlCreator extends ApiDescriptionVisitor {
 
 	/**
 	 * Returns the settings as a XML {@link Document}.
-	 *
-	 * @throws CoreException if something goes wrong
 	 */
 	public Document getXML() {
 		return fDoc;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractProblemDetector.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/AbstractProblemDetector.java
@@ -170,7 +170,6 @@ public abstract class AbstractProblemDetector implements IApiProblemDetector {
 	 * @param reference   reference
 	 * @param javaProject java project (with reference source location)
 	 * @return problem or <code>null</code> if none
-	 * @exception CoreException if something goes wrong
 	 */
 	protected IApiProblem createProblem(IReference reference, IJavaProject javaProject) {
 		IProject project = javaProject.getProject();

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ReferenceExtractor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ReferenceExtractor.java
@@ -883,7 +883,7 @@ public class ReferenceExtractor extends ClassVisitor {
 	private final boolean fIncludeLocalRefs = false;
 
 	/**
-	 * Bit mask of {@link ReferenceModifiers} to extract.
+	 * Bit mask of {@link IReference} constants to extract.
 	 */
 	private int fReferenceKinds = 0;
 
@@ -932,7 +932,7 @@ public class ReferenceExtractor extends ClassVisitor {
 	 * @param type the type to extract references from
 	 * @param collector the listing of references to annotate from this pass
 	 * @param referenceKinds kinds of references to extract as defined by
-	 *            {@link ReferenceModifiers}
+	 *            {@link IReference}
 	 */
 	public ReferenceExtractor(IApiType type, Set<Reference> collector, int referenceKinds) {
 		super(Util.LATEST_OPCODES_ASM, new ClassNode());

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/TagValidator.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/TagValidator.java
@@ -48,8 +48,7 @@ import org.eclipse.pde.api.tools.internal.util.Util;
  * <br>
  * The logic in this class must be kept in sync with how we determine what is
  * visible in out completion proposal code
- *
- * @see org.eclipse.pde.api.tools.ui.internal.completion.APIToolsJavadocCompletionProposalComputer
+ * {@code org.eclipse.pde.api.tools.ui.internal.completion.APIToolsJavadocCompletionProposalComputer}
  *
  * @since 1.0.0
  */

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/DeltaXmlVisitor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/DeltaXmlVisitor.java
@@ -100,8 +100,8 @@ public class DeltaXmlVisitor extends DeltaVisitor {
 	}
 
 	/**
-	 * Return the xml dom document this visitor generates. Use {@link #getXML()}
-	 * to get the serialized xml string.
+	 * Return the xml dom document this visitor generates. Use
+	 * {@link Util#serializeDocument(Document)} to get the serialized xml string.
 	 *
 	 * @return xml dom document
 	 */

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/AbstractApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/AbstractApiTypeContainer.java
@@ -102,7 +102,7 @@ public abstract class AbstractApiTypeContainer extends ApiElement implements IAp
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.provisional.IApiTypeContainer#findTypeRoot(java.lang.String)
+	 * @see IApiTypeContainer#findTypeRoot(java.lang.String)
 	 */
 	@Override
 	public IApiTypeRoot findTypeRoot(String qualifiedName) throws CoreException {
@@ -117,8 +117,7 @@ public abstract class AbstractApiTypeContainer extends ApiElement implements IAp
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.provisional.IApiTypeContainer#findTypeRoot(java.lang.String,
-	 *      java.lang.String)
+	 * @see IApiTypeContainer#findTypeRoot(java.lang.String, java.lang.String)
 	 */
 	@Override
 	public IApiTypeRoot findTypeRoot(String qualifiedName, String id) throws CoreException {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/AbstractApiTypeRoot.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/AbstractApiTypeRoot.java
@@ -80,7 +80,7 @@ public abstract class AbstractApiTypeRoot extends ApiElement implements IApiType
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.provisional.IApiTypeRoot#getApiComponent()
+	 * @see IApiTypeRoot#getApiComponent()
 	 */
 	@Override
 	public IApiComponent getApiComponent() {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ArchiveApiTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ArchiveApiTypeContainer.java
@@ -148,7 +148,7 @@ public class ArchiveApiTypeContainer extends ApiElement implements IApiTypeConta
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.AbstractApiTypeContainer#accept(org.eclipse.pde.api.tools.internal.provisional.ApiTypeContainerVisitor)
+	 * @see AbstractApiTypeContainer#accept(ApiTypeContainerVisitor)
 	 */
 	@Override
 	public void accept(ApiTypeContainerVisitor visitor) throws CoreException {
@@ -181,7 +181,7 @@ public class ArchiveApiTypeContainer extends ApiElement implements IApiTypeConta
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.AbstractApiTypeContainer#close()
+	 * @see AbstractApiTypeContainer#close()
 	 */
 	@Override
 	public synchronized void close() throws CoreException {
@@ -189,7 +189,7 @@ public class ArchiveApiTypeContainer extends ApiElement implements IApiTypeConta
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.provisional.IApiTypeContainer#findTypeRoot(java.lang.String)
+	 * @see IApiTypeContainer#findTypeRoot(java.lang.String)
 	 */
 	@Override
 	public IApiTypeRoot findTypeRoot(String qualifiedName) throws CoreException {
@@ -206,7 +206,7 @@ public class ArchiveApiTypeContainer extends ApiElement implements IApiTypeConta
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.AbstractApiTypeContainer#getPackageNames()
+	 * @see AbstractApiTypeContainer#getPackageNames()
 	 */
 	@Override
 	public String[] getPackageNames() throws CoreException {
@@ -262,8 +262,7 @@ public class ArchiveApiTypeContainer extends ApiElement implements IApiTypeConta
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.provisional.IApiTypeContainer#findTypeRoot(java.lang.String,
-	 *      java.lang.String)
+	 * @see IApiTypeContainer#findTypeRoot(java.lang.String, java.lang.String)
 	 */
 	@Override
 	public IApiTypeRoot findTypeRoot(String qualifiedName, String id) throws CoreException {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/BundleComponent.java
@@ -477,7 +477,6 @@ public class BundleComponent extends Component {
 	 * @param bundle the bundle to load from
 	 * @param packages the complete set of packages names originating from the
 	 *            backing component
-	 * @throws CoreException if an error occurs
 	 */
 	public static void initializeApiDescription(IApiDescription apiDesc, BundleDescription bundle,
 			Set<String> packages) {
@@ -568,7 +567,7 @@ public class BundleComponent extends Component {
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.AbstractApiTypeContainer#createApiTypeContainers()
+	 * @see AbstractApiTypeContainer#createApiTypeContainers()
 	 */
 	@Override
 	protected List<IApiTypeContainer> createApiTypeContainers() throws CoreException {

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/ApiPlugin.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/ApiPlugin.java
@@ -494,7 +494,7 @@ public class ApiPlugin extends Plugin implements ISaveParticipant, DebugOptionsL
 	 * {@link org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline}
 	 * s stored in the manager.
 	 *
-	 * @return the singleton instance of the {@link IApiProfileManager}
+	 * @return the singleton instance of the {@link IApiBaselineManager}
 	 */
 	public IApiBaselineManager getApiBaselineManager() {
 		return ApiBaselineManager.getManager();

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/Factory.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/Factory.java
@@ -88,7 +88,7 @@ public class Factory {
 	 * fully qualified name. Package names are dot qualified and type names are
 	 * '$'-qualified.
 	 *
-	 * @return an {@link ITypeDescriptor} for the type
+	 * @return an {@link IReferenceTypeDescriptor} for the type
 	 */
 	public static IReferenceTypeDescriptor typeDescriptor(String fullyQualifiedName) {
 		String packageName = Signatures.getPackageName(fullyQualifiedName);

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/builder/IApiAnalyzer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/builder/IApiAnalyzer.java
@@ -56,8 +56,8 @@ public interface IApiAnalyzer {
 	 * @param context the build context reported from the
 	 *            {@link ApiAnalysisBuilder}
 	 * @param monitor to report progress
-	 * @see PluginProjectApiComponent
-	 * @see BundleApiComponent
+	 * @see org.eclipse.pde.api.tools.internal.model.ProjectComponent
+	 * @see org.eclipse.pde.api.tools.internal.model.BundleComponent
 	 */
 	public void analyzeComponent(final BuildState buildState, final IApiFilterStore filterStore, final Properties preferences, final IApiBaseline baseline, final IApiComponent component, final IBuildContext context, IProgressMonitor monitor);
 

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/builder/IApiProblemDetector.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/builder/IApiProblemDetector.java
@@ -28,7 +28,7 @@ public interface IApiProblemDetector {
 	/**
 	 * Returns a bit mask of reference kinds this analyzer is interested in.
 	 *
-	 * @return bit mask of {@link ReferenceModifiers} constants
+	 * @return bit mask of {@link IReference} constants
 	 */
 	public int getReferenceKinds();
 

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/comparator/IDelta.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/comparator/IDelta.java
@@ -927,7 +927,7 @@ public interface IDelta {
 	 * {@link IDelta#METHOD_ELEMENT_TYPE}, {@link IDelta#INTERFACE_ELEMENT_TYPE}
 	 * , {@link IDelta#CLASS_ELEMENT_TYPE}, {@link IDelta#FIELD_ELEMENT_TYPE},
 	 * {@link IDelta#API_COMPONENT_ELEMENT_TYPE} and
-	 * {@link IDelta#API_PROFILE_ELEMENT_TYPE}.
+	 * {@link IDelta#API_BASELINE_ELEMENT_TYPE}.
 	 *
 	 * @return flags that describe how an element has changed
 	 */

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/model/IApiElement.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/model/IApiElement.java
@@ -24,8 +24,7 @@ package org.eclipse.pde.api.tools.internal.provisional.model;
 public interface IApiElement {
 
 	/**
-	 * Constant representing an
-	 * {@link org.eclipse.pde.api.tools.internal.provisional.IApiComponent}
+	 * Constant representing an {@link IApiComponent}
 	 */
 	public int COMPONENT = 1;
 
@@ -35,8 +34,7 @@ public interface IApiElement {
 	public int TYPE = 2;
 
 	/**
-	 * Constant representing an
-	 * {@link org.eclipse.pde.api.tools.internal.provisional.IApiTypeContainer}
+	 * Constant representing an {@link IApiTypeContainer}
 	 */
 	public int API_TYPE_CONTAINER = 3;
 
@@ -56,8 +54,7 @@ public interface IApiElement {
 	public int METHOD = 6;
 
 	/**
-	 * Constant representing an
-	 * {@link org.eclipse.pde.api.tools.internal.provisional.IApiTypeRoot}
+	 * Constant representing an {@link IApiTypeRoot}
 	 */
 	public int API_TYPE_ROOT = 7;
 

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/model/IApiType.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/model/IApiType.java
@@ -153,9 +153,8 @@ public interface IApiType extends IApiMember {
 	 * <code>"java.lang.Object"</code>. For anonymous types, the superclass name
 	 * is the name appearing after the 'new' keyword'. If the superclass is a
 	 * parameterized type, the string may include its type arguments enclosed in
-	 * "&lt;&gt;". If the returned string is needed for anything other than
-	 * display purposes, use {@link #getSuperclassTypeSignature()} which returns
-	 * a structured type signature string containing more precise information.
+	 * "&lt;&gt;". If the returned string is needed for anything other than display
+	 * purposes, use {@link #getSuperclass()}.
 	 * </p>
 	 *
 	 * @return the name of this type's superclass or <code>null</code>
@@ -231,8 +230,7 @@ public interface IApiType extends IApiMember {
 	 * kind. The list contains instances of {@link IReference}.
 	 *
 	 * @param referenceMask kinds of references to extract/search for as
-	 *            described by
-	 *            {@link org.eclipse.pde.api.tools.internal.provisional.search.ReferenceModifiers}
+	 *            described by {@link IReference} constants
 	 * @param monitor progress monitor or <code>null</code>
 	 * @return extracted {@link IReference}s, possibly an empty collection
 	 * @throws CoreException if this type does not exist or an exception occurs

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/problems/IApiProblem.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/problems/IApiProblem.java
@@ -714,7 +714,7 @@ public interface IApiProblem {
 
 	/**
 	 * Returns the names of the extra marker attributes associated to this
-	 * problem when persisted into a marker by the {@link ApiProblemReporter}.
+	 * problem when persisted into a marker.
 	 * By default, no EXTRA attributes is persisted, and an {@link IApiProblem}
 	 * only persists the following attributes:
 	 * <ul>

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/search/IApiSearchRequestor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/search/IApiSearchRequestor.java
@@ -31,7 +31,7 @@ public interface IApiSearchRequestor {
 	 * Search mask that will cause the engine to consider API references when
 	 * searching
 	 *
-	 * @see #includesApi()
+	 * @see #includesAPI()
 	 */
 	public static final int INCLUDE_API = 0x0001;
 	/**
@@ -98,8 +98,7 @@ public interface IApiSearchRequestor {
 	/**
 	 * Returns the or'd listing of {@link IReference} kinds to look for.
 	 *
-	 * @see org.eclipse.pde.api.tools.internal.provisional.builder.ReferenceModifiers
-	 *      for a complete listing of reference kinds
+	 * @see IReference for a complete listing of reference kinds
 	 *
 	 * @return the listing of {@link IReference} kinds to consider during the
 	 *         search this requestor is used for.

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/ConsumerReportConvertor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/ConsumerReportConvertor.java
@@ -567,7 +567,7 @@ public class ConsumerReportConvertor extends UseReportConverter {
 	 * Writes the html report for a given producer. The page lists all the types
 	 * that are referenced by the parent consumer that are from the producer.
 	 * <p>
-	 * Called from {@link #writeConsumerReport(Consumer)}
+	 * Called from {@link #writeConsumerReport(Consumer, Map)}
 	 * </p>
 	 *
 	 * @param producer producer to write the report for

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseReportConverter.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/search/UseReportConverter.java
@@ -499,8 +499,9 @@ public class UseReportConverter extends HTMLConvertor {
 
 	/**
 	 * Visibility constant indicating an element has host-fragment level of
-	 * visibility. i.e. fragments have {@link #PRIVATE_PERMISSIBLE}-like access
-	 * to the internals of their host.
+	 * visibility. i.e. fragments have
+	 * {@link VisibilityModifiers#PRIVATE_PERMISSIBLE}-like access to the internals
+	 * of their host.
 	 *
 	 * @since 1.0.1
 	 */

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
@@ -1788,8 +1788,6 @@ public final class Util {
 
 	/**
 	 * Gets the .ee file supplied to run tests based on system property.
-	 *
-	 * @throws CoreException
 	 */
 	public static ExecutionEnvironmentDescription getEEDescriptionFile() {
 		// generate a fake 1.6 ee file

--- a/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/ApiMigrationTask.java
+++ b/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/ApiMigrationTask.java
@@ -156,7 +156,7 @@ public final class ApiMigrationTask extends CommonUtilsTask {
 	}
 
 	/**
-	 * @see org.eclipse.pde.api.tools.internal.tasks.UseTask#assertParameters()
+	 * @see ApiUseTask#assertParameters()
 	 */
 	protected void assertParameters() throws BuildException {
 		if (this.reportLocation == null) {

--- a/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/ApiUseTask.java
+++ b/apitools/org.eclipse.pde.api.tools/src_ant/org/eclipse/pde/api/tools/internal/tasks/ApiUseTask.java
@@ -269,9 +269,6 @@ public final class ApiUseTask extends CommonUtilsTask {
 		archivePatterns = parsePatterns(patterns);
 	}
 
-	/**
-	 * @see org.eclipse.pde.api.tools.internal.tasks.UseTask#assertParameters()
-	 */
 	protected void assertParameters() throws BuildException {
 		if (this.reportLocation == null) {
 			StringWriter out = new StringWriter();

--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.build;singleton:=true
-Bundle-Version: 3.12.500.qualifier
+Bundle-Version: 3.12.600.qualifier
 Bundle-ClassPath: pdebuild.jar
 Bundle-Activator: org.eclipse.pde.internal.build.BuildActivator
 Bundle-Vendor: %providerName

--- a/build/org.eclipse.pde.build/build.properties
+++ b/build/org.eclipse.pde.build/build.properties
@@ -33,3 +33,5 @@ source.lib/pdebuild-ant.jar = src_ant/
 output.lib/pdebuild-ant.jar = bin_ant/
 jars.extra.classpath = platform:/plugin/org.apache.ant/lib/ant.jar,\
                        platform:/plugin/org.eclipse.equinox.p2.repository.tools/lib/repository-tools-ant.jar
+
+pom.model.property.javadoc.excludePackageNames = org.eclipse.pde.internal.build.publisher

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/BuildScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/BuildScriptGenerator.java
@@ -98,7 +98,7 @@ public class BuildScriptGenerator extends AbstractScriptGenerator {
 	/** flag indicating if missing properties file should be logged */
 	private boolean ignoreMissingPropertiesFile = true;
 
-	/** flag indicating if we should generate the plugin & feature versions lists */
+	/** flag indicating if we should generate the plugin and feature versions lists */
 	protected boolean generateVersionsList = false;
 
 	private Properties antProperties = null;
@@ -497,7 +497,7 @@ public class BuildScriptGenerator extends AbstractScriptGenerator {
 	}
 
 	/**
-	 * Whether or not to generate plugin & feature versions lists
+	 * Whether or not to generate plugin and feature versions lists
 	 */
 	public void setGenerateVersionsList(boolean generateVersionsList) {
 		this.generateVersionsList = generateVersionsList;

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/fetch/COPYFetchTasksFactory.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/fetch/COPYFetchTasksFactory.java
@@ -33,21 +33,21 @@ import org.eclipse.pde.internal.build.Utils;
  * copying from a specific location (id: <code>COPY</code>).
  * <p>
  * Map file arguments:
- * <code>&lt;ROOT_LOCATION&gt;[,&lt;ELEMENT_LOCATION&gt;]</code>
+ * {@code <ROOT_LOCATION>[,<ELEMENT_LOCATION>] }
+ * </p>
  * <dl>
  * <dt>ROOT_LOCATION</dt>
  * <dd>The ROOT_LOCATION (eg. <code>/source/eclipse</code>, or
  * <code>D:/dev/myproduct</code>) is used as root path to determine the
  * location to fetch. It can be overwritten via the
  * <code>fetchTag</code> to fetch from another location (for example, on a different machine).</dd>
- * </dl>
  * <dt>ELEMENT_LOCATION</dt>
  * <dd>A path withing the ROOT_LOCATION (eg.
  * <code>org.eclipse.sdk-feature/features/org.eclipse.rcp</code>) to retrive
  * the element from if it is not within the root. If this is not provided the
  * default path will be used which simply maps to the element name.</dd>
  * </dl>
- * </p>
+ * 
  */
 public class COPYFetchTasksFactory implements IFetchFactory, IPDEBuildConstants {
 	public static final String ID = "COPY"; //$NON-NLS-1$

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/fetch/CVSFetchTaskFactory.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/fetch/CVSFetchTaskFactory.java
@@ -33,8 +33,7 @@ import org.eclipse.pde.internal.build.Utils;
 /**
  * An <code>FetchTaskFactory</code> for building fetch scripts that will
  * fetch content from a CVS repository (id: <code>CVS</code>).
- * <p>
- * <code><pre>
+ * <pre>
  * Map file format:
  * 	type@id,[version]=CVS,args
  * args is a comma-separated list of key/value pairs
@@ -45,8 +44,7 @@ import org.eclipse.pde.internal.build.Utils;
  * 	path - optional path relative to the cvsRoot
  * 	prebuilt - optional boolean value indicating that the entry points to a pre-built bundle in the repository
  * 	tag - mandatory CVS tag
- * </pre></code>
- * </p>
+ * </pre>
  */
 public class CVSFetchTaskFactory implements IFetchFactory {
 	public static final String ID = "CVS"; //$NON-NLS-1$

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/ReachablePlugin.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/ReachablePlugin.java
@@ -22,7 +22,7 @@ import org.osgi.framework.VersionRange;
 
 /**
  * ReachablePlugin's are sorted first by id, then by the width of the version range.
- * With equal range width, R1 < R2 if R1.range.getMinimum() < R2.range.getMaximum()
+ * With equal range width, {@code R1 < R2} if {@code R1.range.getMinimum() < R2.range.getMaximum()}
  */
 public class ReachablePlugin implements Comparable<Object> {
 	public static final VersionRange WIDEST_RANGE = Utils.EMPTY_RANGE;

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/BuildScriptGeneratorTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/BuildScriptGeneratorTask.java
@@ -181,7 +181,7 @@ public class BuildScriptGeneratorTask extends Task {
 
 	/** 
 	 * Set the configuration for which the script should be generated. The default is set to be configuration independent.
-	 * @param configInfo an ampersand separated list of configuration (for example win32, win32, x86 & macoxs, carbon, ppc).
+	 * @param configInfo an ampersand separated list of configuration (for example {@code win32, win32, x86 & macoxs, carbon, ppc}).
 	 * @since 3.0
 	 */
 	public void setConfigInfo(String configInfo) throws CoreException {
@@ -190,7 +190,7 @@ public class BuildScriptGeneratorTask extends Task {
 
 	/** 
 	 * Set on a configuration basis, the format of the archive being produced. The default is set to be configuration independent.
-	 * @param archivesFormat an ampersand separated list of configuration (for example win32, win32 - zip, x86 & macoxs, carbon, ppc - tar).
+	 * @param archivesFormat an ampersand separated list of configuration (for example {@code win32, win32 - zip, x86 & macoxs, carbon, ppc - tar}).
 	 * @since 3.0
 	 */
 	public void setArchivesFormat(String archivesFormat) {
@@ -280,7 +280,7 @@ public class BuildScriptGeneratorTask extends Task {
 	}
 
 	/**
-	 * Set whether or not to generate plugin & feature versions lists
+	 * Set whether or not to generate plugin and feature versions lists
 	 */
 	public void setGenerateVersionsLists(boolean value) {
 		generator.setGenerateVersionsList(value);

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/FeatureGeneratorTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/FeatureGeneratorTask.java
@@ -146,7 +146,7 @@ public class FeatureGeneratorTask extends Task {
 
 	/** 
 	 * Set the configuration for which the script should be generated. The default is set to be configuration independent.
-	 * @param configInfo an ampersand separated list of configuration (for example win32, win32, x86 & macoxs, carbon, ppc).
+	 * @param configInfo an ampersand separated list of configuration (for example {@code win32, win32, x86 & macoxs, carbon, ppc}).
 	 */
 	public void setConfigInfo(String configInfo) throws CoreException {
 		AbstractScriptGenerator.setConfigInfo(configInfo);

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/FetchFileGeneratorTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/FetchFileGeneratorTask.java
@@ -38,7 +38,7 @@ public class FetchFileGeneratorTask extends Task {
 
 	/** 
 	 * Set the configuration for which the script should be generated. The default is set to be configuration independent. 
-	 * @param config an ampersand separated list of configuration (for example win32, win32, x86 & macoxs, carbon, ppc).
+	 * @param config an ampersand separated list of configuration (for example {@code win32, win32, x86 & macoxs, carbon, ppc}).
 	 */
 	public void setConfigInfo(String config) throws CoreException {
 		AbstractScriptGenerator.setConfigInfo(config);

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/FetchTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/FetchTask.java
@@ -140,7 +140,7 @@ public class FetchTask extends Task {
 
 	/** 
 	 * Set the configuration for which the script should be generated. The default is set to be configuration independent.
-	 * @param configInfo an ampersand separated list of configuration (for example win32, win32, x86 & macoxs, carbon, ppc).
+	 * @param configInfo an ampersand separated list of configuration (for example {@code win32, win32, x86 & macoxs, carbon, ppc}).
 	 * @since 3.0
 	 */
 	public void setConfigInfo(String configInfo) throws CoreException {

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/IdReplaceTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/IdReplaceTask.java
@@ -89,7 +89,7 @@ public class IdReplaceTask extends Task {
 	/**
 	 * Set the values to use when replacing a generic value used in a plugin reference.
 	 * Note all the pluginIds that have a generic number into the feature.xml must be
-	 * listed in <param>values</param>.
+	 * listed in {@code values}.
 	 * @param values a comma separated list alternating pluginId and versionNumber.
 	 * For example: org.eclipse.pde.build,2.1.0,org.eclipse.core.resources,1.2.0
 	 */
@@ -112,7 +112,7 @@ public class IdReplaceTask extends Task {
 	/**
 	 * Set the values to use when replacing a generic value used in a feature reference
 	 * Note that all the featureIds that have a generic number into the feature.xml must
-	 * be liste in <param>values</param>.
+	 * be listed in {@code values}.
 	 */
 	public void setFeatureIds(String values) {
 		featureIds = new HashMap<>(10);

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/JNLPGeneratorTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/JNLPGeneratorTask.java
@@ -71,7 +71,7 @@ public class JNLPGeneratorTask extends Task {
 
 	/**
 	 * The locale in which the jnlp file generated should be translated into.
-	 *The translation values are read from the feature_<locale>.properties file.
+	 *The translation values are read from the feature_&lt;locale&gt;.properties file.
 	 * @param nlsString - the locale in which to generate the jnlp files.
 	 * */
 	public void setLocale(String nlsString) {

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/PackagerTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/PackagerTask.java
@@ -69,7 +69,7 @@ public class PackagerTask extends Task {
 
 	/** 
 	 * Set on a configuration basis, the format of the archive being produced. The default is set to be configuration independent.
-	 * @param archivesFormat an ampersand separated list of configuration (for example win32, win32 - zip, x86 & macoxs, carbon, ppc - tar).
+	 * @param archivesFormat an ampersand separated list of configuration (for example {@code win32, win32 - zip, x86 & macoxs, carbon, ppc - tar}).
 	 * @since 3.0
 	 */
 	public void setArchivesFormat(String archivesFormat) {

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/UnzipperGeneratorTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/UnzipperGeneratorTask.java
@@ -55,7 +55,7 @@ public class UnzipperGeneratorTask extends Task {
 
 	/** 
 	 * Set the configuration for which the script should be generated. The default is set to be configuration independent.
-	 * @param configInfo an ampersand separated list of configuration (for example win32, win32, x86 & macoxs, carbon, ppc).
+	 * @param configInfo an ampersand separated list of configuration (for example {@code win32, win32, x86 & macoxs, carbon, ppc}).
 	 */
 	public void setConfigInfo(String configInfo) throws BuildException {
 		try {

--- a/ds/org.eclipse.pde.ds.annotations/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.annotations/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.ds.annotations;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Activator: org.eclipse.pde.ds.internal.annotations.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.105.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ComponentPropertyTester.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ComponentPropertyTester.java
@@ -31,8 +31,9 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.pde.internal.ds.core.IDSConstants;
 
 /**
- * Tests if a type (or any nested type) has a {@link Component} annotation with
- * no <code>name</code> attribute.
+ * Tests if a type (or any nested type) has a
+ * {@link org.osgi.service.component.annotations.Component} annotation with no
+ * <code>name</code> attribute.
  */
 @SuppressWarnings("restriction")
 public class ComponentPropertyTester extends PropertyTester {

--- a/ds/org.eclipse.pde.ds.core/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.ds.core;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ds.core.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.filebuffers;bundle-version="[3.3.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/IDSModel.java
+++ b/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/IDSModel.java
@@ -23,7 +23,7 @@ import org.eclipse.pde.core.IModelChangeProvider;
  *
  * @since 3.4
  * @see IDSComponent
- * @see IDSFactory
+ * @see IDSDocumentFactory
  */
 public interface IDSModel extends IModelChangeProvider, IModel {
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-pde/eclipse.pde.git</tycho.scmUrl>
+    <failOnJavadocErrors>true</failOnJavadocErrors>
+    <javadoc.excludePackageNames></javadoc.excludePackageNames>
   </properties>
 
   <modules>
@@ -57,6 +59,13 @@
 				   <includeAllSources>true</includeAllSources>
 			   </configuration>
 		  </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<excludePackageNames>${javadoc.excludePackageNames}</excludePackageNames>
+				</configuration>
+			</plugin>
 	  </plugins>
   </build>
 

--- a/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Generic UI components related to BND
 Bundle-SymbolicName: org.eclipse.pde.bnd.ui;singleton:=true
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Export-Package: org.eclipse.pde.bnd.ui.autocomplete;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.plugins;x-internal:=true,
  org.eclipse.pde.bnd.ui.preferences;version="1.0.0";x-friends:="org.eclipse.pde.ui",

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/model/repo/RepositoryTreeLabelProvider.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/model/repo/RepositoryTreeLabelProvider.java
@@ -159,10 +159,11 @@ public class RepositoryTreeLabelProvider extends StyledCellLabelProvider
 
 	/**
 	 * Return the text to be shown as a tooltip.
-	 * <p/>
+	 * <p>
 	 * TODO allow markdown to be used. Not sure how to create a rich text
 	 * tooltip though. Would also be nice if we could copy/paste from the
 	 * tooltip like in the JDT.
+	 * </p>
 	 */
 	@Override
 	public String getToolTipText(Object element) {

--- a/ui/org.eclipse.pde.core/build.properties
+++ b/ui/org.eclipse.pde.core/build.properties
@@ -38,3 +38,4 @@ jars.extra.classpath = platform:/plugin/org.apache.ant/lib/ant.jar,\
 extra.lib/pde-ant.jar = ../org.apache.ant/ant.jar,\
                         ../org.eclipse.pde.build/lib/pdebuild-ant.jar
 pom.model.property.defaultSigning-excludeInnerJars = true
+pom.model.property.javadoc.excludePackageNames = org.eclipse.pde.internal.core.ant

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/Bundle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/Bundle.java
@@ -62,7 +62,7 @@ public class Bundle extends BundleObject implements IBundle {
 	 * headers previously loaded will be cleared. Empty value strings will create empty headers.
 	 * Null values will be ignored.
 	 *
-	 * @param headers map<String, String> of manifest key and values
+	 * @param headers Map&lt;String, String&gt; of manifest key and values
 	 */
 	public void load(Map<String, String> headers) {
 		fDocumentHeaders.clear();

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ischema/ISchema.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ischema/ISchema.java
@@ -157,15 +157,16 @@ public interface ISchema extends ISchemaObject, IBaseModel, IModelChangeProvider
 	ISchemaInclude[] getIncludes();
 
 	/**
-	 * Returns whether the root schema element (the <extension> element)
+	 * Returns whether the root schema element (the &lt;extension&gt; element)
 	 * has been marked deprecated, making this schema deprecated.
 	 * @return true if this schema is deprecated
 	 */
 	public boolean isDeperecated();
 
 	/**
-	 * Returns whether the root schema element (the <extension> element)
+	 * Returns whether the root schema element (the &lt;extension&gt; element)
 	 * has been marked internal, making this schema internal.
+	 *
 	 * @return true if this schema is internal
 	 *
 	 * @since 3.4

--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
@@ -63,7 +63,7 @@ public class LaunchArgumentsHelper {
 
 	/**
 	 * Returns the location that will be used as the workspace when launching or
-	 * an empty string if the user has specified the <code>-data &#64none</code>
+	 * an empty string if the user has specified the {@code -data @none}
 	 * argument for no workspace.  Will replace variables, so this method should
 	 * only be called when variable substitution (may prompt the user) is appropriate.
 	 *

--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.runtime; singleton:=true
-Bundle-Version: 3.8.500.qualifier
+Bundle-Version: 3.8.600.qualifier
 Bundle-Activator: org.eclipse.pde.internal.runtime.PDERuntimePlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/Property.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/registry/model/Property.java
@@ -56,16 +56,17 @@ public class Property extends ModelObject implements Comparable<Property> {
 	 *
 	 * <p>
 	 * The {@link Property}s are compared according to the following rules:
+	 * </p>
 	 * <ul>
 	 * <li>objectClass is always less than everything else</li>
 	 * <li>properties with names starting with "service." are considered "less"
 	 * than other properties.</li>
 	 * <li>regular properties are considered "more" than other properties</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * <p>
 	 * When sorting an array of properties with the following code:
+	 * </p>
 	 *
 	 * <pre>
 	 * Property[] properties = ...;
@@ -78,7 +79,6 @@ public class Property extends ModelObject implements Comparable<Property> {
 	 * <li>service.id</li>
 	 * <li>service.id</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param other
 	 *            other property to be compared against

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PDE JUnit Tests
 Bundle-SymbolicName: org.eclipse.pde.ui.tests; singleton:=true
-Bundle-Version: 3.12.600.qualifier
+Bundle-Version: 3.12.700.qualifier
 Bundle-ClassPath: tests.jar
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.pde.ui,

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.tests</artifactId>
-  <version>3.12.600-SNAPSHOT</version>
+  <version>3.12.700-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/TargetDefinitionResolutionTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/TargetDefinitionResolutionTests.java
@@ -70,7 +70,7 @@ public class TargetDefinitionResolutionTests extends AbstractTargetTest {
 	 * Tests that if we find a bundle with a bad or missing manifest when
 	 * resolving we create the correct status.
 	 *
-	 * @see TargetBundle.STATUS_INVALID_MANIFEST
+	 * @see TargetBundle#STATUS_INVALID_MANIFEST
 	 */
 	@Test
 	public void testInvalidManifest() throws Exception {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/StructuredViewerSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/StructuredViewerSection.java
@@ -164,11 +164,16 @@ public abstract class StructuredViewerSection extends PDESection implements IPDE
 	}
 
 	/**
-	 * <p>Given the index of TreeViewer item and the size of the array of its immediate
-	 * siblings, gets the index of the desired new selection as follows:
-	 * <ul><li>if this is the only item, return -1 (meaning select the parent)</li>
+	 * <p>
+	 * Given the index of TreeViewer item and the size of the array of its
+	 * immediate siblings, gets the index of the desired new selection as
+	 * follows:
+	 * </p>
+	 * <ul>
+	 * <li>if this is the only item, return -1 (meaning select the parent)</li>
 	 * <li>if this is the last item, return the index of the predecessor</li>
-	 * <li>otherwise, return the index of the successor</li></p>
+	 * <li>otherwise, return the index of the successor</li>
+	 * </ul>
 	 *
 	 * @param thisIndex
 	 * 			the item's index

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/ModelModification.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/ModelModification.java
@@ -44,9 +44,12 @@ public abstract class ModelModification {
 
 	/**
 	 * Create a full IBundlePluginModelBase modification
-	 * @param bundleFile the MANIFEST.MF file
-	 * @param xmlFile the plugin.xml/fragment.xml file for this modification (optional - can be null)
-	 * @pre bundleFile must not be <code>null</code>
+	 *
+	 * @param bundleFile
+	 *            the MANIFEST.MF file (must not be {@code null})
+	 * @param xmlFile
+	 *            the plugin.xml/fragment.xml file for this modification
+	 *            (optional - may be {@code null})
 	 */
 	public ModelModification(IFile bundleFile, IFile xmlFile) {
 		createFullBundleModification(bundleFile, xmlFile);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/PDELabelUtility.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/PDELabelUtility.java
@@ -180,9 +180,17 @@ public class PDELabelUtility {
 	}
 
 	/**
-	 * <p>Generates a name that does not conflict with any of the given names with one of two forms:
-	 * <ol><li>&quot;&lt;base&gt; (#)&quot;</li><li>&quot;&lt;base&gt;#&quot;</li></ol>
-	 * The number will be omitted if the base name alone is available.</p>
+	 * <p>
+	 * Generates a name that does not conflict with any of the given names with
+	 * one of two forms:
+	 * </p>
+	 * <ol>
+	 * <li>&quot;&lt;base&gt; (#)&quot;</li>
+	 * <li>&quot;&lt;base&gt;#&quot;</li>
+	 * </ol>
+	 * <p>
+	 * The number will be omitted if the base name alone is available.
+	 * </p>
 	 *
 	 * @param names
 	 * 			the existing names that should not be conflicted

--- a/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/SampleWizard.java
+++ b/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/SampleWizard.java
@@ -242,7 +242,6 @@ public class SampleWizard extends Wizard implements INewWizard, IExecutableExten
 
 	/**
 	 * @return Returns the switchPerspective.
-	 * @todo Generated comment
 	 */
 	public boolean isSwitchPerspective() {
 		return switchPerspective;
@@ -250,7 +249,6 @@ public class SampleWizard extends Wizard implements INewWizard, IExecutableExten
 
 	/**
 	 * @param switchPerspective The switchPerspective to set.
-	 * @todo Generated comment
 	 */
 	public void setSwitchPerspective(boolean switchPerspective) {
 		this.switchPerspective = switchPerspective;
@@ -258,7 +256,6 @@ public class SampleWizard extends Wizard implements INewWizard, IExecutableExten
 
 	/**
 	 * @return Returns the selectRevealEnabled.
-	 * @todo Generated comment
 	 */
 	public boolean isSelectRevealEnabled() {
 		return selectRevealEnabled;
@@ -266,7 +263,6 @@ public class SampleWizard extends Wizard implements INewWizard, IExecutableExten
 
 	/**
 	 * @param selectRevealEnabled The selectRevealEnabled to set.
-	 * @todo Generated comment
 	 */
 	public void setSelectRevealEnabled(boolean selectRevealEnabled) {
 		this.selectRevealEnabled = selectRevealEnabled;
@@ -274,7 +270,6 @@ public class SampleWizard extends Wizard implements INewWizard, IExecutableExten
 
 	/**
 	 * @return Returns the activitiesEnabled.
-	 * @todo Generated comment
 	 */
 	public boolean getActivitiesEnabled() {
 		return activitiesEnabled;
@@ -282,7 +277,6 @@ public class SampleWizard extends Wizard implements INewWizard, IExecutableExten
 
 	/**
 	 * @param activitiesEnabled The activitiesEnabled to set.
-	 * @todo Generated comment
 	 */
 	public void setActivitiesEnabled(boolean activitiesEnabled) {
 		this.activitiesEnabled = activitiesEnabled;

--- a/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/ShowSampleAction.java
+++ b/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/ShowSampleAction.java
@@ -215,8 +215,8 @@ public class ShowSampleAction extends Action implements IIntroAction {
 	}
 
 	/**
-	 * Returns a Collection<IInstallableUnit> of the installable units that contain the samples
-	 * to be installed.
+	 * Returns a Collection&lt;IInstallableUnit&gt; of the installable units
+	 * that contain the samples to be installed.
 	 */
 	protected Collection<IInstallableUnit> findSampleIUs(URI location, SubMonitor monitor) throws ProvisionException {
 		IMetadataRepository repository = provUI.loadMetadataRepository(location, false, monitor.split(5));


### PR DESCRIPTION
Fix all javadoc errors except for the packages `org.eclipse.pde.internal.build.publisher` and `org.eclipse.pde.internal.core.ant` which contain only ANT task sources and therefore require special class-path configuration that I wasn't able to properly replicate for the javadoc build.

To avoid javadoc errors in the future also fail the build on javadoc errors.

Should fix https://github.com/eclipse-pde/eclipse.pde/issues/1392.

This also contains the commit/changes from the following PRs with the requested changes applied:
- https://github.com/eclipse-pde/eclipse.pde/pull/1394
- https://github.com/eclipse-pde/eclipse.pde/pull/1393