### PR TITLE
Ignore 'target' folders in e4tools

### DIFF
--- a/e4tools/.gitignore
+++ b/e4tools/.gitignore
@@ -1,0 +1,2 @@
+# DO NOT ignore all 'target' folders in the repo-root because PDE has numerous packages with elements named 'target'
+target/


### PR DESCRIPTION
Because in PDE we have packages that contain an element named 'target' we cannot generally ignore 'target'-folders and the patterns have to be more specific than usual.