### PR TITLE
Force qualifier update in org.eclipse.pde.api.tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,22 @@
     <tycho.scmUrl>scm:git:https://github.com/eclipse-pde/eclipse.pde.git</tycho.scmUrl>
     <failOnJavadocErrors>true</failOnJavadocErrors>
     <javadoc.excludePackageNames></javadoc.excludePackageNames>
+    <cbi-ecj-version>[3.40.0,4)</cbi-ecj-version>
   </properties>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>eclipse-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/eclipse-snapshots</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+
+  </pluginRepositories>
 
   <modules>
     <module>apitools</module>
@@ -68,7 +83,7 @@
 	  </plugins>
   </build>
 
-  <!--
+	<!--
     To build individual bundles, we specify a repository where to find parent pom,
     in case it is not in local maven cache already
     and that parent pom also has fuller individual-bundle profile


### PR DESCRIPTION
to fix comparator errors/warnings in verification builds:
```
 [WARNING] MavenProject: org.eclipse.pde:org.eclipse.pde.api.tools:1.3.600-SNAPSHOT @ /home/jenkins/agent/workspace/eclipse.pde_master/apitools/org.eclipse.pde.api.tools/.polyglot.META-INF: baseline and build artifacts have same version but different contents
    no-classifier: different
       org/eclipse/pde/api/tools/internal/builder/IncrementalApiBuilder$ResourceDeltaVisitor.class: different
       org/eclipse/pde/api/tools/internal/util/Signatures.class: different
```

But since the I-build does not complain I fear it's a configuration difference and it will be a reoccurring issue.