### PR TITLE
Build on ubuntu-latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
 		timestamps()
 	}
 	agent {
-		label 'centos-latest-8gb'
+		label 'ubuntu-latest'
 	}
 	tools {
 		maven 'apache-maven-latest'

--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Rework PluginRegistry API and introduce VersionMatchRule enum : https://github.c
 Comparator errors in I20240904-0240
 Add missing reference/api content
 Pick-up javadoc changes
+Force javadoc regeneration


### PR DESCRIPTION
centos-latest is deprecated as per:
https://github.com/eclipse-cbi/jiro-agents/blob/master/README.md