### PR TITLE
Set up workflow for automated version increments in pull-requests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,6 @@ on:
     branches: [ master ]
 
 jobs:
-  check-freeze-period:
-    if: github.event_name == 'pull_request'
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master
-  check-merge-commits:
-    if: github.event_name == 'pull_request'
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
   check-dash-licenses:
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,10 @@ on:
     branches: [ master ]
 
 jobs:
+  check-freeze-period:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master
+  check-merge-commits:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
   check-versions:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkVersions.yml@master
     with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,17 @@
+# Fast running checks for pull-requests
+
+name: Pull-Request Checks
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check-versions:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkVersions.yml@master
+    with:
+      botName: Eclipse PDE Bot
+      botMail: eclipse-pde-bot@eclipse.org

--- a/.github/workflows/version-increments.yml
+++ b/.github/workflows/version-increments.yml
@@ -1,0 +1,14 @@
+name: Publish Version Check Results
+
+on:
+  workflow_run:
+    workflows: [ 'Pull-Request Checks' ]
+    types: [ completed ]
+
+jobs:
+  publish-version-check-results:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/publishVersionCheckResults.yml@master
+    with:
+      botGithubId: eclipse-pde-bot
+    secrets:
+      githubBotPAT: ${{ secrets.PDE_BOT_PAT }}


### PR DESCRIPTION
Set up the workflow for automated version increments in pull-requests, added via https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2352, for PDE.

Before this can fully work, the EF infra team has to add the required PAT of the PDE-bot to this repo as desribed in the linked PR.