### PR TITLE
Fix failing case in Bug528706CompletionWithMultilineTagsTest

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Generic Target Platform Editor
 Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension.tests
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.genericeditor.extension.tests</artifactId>
-  <version>1.2.400-SNAPSHOT</version>
+  <version>1.2.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AbstractTargetEditorTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AbstractTargetEditorTest.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.filebuffers.FileBuffers;
@@ -52,12 +54,7 @@ public abstract class AbstractTargetEditorTest {
 	protected File tempFile;
 
 	protected void checkProposals(String[] expectedProposals, ICompletionProposal[] actualProposals, int offset) {
-		assertEquals("Proposal lengths are not equal at offset " + offset + ". Actual: "
-				+ proposalListToString(actualProposals), expectedProposals.length, actualProposals.length);
-		for (int i = 0; i < actualProposals.length; i++) {
-			assertEquals("Proposal at index " + i + " did not match expected at offset " + offset,
-					actualProposals[i].getDisplayString(), expectedProposals[i]);
-		}
+		assertEquals(Arrays.asList(expectedProposals), toProposalStrings(actualProposals));
 	}
 
 	@Before
@@ -102,18 +99,11 @@ public abstract class AbstractTargetEditorTest {
 		if (proposals == null) {
 			return "null";
 		}
-		if (proposals.length == 0) {
-			return "[]";
-		}
-		StringBuilder builder = new StringBuilder();
-		builder.append('[');
-		for (ICompletionProposal proposal : proposals) {
-			builder.append(proposal.getDisplayString());
-			builder.append(", ");
-		}
-		builder.setLength(builder.length() - 2);
-		builder.append(']');
-		return builder.toString();
+		return "[" + String.join(",", toProposalStrings(proposals)) + "]";
+	}
+
+	private static List<String> toProposalStrings(ICompletionProposal[] proposals) {
+		return Arrays.stream(proposals).map(ICompletionProposal::getDisplayString).toList();
 	}
 
 	public static ITextFileBuffer getTextFileBufferFromFile(File file) {

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug528706CompletionWithMultilineTagsTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug528706CompletionWithMultilineTagsTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.ITextViewer;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,8 +50,7 @@ public class Bug528706CompletionWithMultilineTagsTest extends AbstractTargetEdit
 
 	@Test
 	public void testTagValueCompletionAfterAMultiline() {
-		checkProposals(new String[] { "x86", "x86_64" },
-				contentAssist.computeCompletionProposals(textViewer, 181 + 1), 181);
+		checkProposals(Platform.knownOSArchValues(), contentAssist.computeCompletionProposals(textViewer, 181), 181);
 	}
 
 	@Test

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/MultilineTagTestCaseTarget.txt
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/testing-files/target-files/MultilineTagTestCaseTarget.txt
@@ -17,6 +17,6 @@
 linu
 
 </os>
-<arch>x</arch>
+<arch></arch>
 </environment>
 </target>


### PR DESCRIPTION
Is probably failing due to the update of the supported architectures list in https://github.com/eclipse-platform/eclipse.platform/pull/1576.

And simplify `AbstractTargetEditorTest`.