### PR TITLE
Cleanup deprecated Platform.ARCH_X86 usage 

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ArgumentsInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ArgumentsInfo.java
@@ -123,6 +123,7 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 		return getCompleteProgramArguments(os, ""); //$NON-NLS-1$
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public String getCompleteProgramArguments(String os, String arch) {
 		int archIndex = L_ARGS_ARCH_ALL;
@@ -217,6 +218,7 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 		return getCompleteVMArguments(os, ""); //$NON-NLS-1$
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public String getCompleteVMArguments(String os, String arch) {
 		int archIndex = L_ARGS_ARCH_ALL;

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/util/PDESchemaHelperTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/util/PDESchemaHelperTest.java
@@ -51,13 +51,13 @@ public class PDESchemaHelperTest {
 		property2.setName("osgi.configuration.area");
 		property2.setValue("/usr/local/share/Eclipse");
 		property2.setOs(Platform.OS_LINUX);
-		property2.setArch(Platform.ARCH_X86);
+		property2.setArch(Platform.ARCH_AARCH64);
 		fConfigurationProperties.add(property2);
 		IConfigurationProperty property3 = fProductModelFactory.createConfigurationProperty();
 		property3.setName("p1");
 		property3.setValue("v1");
 		property3.setOs(PDESchemaHelper.ALL_OS);
-		property3.setArch(Platform.ARCH_X86);
+		property3.setArch(Platform.ARCH_X86_64);
 		fConfigurationProperties.add(property3);
 
 	}
@@ -70,12 +70,12 @@ public class PDESchemaHelperTest {
 		assertTrue(containsMatchingProperty);
 
 		containsMatchingProperty = PDESchemaHelper.containsMatchingProperty(fConfigurationProperties,
-				"osgi.configuration.area", Platform.OS_LINUX, Platform.ARCH_X86);
+				"osgi.configuration.area", Platform.OS_LINUX, Platform.ARCH_AARCH64);
 		assertTrue(containsMatchingProperty);
 
 		// specific architecture
 		containsMatchingProperty = PDESchemaHelper.containsMatchingProperty(fConfigurationProperties,
-				"org.osgi.instance.area", Platform.OS_WIN32, Platform.ARCH_X86);
+				"org.osgi.instance.area", Platform.OS_WIN32, Platform.ARCH_X86_64);
 		assertTrue(containsMatchingProperty);
 
 		containsMatchingProperty = PDESchemaHelper.containsMatchingProperty(fConfigurationProperties,
@@ -89,7 +89,7 @@ public class PDESchemaHelperTest {
 
 		// for all os but specific arch
 		containsMatchingProperty = PDESchemaHelper.containsMatchingProperty(fConfigurationProperties,
-				"org.osgi.instance.area", PDESchemaHelper.ALL_OS, Platform.ARCH_X86);
+				"org.osgi.instance.area", PDESchemaHelper.ALL_OS, Platform.ARCH_X86_64);
 		assertTrue(containsMatchingProperty);
 
 		// for different OS
@@ -104,7 +104,7 @@ public class PDESchemaHelperTest {
 
 		// all os but different architecture
 		containsMatchingProperty = PDESchemaHelper.containsMatchingProperty(fConfigurationProperties, "p1",
-				PDESchemaHelper.ALL_OS, Platform.ARCH_X86_64);
+				PDESchemaHelper.ALL_OS, Platform.ARCH_PPC64LE);
 		assertFalse(containsMatchingProperty);
 
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ArgumentsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ArgumentsSection.java
@@ -50,6 +50,7 @@ import org.eclipse.ui.forms.IFormColors;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
 
+@SuppressWarnings("deprecation")
 public class ArgumentsSection extends PDESection {
 
 	private static final String[] TAB_LABELS = new String[4];

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PropertiesSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PropertiesSection.java
@@ -130,6 +130,7 @@ public class PropertiesSection extends TableSection {
 
 		private final String[] COMBO_OSLABELS = new String[] { PDEUIMessages.PropertiesSection_All, Platform.OS_LINUX,
 				Platform.OS_MACOSX, Platform.OS_WIN32 };
+		@SuppressWarnings("deprecation")
 		private final String[] COMBO_ARCHLABELS = new String[] { PDEUIMessages.PropertiesSection_All, Platform.ARCH_X86,
 				Platform.ARCH_X86_64 };
 


### PR DESCRIPTION
Silenced in code to allow targeting older versions. Replaced in tests.