### PR TITLE
WIP: Fix NPE in PDEModelUtility.java (line 415) by adding null check (Fix #1404)

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/PDEModelUtility.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/PDEModelUtility.java
@@ -54,6 +54,7 @@ import org.eclipse.pde.internal.ui.editor.build.BuildEditor;
 import org.eclipse.pde.internal.ui.editor.build.BuildInputContext;
 import org.eclipse.pde.internal.ui.editor.build.BuildSourcePage;
 import org.eclipse.pde.internal.ui.editor.context.InputContext;
+import org.eclipse.pde.internal.ui.editor.context.InputContextManager;
 import org.eclipse.pde.internal.ui.editor.plugin.ManifestEditor;
 import org.eclipse.pde.internal.ui.editor.schema.SchemaEditor;
 import org.eclipse.pde.internal.ui.editor.schema.SchemaInputContext;
@@ -412,9 +413,13 @@ public class PDEModelUtility {
 				for (IFile file : files) {
 					if (file == null)
 						continue;
-					InputContext con = editor.getContextManager().findContext(file);
-					if (con != null)
-						con.flushEditorInput();
+					InputContextManager manager = editor.getContextManager();
+					if (manager != null){
+						InputContext con = manager.findContext(file);
+						if (con != null) {
+							con.flushEditorInput();
+						}
+					}
 				}
 				if (mod.saveOpenEditor())
 					editor.doSave(monitor);


### PR DESCRIPTION
**Summary Of Change**
Added a null guard to editor.getContextManager() to prevent NullPointerException (NPE).

**Why this Change is Needed**
An NPE occurs when too many processes are running and the user uses the context menu to close all tabs. This is caused by a race condition where dispose() is called while modifyEditorModel() is still running, resulting in getContextManager() returning null.

**Related Issue**
Fix #1404 

**Testing**
Testing is in progress. We are working on a test where dispose() is called followed by modifyEditorModel() to verify that the null guard resolves the issue.

