### PR TITLE
Move workbench running check in ColorManager to prevent SWT errors when headless

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/ColorManager.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/ColorManager.java
@@ -48,19 +48,19 @@ public class ColorManager implements IColorManager, IPDEColorConstants {
 	}
 
 	public static void initializeDefaults(IPreferenceStore store) {
-		PreferenceConverter.setDefault(store, P_DEFAULT, DEFAULT);
-		PreferenceConverter.setDefault(store, P_PROC_INSTR, PROC_INSTR);
-		PreferenceConverter.setDefault(store, P_STRING, STRING);
-		PreferenceConverter.setDefault(store, P_EXTERNALIZED_STRING, EXTERNALIZED_STRING);
-		PreferenceConverter.setDefault(store, P_TAG, TAG);
-		PreferenceConverter.setDefault(store, P_XML_COMMENT, XML_COMMENT);
-		PreferenceConverter.setDefault(store, P_HEADER_KEY, HEADER_KEY);
-		PreferenceConverter.setDefault(store, P_HEADER_OSGI, HEADER_OSGI);
+		setDefault(store, P_DEFAULT, DEFAULT);
+		setDefault(store, P_PROC_INSTR, PROC_INSTR);
+		setDefault(store, P_STRING, STRING);
+		setDefault(store, P_EXTERNALIZED_STRING, EXTERNALIZED_STRING);
+		setDefault(store, P_TAG, TAG);
+		setDefault(store, P_XML_COMMENT, XML_COMMENT);
+		setDefault(store, P_HEADER_KEY, HEADER_KEY);
+		setDefault(store, P_HEADER_OSGI, HEADER_OSGI);
 		store.setDefault(P_HEADER_OSGI + IPDEColorConstants.P_BOLD_SUFFIX, true);
-		PreferenceConverter.setDefault(store, P_HEADER_VALUE, HEADER_VALUE);
-		PreferenceConverter.setDefault(store, P_HEADER_ATTRIBUTES, HEADER_ATTRIBUTES);
+		setDefault(store, P_HEADER_VALUE, HEADER_VALUE);
+		setDefault(store, P_HEADER_ATTRIBUTES, HEADER_ATTRIBUTES);
 		store.setDefault(P_HEADER_ATTRIBUTES + IPDEColorConstants.P_ITALIC_SUFFIX, true);
-		PreferenceConverter.setDefault(store, P_HEADER_ASSIGNMENT, HEADER_ASSIGNMENT);
+		setDefault(store, P_HEADER_ASSIGNMENT, HEADER_ASSIGNMENT);
 		if (!PlatformUI.isWorkbenchRunning()) {
 			return;
 		}
@@ -68,9 +68,9 @@ public class ColorManager implements IColorManager, IPDEColorConstants {
 			Display display = PlatformUI.getWorkbench().getDisplay();
 			Runnable runnable = () -> {
 				if (!display.isDisposed() && display.getHighContrast()) {
-					PreferenceConverter.setDefault(store, P_DEFAULT, DEFAULT_HIGH_CONTRAST);
-					PreferenceConverter.setDefault(store, P_HEADER_VALUE, HEADER_VALUE_HIGH_CONTRAST);
-					PreferenceConverter.setDefault(store, P_HEADER_ATTRIBUTES, HEADER_ASSIGNMENT_HIGH_CONTRAST);
+					setDefault(store, P_DEFAULT, DEFAULT_HIGH_CONTRAST);
+					setDefault(store, P_HEADER_VALUE, HEADER_VALUE_HIGH_CONTRAST);
+					setDefault(store, P_HEADER_ATTRIBUTES, HEADER_ASSIGNMENT_HIGH_CONTRAST);
 				}
 			};
 			if (display == Display.getCurrent()) {
@@ -141,5 +141,9 @@ public class ColorManager implements IColorManager, IPDEColorConstants {
 		} else {
 			putColor(event.getProperty(), StringConverter.asRGB(color.toString()));
 		}
+	}
+
+	private static void setDefault(IPreferenceStore store, String name, RGB value) {
+		store.setDefault(name, StringConverter.asString(value));
 	}
 }


### PR DESCRIPTION
This change adjusts the check added for Eclipze bugzilla 546205 ticket. The check for running workbench is now done at the start of ColorManager.initializeDefaults(), to prevent the creation of an SWT Display object when in headless mode.

See: https://bugs.eclipse.org/bugs//show_bug.cgi?id=546205

Fixes: #1486