### PR TITLE
Comparator errors in I20241106-1800

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/forceQualifierUpdate.txt
+++ b/apitools/org.eclipse.pde.api.tools/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ Comparator errors in I20230906-0400
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+Comparator errors in I20241106-1800/ - Expected due to https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3254


### PR DESCRIPTION
These are expected changes due to the compiler changes via https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3254