### PR TITLE
Fix pde.ui.templates.tests failures on Java 23

### DIFF
--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -173,12 +173,18 @@ public class TestPDETemplates {
 	private void assertErrorFree() throws CoreException {
 		IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
 
+		// ignore "value of lambda parameter is not used", filtering should be
+		// removed once the min JVM level supports this warning (Java 22) and
+		// templates are fixed to not produce it
+		markers = Arrays.stream(markers).filter(
+				m -> !m.getAttribute(IMarker.MESSAGE, "").equals("The value of the lambda parameter e is not used"))
+				.toArray(IMarker[]::new);
+
 		// ignore missing package export marker
 		if (markers.length == 1 && CompilerFlags.P_MISSING_EXPORT_PKGS
 				.equals(markers[0].getAttribute(PDEMarkerFactory.compilerKey, ""))) {
 			System.out.println("Template '" + template.getLabel() + "' ignored errors.");
 			System.out.println(markers[0]);
-			System.out.println("--------------------------------------------------------");
 			markers = new IMarker[0];
 		}
 		// ignore "DS Annotations missing from permanent build path"


### PR DESCRIPTION
ECJ has been enhanced to warn about unused lambda parameters (https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3053 ) but templates are done for lowest Java version supported without an easy way to generate per JVM versioned code thus there is no easy way to change them.
Filter these warnings until Java 22 is the min required version for templates.
Fixes I-build tests
https://download.eclipse.org/eclipse/downloads/drops4/I20241015-1820/testresults/html/org.eclipse.pde.ui.templates.tests_ep434I-unit-cen64-gtk3-java23_linux.gtk.x86_64_23.html