### PR TITLE
Automated management of dependencies

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -2802,6 +2802,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String SecondaryBundlesSection_resolve;
 
+	public static String ExtraClassPathLink;
+
 	public static String ArgumentsSection_allPlatforms;
 
 	public static String ArgumentsSection_allArch;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyManagementSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyManagementSection.java
@@ -215,9 +215,9 @@ public class DependencyManagementSection extends TableSection implements IPlugin
 
 		gd = new GridData();
 		gd.horizontalSpan = 2;
-		FormText resolveText = toolkit.createFormText(container, true);
-		resolveText.setText(PDEUIMessages.SecondaryBundlesSection_resolve, true, true);
-		resolveText.setLayoutData(gd);
+		FormText buildSectionLinkText = toolkit.createFormText(container, true);
+		buildSectionLinkText.setText(PDEUIMessages.ExtraClassPathLink, true, true);
+		buildSectionLinkText.setLayoutData(gd);
 		resolveText.addHyperlinkListener(new HyperlinkAdapter() {
 			@Override
 			public void linkActivated(HyperlinkEvent e) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2703,6 +2703,7 @@ OSGiConsoleFactory_title=WARNING: This console is connected to the current runni
 NewElement_deprecated={0} (deprecated)
 ElementIsDeprecated=Element ''{0}'' is deprecated.
 
+ExtraClassPathLink=<p> You can go the 'Build' page to add additional classpath entries to the plugin classpath. </p>
 ExtensionAttributeRow_AttrDepr={0} (deprecated)
 ExtensionAttributeRow_AttrReq={0} (required)
 ExtensionAttributeRow_AttrReqDepr={0} (required) (deprecated)


### PR DESCRIPTION
Wasn't able to add a link to the editor object so just added a text description of the "Automated Management of Dependencies"

Before:
<img width="816" alt="buildclasspathafter" src="https://github.com/user-attachments/assets/4984e8d7-32cf-48ce-9e14-99ed5010294b">

After:
<img width="791" alt="Screenshot 2024-11-12 at 1 06 52 AM" src="https://github.com/user-attachments/assets/25a3e537-dafc-4f1a-9510-af899ed3cd0a">

