### PR TITLE
Adapt to changed output directory in maven-javadoc-plugin 3.10.0

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Fix deprecation tag 'since' value
 Modernize pde.project description interfaces: https://github.com/eclipse-pde/eclipse.pde/pull/1341
 Rework PluginRegistry API and introduce VersionMatchRule enum : https://github.com/eclipse-pde/eclipse.pde/pull/1163
 Comparator errors in I20240904-0240
+Add missing reference/api content

--- a/org.eclipse.pde.doc.user/pom.xml
+++ b/org.eclipse.pde.doc.user/pom.xml
@@ -228,7 +228,7 @@
                   <outputDirectory>${basedir}/reference/api</outputDirectory>
                   <resources>          
                     <resource>
-                      <directory>${project.build.directory}/site/apidocs</directory>
+                      <directory>${project.build.directory}/reports/apidocs</directory>
                     </resource>
                   </resources>
                 </configuration>


### PR DESCRIPTION
Probably as part of https://github.com/apache/maven-javadoc-plugin/pull/204, the default output directory of the `maven-javadoc-plugin` changed when updating the `maven-javadoc-plugin` from `3.8.0` to `3.10.0`. This adapts the doc-bundle build accordingly.

In a local test the missing `reference/api` folder was generated in the project as expected, but the built jar still didn't contain it. So maybe more adaption is necessary.

Hopefully fixes https://github.com/eclipse-pde/eclipse.pde/issues/1392