### PR TITLE
Provide TARGET_SAVED and TARGET_DELETED events

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -7,3 +7,4 @@ Add missing reference/api content
 Pick-up javadoc changes
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2396
 Touch for build JVM change causing using newer jquery
+Add new TargetEvents constants

--- a/ui/org.eclipse.pde.core/.settings/.api_filters
+++ b/ui/org.eclipse.pde.core/.settings/.api_filters
@@ -1,5 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.pde.core" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter id="926941240">
+            <message_arguments>
+                <message_argument value="3.20.0"/>
+                <message_argument value="3.19.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/pde/core/target/TargetEvents.java" type="org.eclipse.pde.core.target.TargetEvents">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.pde.core.target.TargetEvents"/>
+                <message_argument value="TOPIC_TARGET_DELETED"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.pde.core.target.TargetEvents"/>
+                <message_argument value="TOPIC_TARGET_SAVED"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/pde/internal/core/project/BundleProjectService.java" type="org.eclipse.pde.internal.core.project.BundleProjectService">
         <filter comment="Platform Team allows use of bundle importers for PDE import from source repository" id="640712815">
             <message_arguments>

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
@@ -101,6 +101,7 @@ Import-Package: aQute.bnd.build;version="[4.4.0,5.0.0)",
  org.eclipse.equinox.internal.p2.publisher.eclipse,
  org.eclipse.equinox.p2.publisher,
  org.eclipse.equinox.p2.publisher.eclipse,
+ org.osgi.service.event;version="[1.4.0,2.0.0)",
  org.osgi.service.repository;version="[1.1.0,2.0.0)",
  org.osgi.util.promise;version="[1.3.0,2.0.0)"
 Require-Bundle: 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/TargetEvents.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/TargetEvents.java
@@ -12,28 +12,84 @@
  ********************************************************************************/
 package org.eclipse.pde.core.target;
 
