### PR TITLE
NPE in VersionUtil

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
@@ -42,7 +42,9 @@ public class VersionUtil {
 
 	public static IStatus validateVersionRange(String versionRangeString) {
 		try {
-			new VersionRange(versionRangeString);
+			if (versionRangeString != null) {
+				new VersionRange(versionRangeString);
+			}
 		} catch (IllegalArgumentException e) {
 			return Status.error(UtilMessages.BundleErrorReporter_invalidVersionRangeFormat, e);
 		}


### PR DESCRIPTION
Take same strategy as for a version string: Don't report an error for null values, assuming this just means absence of a version range.

java.lang.NullPointerException: Cannot invoke "String.length()" because "str" is null
	at java.base/java.util.StringTokenizer.<init>(StringTokenizer.java:199)
	at org.osgi.framework.VersionRange.<init>(VersionRange.java:137)
	at org.eclipse.pde.internal.core.util.VersionUtil.validateVersionRange(VersionUtil.java:45)
	at org.eclipse.pde.internal.core.builders.BundleErrorReporter.validateFragmentHost(BundleErrorReporter.java:480)
	at org.eclipse.pde.internal.core.builders.BundleErrorReporter.validate(BundleErrorReporter.java:164)
	at org.eclipse.pde.internal.core.builders.ErrorReporter.validateContent(ErrorReporter.java:109)
	at org.eclipse.pde.internal.core.builders.ManifestConsistencyChecker.validateManifestFile(ManifestConsistencyChecker.java:318)
	at org.eclipse.pde.internal.core.builders.ManifestConsistencyChecker.validateProject(ManifestConsistencyChecker.java:272)
	at org.eclipse.pde.internal.core.builders.ManifestConsistencyChecker.build(ManifestConsistencyChecker.java:194)
	at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:1077)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:296)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:352)
	at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:441)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:444)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:555)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:503)
	at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:585)
	at org.eclipse.core.internal.resources.Workspace.buildInternal(Workspace.java:595)
	at org.eclipse.core.internal.resources.Workspace.build(Workspace.java:484)
	at org.eclipse.oomph.setup.internal.core.SetupTaskPerformer$6.run(SetupTaskPerformer.java:3909)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)