### PR TITLE
[TP-Editor] Adapt content-assist to support of version-ranges/no-version

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension;singleton:=true
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface.text,

--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/autocomplete/TagCompletionProposal.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/autocomplete/TagCompletionProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat Inc. and others
+ * Copyright (c) 2018, 2024 Red Hat Inc. and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -39,8 +39,7 @@ public class TagCompletionProposal extends TargetCompletionProposal {
 				new Attribute(ITargetConstants.LOCATION_PATH_ATTR, null),
 				new Attribute(ITargetConstants.LOCATION_TYPE_ATTR, ITargetConstants.LOCATION_TYPE_ATTR_VALUE_PROFILE) });
 		tagStartingAttributesAndValues.put(ITargetConstants.UNIT_TAG, new Attribute[] {
-				new Attribute(ITargetConstants.UNIT_ID_ATTR, null),
-				new Attribute(ITargetConstants.UNIT_VERSION_ATTR, ITargetConstants.UNIT_VERSION_ATTR_GENERIC) });
+				new Attribute(ITargetConstants.UNIT_ID_ATTR, null) });
 		tagStartingAttributesAndValues.put(ITargetConstants.REPOSITORY_TAG, new Attribute[] {
 				new Attribute(ITargetConstants.REPOSITORY_LOCATION_ATTR, null) });
 		tagStartingAttributesAndValues.put(ITargetConstants.TARGET_JRE_TAG, new Attribute[] {


### PR DESCRIPTION
- Remove 'version' attribute from 'unit' proposal
Now that PDE supports no versions in unit declarations it does not have to be proposed for all cases.

- Skip units with version-range in the 'UpdateUnitVersions' action from the context menu in the Source tab.

Follow-up on https://github.com/eclipse-pde/eclipse.pde/pull/1245.