### PR TITLE
Simplify TestPDETemplates

### DIFF
--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for PDE templates
 Bundle-SymbolicName: org.eclipse.pde.ui.templates.tests
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: tests.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/ui/org.eclipse.pde.ui.templates.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.templates.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.templates.tests</artifactId>
-  <version>1.2.400-SNAPSHOT</version>
+  <version>1.2.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2017, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -117,17 +117,7 @@ public class TestPDETemplates {
 		data.setHasBundleStructure(true);
 		data.setSourceFolderName("src");
 		data.setOutputFolderName("bin");
-		data.setExecutionEnvironment("JavaSE-1.8");
-		String version = System.getProperty("java.specification.version"); //$NON-NLS-1$
-		int ver = -1;
-		try {
-			ver = Integer.parseInt(version);
-		} catch (NumberFormatException e) {
-			// preJava9
-		}
-		if (ver >= 9) {
-			data.setExecutionEnvironment("JavaSE-" + version);
-		}
+		data.setExecutionEnvironment("JavaSE-" + Runtime.version().feature());
 		data.setTargetVersion(ICoreConstants.TARGET_VERSION_LATEST);
 		data.setDoGenerateClass(true);
 		String pureOSGi = template.getConfigurationElement().getAttribute("pureOSGi");


### PR DESCRIPTION
Use api rather than quering system property java.specification.version.