### PR TITLE
Fix Typo in Plugin-in Template

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.pde.ui.templates;singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.pde.internal.ui.templates;x-internal:=true,

--- a/ui/org.eclipse.pde.ui.templates/templates_3.5/E4View/java/parts/$className$.java
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.5/E4View/java/parts/$className$.java
@@ -31,7 +31,7 @@ public class $className$ {
 	}
 
 	/**
-	 * This method is kept for E3 compatiblity. You can remove it if you do not
+	 * This method is kept for E3 compatibility. You can remove it if you do not
 	 * mix E3 and E4 code. <br/>
 	 * With E4 code you will set directly the selection in ESelectionService and
 	 * you do not receive a ISelection


### PR DESCRIPTION
This change fixes a typo in the plugin-in template "View contribution using 4.x API".