+import org.eclipse.e4.core.services.events.IEventBroker;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+
 /**
- * Target events and event topic definitions
+ * Target events and event topic definitions.
  *
+ * <p>
+ * The following code is an example of to subscribe to the
+ * {@link #TOPIC_TARGET_SAVED} event:
+ * </p>
+ *
+ * <pre>
+ * EventHandler eventHandler = event -> {
+ * 	if (event.getProperty(IEventBroker.DATA) instanceof ITargetHandle handle) {
+ * 		// Work with the target handle...
+ * 	}
+ * };
+ * IEclipseContext context = EclipseContextFactory.getServiceContext(bundleContext);
+ * IEventBroker broker = context.get(IEventBroker.class);
+ * if (broker != null) {
+ * 	broker.subscribe(TargetEvents.TOPIC_TARGET_SAVED, eventHandler);
+ * 	// Do not forget to unsubscribe later!
+ * }
+ * </pre>
+ *
+ * @see ITargetPlatformService
+ * @see IEventBroker#subscribe(String, EventHandler)
+ * @see IEventBroker#subscribe(String, String, EventHandler, boolean)
+ * @see IEventBroker#unsubscribe(EventHandler)
  * @since 3.13
  */
 public class TargetEvents {
 
 	/**
-	 * Base topic for all Target events
+	 * Base topic for all target events.
 	 */
 	public static final String TOPIC_BASE = "org/eclipse/pde/core/target/TargetEvents"; //$NON-NLS-1$
 
 	/**
-	 * Topic for all Target events
+	 * Topic for all target events.
 	 */
 	public static final String TOPIC_ALL = TOPIC_BASE + "/*"; //$NON-NLS-1$
 
 	/**
-	 * Sent when workspace target definition is changed
+	 * Sent when workspace target definition is changed.
+	 * <p>
+	 * The {@link IEventBroker#DATA data} {@link Event#getProperty(String) event
+	 * property} of events with this topic is the changed
+	 * {@link ITargetDefinition}.
+	 * </p>
 	 *
 	 * @see ITargetPlatformService#getWorkspaceTargetDefinition()
 	 */
 	public static final String TOPIC_WORKSPACE_TARGET_CHANGED = TOPIC_BASE + "/workspaceTargetChanged"; //$NON-NLS-1$
 
+	/**
+	 * Sent when a target is saved.
+	 * <p>
+	 * The {@link IEventBroker#DATA data} {@link Event#getProperty(String) event
+	 * property} of events with this topic is the saved {@link ITargetHandle}.
+	 * </p>
+	 *
+	 * @see ITargetPlatformService#saveTargetDefinition(ITargetDefinition)
+	 * @see IEventBroker
+	 * @since 3.20
+	 */
+	public static final String TOPIC_TARGET_SAVED = TOPIC_BASE + "/targetSaved"; //$NON-NLS-1$
+
+	/**
+	 * Sent when a target is deleted.
+	 * <p>
+	 * The {@link IEventBroker#DATA data} {@link Event#getProperty(String) event
+	 * property} of events with this topic is the deleted {@link ITargetHandle}.
+	 * </p>
+	 *
+	 * @see ITargetPlatformService#deleteTarget(ITargetHandle)
+	 * @since 3.20
+	 */
+	public static final String TOPIC_TARGET_DELETED = TOPIC_BASE + "/targetDeleted"; //$NON-NLS-1$
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/AbstractTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/AbstractTargetHandle.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.pde.core.target.ITargetDefinition;
 import org.eclipse.pde.core.target.ITargetHandle;
+import org.eclipse.pde.core.target.TargetEvents;
 
 /**
  * Common implementation of target handles.
@@ -53,11 +54,16 @@ public abstract class AbstractTargetHandle implements ITargetHandle {
 	 */
 	abstract void delete() throws CoreException;
 
+	public final void save(ITargetDefinition definition) throws CoreException {
+		doSave(definition);
+		TargetPlatformService.scheduleEvent(TargetEvents.TOPIC_TARGET_SAVED, definition.getHandle());
+	}
+
 	/**
 	 * Saves the definition to underlying storage.
 	 *
 	 * @param definition target to save
 	 * @throws CoreException on failure
 	 */
-	abstract void save(ITargetDefinition definition) throws CoreException;
+	abstract void doSave(ITargetDefinition definition) throws CoreException;
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/ExternalFileTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/ExternalFileTargetHandle.java
@@ -81,7 +81,7 @@ public class ExternalFileTargetHandle extends AbstractTargetHandle {
 
 
 	@Override
-	void save(ITargetDefinition definition) throws CoreException {
+	void doSave(ITargetDefinition definition) throws CoreException {
 		try (OutputStream stream = new BufferedOutputStream(new FileOutputStream(fFile))) {
 			((TargetDefinition) definition).write(stream);
 		} catch (IOException e) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/LocalTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/LocalTargetHandle.java
@@ -193,7 +193,7 @@ public class LocalTargetHandle extends AbstractTargetHandle {
 	}
 
 	@Override
-	void save(ITargetDefinition definition) throws CoreException {
+	void doSave(ITargetDefinition definition) throws CoreException {
 		try (OutputStream stream = getOutputStream()) {
 			((TargetDefinition) definition).write(stream);
 		} catch (IOException e) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
@@ -126,6 +126,7 @@ public class TargetPlatformService implements ITargetPlatformService {
 		}
 		((AbstractTargetHandle) handle).delete();
 		TargetPlatformHelper.getTargetDefinitionMap().remove(handle);
+		scheduleEvent(TargetEvents.TOPIC_TARGET_DELETED, handle);
 	}
 
 	@Override
@@ -332,6 +333,10 @@ public class TargetPlatformService implements ITargetPlatformService {
 		if (!Objects.equals(oldTarget, target)) {
 			notifyEvent(TargetEvents.TOPIC_WORKSPACE_TARGET_CHANGED, target, asyncEvents);
 		}
+	}
+
+	public static void scheduleEvent(String topic, Object data) {
+		notifyEvent(topic, data, true);
 	}
 
 	private static void notifyEvent(String topic, Object data, boolean asyncEvents) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/WorkspaceFileTargetHandle.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/WorkspaceFileTargetHandle.java
@@ -76,7 +76,7 @@ public class WorkspaceFileTargetHandle extends AbstractTargetHandle {
 	}
 
 	@Override
-	public void save(ITargetDefinition definition) throws CoreException {
+	void doSave(ITargetDefinition definition) throws CoreException {
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		((TargetDefinition) definition).write(outputStream);
 		ByteArrayInputStream stream = new ByteArrayInputStream(outputStream.toByteArray());

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -65,6 +65,7 @@ import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEPreferencesManager;
 import org.eclipse.pde.internal.core.target.P2TargetUtils;
 import org.eclipse.pde.internal.core.target.TargetDefinitionPersistenceHelper;
+import org.eclipse.pde.internal.core.target.TargetPlatformService;
 import org.eclipse.pde.internal.core.target.WorkspaceFileTargetHandle;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPlugin;
@@ -175,6 +176,7 @@ public class TargetEditor extends FormEditor {
 
 	@Override
 	public void doSave(IProgressMonitor monitor) {
+		ITargetHandle handle = fInputHandler.getTarget().getHandle();
 		fInputHandler.setSaving(true);
 		if (!isActiveTabTextualEditor()) {
 			markStale();
@@ -184,6 +186,8 @@ public class TargetEditor extends FormEditor {
 		fDirty = false;
 		editorDirtyStateChanged();
 		fInputHandler.setSaving(false);
+
+		TargetPlatformService.scheduleEvent(TargetEvents.TOPIC_TARGET_SAVED, handle);
 	}
 
 	@Override
@@ -286,6 +290,16 @@ public class TargetEditor extends FormEditor {
 		super.dispose();
 	}
 
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter.equals(ITargetHandle.class)) {
+			ITargetDefinition target = getTarget();
+			if (target != null) {
+				return adapter.cast(target.getHandle());
+			}
+		}
+		return super.getAdapter(adapter);
+	}
 	/**
 	 * Returns the target model backing this editor
 	 * @return target model


### PR DESCRIPTION
When building tools on top of PDE's target platform framework it's often necessary to be informed about state changes in targets. PDE already uses an IEventBroker to send "workspaceTargetChanged" events. This change is about sending two new events:

    TARGET_SAVED and TARGET_DELETED

Please note that I also added the method TargetEditor.getAdapter(), which provides callers with the ITargetHandle of the editor.