### PR TITLE
Null pointer check added for system package

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -441,7 +441,6 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 					IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(javaProfiles[j]);
 					String systemPackages = getSystemPackages(env, profileProps);
 					String ee = profileProps.getProperty(FRAMEWORK_EXECUTIONENVIRONMENT);
-                                         
 					Dictionary<String, Object> prop = new Hashtable<>();
 					if (systemPackages != null) { 
 						prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -441,9 +441,11 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 					IExecutionEnvironment env = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(javaProfiles[j]);
 					String systemPackages = getSystemPackages(env, profileProps);
 					String ee = profileProps.getProperty(FRAMEWORK_EXECUTIONENVIRONMENT);
-
+                                         
 					Dictionary<String, Object> prop = new Hashtable<>();
-					prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);
+					if (systemPackages != null) { 
+						prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);
+					}
 					if (profileName.equals("JavaSE-9")) { //$NON-NLS-1$
 						eeJava9 = ee;
 					}


### PR DESCRIPTION
Hashtable does not store null values , so if systempackage comes as null it will throw null pointer exception
Fixes :- [#1453](https://github.com/eclipse-pde/eclipse.pde/issues/1453)