### PR TITLE
Always add a version if exporting a package #1426

### DIFF
--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
@@ -39,7 +39,7 @@ public class ImportPackageObject extends PackageObject {
 					"[" + version.getMajor() + "." + version.getMinor() + "," + (version.getMajor() + 1) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$//$NON-NLS-4$
 							.toString();
 		}
-		return null;
+		return "[1.0.0)";
 	}
 
 	public ImportPackageObject(ManifestHeader header, ManifestElement element, String versionAttribute) {


### PR DESCRIPTION
Changed the default for get version to always return a version even if file is unversioned. Defaults at 1.0.0