### PR TITLE
back-port: Null pointer check added for system package (#1455)

### DIFF
--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.build;singleton:=true
-Bundle-Version: 3.12.300.qualifier
+Bundle-Version: 3.12.301.qualifier
 Bundle-ClassPath: pdebuild.jar
 Bundle-Activator: org.eclipse.pde.internal.build.BuildActivator
 Bundle-Vendor: %providerName

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java
@@ -441,7 +441,9 @@ public class PDEState implements IPDEBuildConstants, IBuildPropertiesConstants {
 					ee = profileProps.getProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT);
 
 					prop = new Hashtable<>();
-					prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);
+					if (systemPackages != null) { 
+						prop.put(ProfileManager.SYSTEM_PACKAGES, systemPackages);
+					}
 					if (profileName.equals("JavaSE-9")) { //$NON-NLS-1$
 						eeJava9 = ee;
 					}

--- a/features/org.eclipse.e4.tools.persistence.feature/feature.xml
+++ b/features/org.eclipse.e4.tools.persistence.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.e4.tools.persistence.feature"
       label="%featureName"
-      version="1.1.300.qualifier"
+      version="1.1.301.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde"
       label="%featureName"
-      version="3.15.300.qualifier"
+      version="3.15.301.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.doc.user; singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/org.eclipse.pde.doc.user/pom.xml
+++ b/org.eclipse.pde.doc.user/pom.xml
@@ -17,7 +17,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.pde.doc.user</artifactId>
-  <version>3.15.0-SNAPSHOT</version>
+  <version>3.15.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>


### PR DESCRIPTION
Null pointer check added for system package

Hashtable does not store null values , so if systempackage comes as null it will throw null pointer exception

/cc @MohananRahul 