### PR TITLE
Updated BuildClasspathSection.java

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildClasspathSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/build/BuildClasspathSection.java
@@ -171,8 +171,7 @@ public class BuildClasspathSection extends TableSection {
 
 	public void initialize() {
 		getBuildModel().addModelChangedListener(this);
-		IBuildEntry entry = getBuildModel().getBuild().getEntry(IBuildPropertiesConstants.PROPERTY_JAR_EXTRA_CLASSPATH);
-		getSection().setExpanded(entry != null && entry.getTokens().length > 0);
+		getSection().setExpanded(true);
 	}
 
 	@Override


### PR DESCRIPTION
Rewrote the initialize() function in BuildClasspathSection.java to make the 'Extra Classpath Entries' expanded by default
Before:
<img width="773" alt="buildclasspathbefore" src="https://github.com/user-attachments/assets/0f1cff7d-2c38-4b51-8136-ea1e7cdd8c8d">

After:
<img width="773" alt="Screenshot 2024-11-10 at 1 21 32 PM" src="https://github.com/user-attachments/assets/23ca4142-2a87-4379-9323-1c2dc263daa0">