### PR TITLE
Null Pointer Check added for systempackages in resolveState

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -443,7 +443,9 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 					String ee = profileProps.getProperty(FRAMEWORK_EXECUTIONENVIRONMENT);
 
 					Dictionary<String, Object> prop = new Hashtable<>();
-					prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);
+					if(systemPackages != null){
+					  prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);
+					}
 					if (profileName.equals("JavaSE-9")) { //$NON-NLS-1$
 						eeJava9 = ee;
 					}


### PR DESCRIPTION
HashTable is throwing null pointer exception when system packages are null