### PR TITLE
[Launching] Don't add -Djava.security.manager=allow for Java-24 or later

### DIFF
--- a/features/org.eclipse.pde.unittest.junit-feature/feature.xml
+++ b/features/org.eclipse.pde.unittest.junit-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde.unittest.junit"
       label="%featureName"
-      version="1.0.900.qualifier"
+      version="1.0.1000.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/VMHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/VMHelper.java
@@ -232,4 +232,10 @@ public class VMHelper {
 		return JavaRuntime.newRuntimeContainerClasspathEntry(containerPath, IRuntimeClasspathEntry.BOOTSTRAP_CLASSES);
 	}
 
+	public static void addNewArgument(List<String> arguments, String key, String value) {
+		if (arguments.stream().noneMatch(a -> a.startsWith(key + "="))) { //$NON-NLS-1$
+			arguments.add(key + "=" + value); //$NON-NLS-1$
+		}
+	}
+
 }

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/AbstractPDELaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/AbstractPDELaunchConfiguration.java
@@ -176,7 +176,7 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 		if (isEclipseBundleGreaterThanVersion(4, 24) // Don't add allow flags for eclipse before 4.24
 				&& vmInstall instanceof AbstractVMInstall install) {
 			String vmver = install.getJavaVersion();
-			if (vmver != null && JavaCore.compareJavaVersions(vmver, JavaCore.VERSION_17) >= 0) {
+			if (vmver != null && JavaCore.compareJavaVersions(vmver, JavaCore.VERSION_17) >= 0 && JavaCore.compareJavaVersions(vmver, JavaCore.VERSION_23) <= 0) {
 				VMHelper.addNewArgument(arguments, "-Djava.security.manager", "allow"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/AbstractPDELaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/AbstractPDELaunchConfiguration.java
@@ -17,6 +17,7 @@ package org.eclipse.pde.launching;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,6 +44,7 @@ import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMRunner;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.VMRunnerConfiguration;
+import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.core.ICoreConstants;
@@ -112,8 +114,7 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 
 		VMRunnerConfiguration runnerConfig = new VMRunnerConfiguration(getMainClass(), getClasspath(configuration));
 		IVMInstall launcher = VMHelper.createLauncher(configuration);
-		boolean isModular = JavaRuntime.isModularJava(launcher);
-		runnerConfig.setVMArguments(updateVMArgumentWithAdditionalArguments(getVMArguments(configuration), isModular, configuration));
+		runnerConfig.setVMArguments(updateVMArgumentWithAdditionalArguments(getVMArguments(configuration), launcher));
 		runnerConfig.setProgramArguments(getProgramArguments(configuration));
 		runnerConfig.setWorkingDirectory(getWorkingDirectory(configuration).getAbsolutePath());
 		runnerConfig.setEnvironment(getEnvironment(configuration));
@@ -148,8 +149,7 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 
 		VMRunnerConfiguration runnerConfig = new VMRunnerConfiguration(getMainClass(), getClasspath(configuration));
 		IVMInstall launcher = VMHelper.createLauncher(configuration);
-		boolean isModular = JavaRuntime.isModularJava(launcher);
-		runnerConfig.setVMArguments(updateVMArgumentWithAdditionalArguments(getVMArguments(configuration), isModular, configuration));
+		runnerConfig.setVMArguments(updateVMArgumentWithAdditionalArguments(getVMArguments(configuration), launcher));
 		runnerConfig.setProgramArguments(getProgramArguments(configuration));
 		runnerConfig.setWorkingDirectory(getWorkingDirectory(configuration).getAbsolutePath());
 		runnerConfig.setEnvironment(getEnvironment(configuration));
@@ -167,50 +167,23 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 
 	}
 
-	private String[] updateVMArgumentWithAdditionalArguments(String[] args, boolean isModular, ILaunchConfiguration configuration) {
-		String modAllSystem= "--add-modules=ALL-SYSTEM"; //$NON-NLS-1$
-		String allowSecurityManager = "-Djava.security.manager=allow"; //$NON-NLS-1$
-		boolean addModuleSystem = false;
-		boolean addAllowSecurityManager = false;
-		int argLength = args.length;
-		if (isModular && !argumentContainsAttribute(args, modAllSystem)) {
-			addModuleSystem = true;
-			argLength++; // Need to add the argument
+	private String[] updateVMArgumentWithAdditionalArguments(String[] args, IVMInstall vmInstall) {
+		List<String> arguments = new ArrayList<>(Arrays.asList(args));
+		boolean isModular = JavaRuntime.isModularJava(vmInstall);
+		if (isModular) {
+			VMHelper.addNewArgument(arguments, "--add-modules", "ALL-SYSTEM"); //$NON-NLS-1$//$NON-NLS-2$
 		}
-
-		if (isEclipseBundleGreaterThanVersion(4, 24)) { // Don't add allow flags for eclipse before 4.24
-			try {
-				IVMInstall vmInstall = VMHelper.getVMInstall(configuration);
-				if (vmInstall instanceof AbstractVMInstall) {
-					AbstractVMInstall install = (AbstractVMInstall) vmInstall;
-					String vmver = install.getJavaVersion();
-					if (vmver != null && JavaCore.compareJavaVersions(vmver, JavaCore.VERSION_17) >= 0) {
-						if (!argumentContainsAttribute(args, allowSecurityManager)) {
-							addAllowSecurityManager = true;
-							argLength++; // Need to add the argument
-						}
-					}
-				}
-			} catch (CoreException e) {
-				PDELaunchingPlugin.log(e);
-			}
-		}
-		if (addModuleSystem || addAllowSecurityManager) {
-			args = Arrays.copyOf(args, argLength);
-			if (addAllowSecurityManager) {
-				args[--argLength] = allowSecurityManager;
-			}
-			if (addModuleSystem) {
-				args[--argLength] = modAllSystem;
+		if (isEclipseBundleGreaterThanVersion(4, 24) // Don't add allow flags for eclipse before 4.24
+				&& vmInstall instanceof AbstractVMInstall install) {
+			String vmver = install.getJavaVersion();
+			if (vmver != null && JavaCore.compareJavaVersions(vmver, JavaCore.VERSION_17) >= 0) {
+				VMHelper.addNewArgument(arguments, "-Djava.security.manager", "allow"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 		if (!isModular) {
-			ArrayList<String> arrayList = new ArrayList<>(Arrays.asList(args));
-			arrayList.remove(modAllSystem);
-			arrayList.trimToSize();
-			args = arrayList.toArray(new String[arrayList.size()]);
+			arguments.remove("--add-modules=ALL-SYSTEM"); //$NON-NLS-1$
 		}
-		return args;
+		return arguments.toArray(String[]::new);
 	}
 
 
@@ -218,31 +191,18 @@ public abstract class AbstractPDELaunchConfiguration extends LaunchConfiguration
 		PDEState pdeState = TargetPlatformHelper.getPDEState();
 		if (pdeState != null) {
 			try {
-				Optional<IPluginModelBase> platformBaseModel = Arrays.stream(pdeState.getTargetModels()).filter(x -> Objects.nonNull(x.getBundleDescription())).filter(x -> ("org.eclipse.platform").equals(x.getBundleDescription().getSymbolicName()))//$NON-NLS-1$
-						.findFirst();
-				if (platformBaseModel.isPresent()) {
-					Version version = platformBaseModel.get().getBundleDescription().getVersion();
-					Version comparedVersion = new Version(major, minor, 0);
-					if (version != null && version.compareTo(comparedVersion) >= 0) {
-						return true;
-					}
-				}
-			}
-			catch (Exception ex) {
+				Optional<BundleDescription> model = Arrays.stream(pdeState.getTargetModels()) //
+						.map(IPluginModelBase::getBundleDescription).filter(Objects::nonNull) //
+						.filter(x -> "org.eclipse.platform".equals(x.getSymbolicName())).findFirst(); //$NON-NLS-1$
+				return model.map(BundleDescription::getVersion).filter(v -> v.compareTo(new Version(major, minor, 0)) >= 0).isPresent();
+			} catch (Exception ex) {
 				PDELaunchingPlugin.log(ex);
 			}
 		}
 		return false;
-
 	}
 
-	private boolean argumentContainsAttribute(String[] args, String modAllSystem) {
-		for (String string : args) {
-			if (string.equals(modAllSystem))
-				return true;
-		}
-		return false;
-	}
+
 
 	/**
 	 * Returns the VM runner for the given launch mode to use when launching the

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -280,9 +280,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		IVMInstall launcher = VMHelper.createLauncher(configuration);
 		boolean isModular = JavaRuntime.isModularJava(launcher);
 		if (isModular) {
-			String modAllSystem = "--add-modules=ALL-SYSTEM"; //$NON-NLS-1$
-			if (!vmArguments.contains(modAllSystem))
-				vmArguments.add(modAllSystem);
+			VMHelper.addNewArgument(vmArguments, "--add-modules", "ALL-SYSTEM"); //$NON-NLS-1$//$NON-NLS-2$
 		}
 		//  if element is a test class annotated with @RunWith(JUnitPlatform.class, we add this in program arguments
 		@SuppressWarnings("restriction")

--- a/ui/org.eclipse.pde.unittest.junit/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.pde.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.unittest.junit;singleton:=true
-Bundle-Version: 1.1.500.qualifier
+Bundle-Version: 1.1.600.qualifier
 Bundle-Activator: org.eclipse.pde.unittest.junit.JUnitPluginTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -586,9 +586,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 		IVMInstall launcher = VMHelper.createLauncher(configuration);
 		boolean isModular = JavaRuntime.isModularJava(launcher);
 		if (isModular) {
-			String modAllSystem = "--add-modules=ALL-SYSTEM"; //$NON-NLS-1$
-			if (!vmArguments.contains(modAllSystem))
-				vmArguments.add(modAllSystem);
+			VMHelper.addNewArgument(vmArguments, "--add-modules", "ALL-SYSTEM"); //$NON-NLS-1$//$NON-NLS-2$
 		}
 		// if element is a test class annotated with @RunWith(JUnitPlatform.class, we
 		// add this in program arguments


### PR DESCRIPTION
Since Java-24 the security-manager cannot be used anymore and launching a Java-24 VM fails to launch if the VM-argument
`-Djava.security.manager=allow` is specified.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2623

CC @merks

Depends on https://github.com/eclipse-pde/eclipse.pde/pull/1515.
