### PR TITLE
Enforce qualifier-update of o.e.pde.doc.user to pick up javadoch changes

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Modernize pde.project description interfaces: https://github.com/eclipse-pde/ecl
 Rework PluginRegistry API and introduce VersionMatchRule enum : https://github.com/eclipse-pde/eclipse.pde/pull/1163
 Comparator errors in I20240904-0240
 Add missing reference/api content
+Pick-up javadoc changes


### PR DESCRIPTION
Something changed the result of the javadoc generation again and therefore the last master branch build failed due to comparator errors.