### PR TITLE
Fix editing of Implicit Plugin-Dpendencies

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
@@ -819,6 +819,7 @@ public class TargetDefinition implements ITargetDefinition {
 
 	@Override
 	public void setImplicitDependencies(NameVersionDescriptor[] bundles) {
+		incrementSequenceNumber();
 		if (bundles != null && bundles.length == 0) {
 			bundles = null;
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/ImplicitDependenciesSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/ImplicitDependenciesSection.java
@@ -217,9 +217,9 @@ public class ImplicitDependenciesSection extends SectionPart {
 			if (currentBundles != null) {
 				allDependencies.addAll(Arrays.asList(currentBundles));
 			}
-			getTarget().setImplicitDependencies(allDependencies.toArray(new NameVersionDescriptor[allDependencies.size()]));
 			markDirty();
-			refresh();
+			getTarget().setImplicitDependencies(allDependencies.toArray(new NameVersionDescriptor[allDependencies.size()]));
+			updateUI();
 		}
 	}
 
@@ -260,26 +260,30 @@ public class ImplicitDependenciesSection extends SectionPart {
 					bundles.remove(removeBundle);
 				}
 			}
-			getTarget().setImplicitDependencies(bundles.toArray((new NameVersionDescriptor[bundles.size()])));
 			markDirty();
-			refresh();
+			getTarget().setImplicitDependencies(bundles.toArray((new NameVersionDescriptor[bundles.size()])));
+			updateUI();
 		}
 	}
 
 	private void handleRemoveAll() {
-		getTarget().setImplicitDependencies(null);
 		markDirty();
-		refresh();
+		getTarget().setImplicitDependencies(null);
+		updateUI();
 	}
 
 	@Override
 	public void refresh() {
 		// TODO Try to retain selection during refresh, add and remove operations
+		updateUI();
+		super.refresh();
+	}
+
+	protected void updateUI() {
 		fViewer.setInput(getTarget());
 		fViewer.refresh();
 		updateButtons();
 		updateCount();
-		super.refresh();
 	}
 
 }


### PR DESCRIPTION
Currently editing the Implicit Plugin-Dpendencies only seem to work randomly (e.g. if one change some other property along with the change).

This now do not refresh the full target (what seem to reset the underlying model and remove the dirty flag before changes are applied) but only updates the UI so finally these thing appear in the target file.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/451