### PR TITLE
Provide user feedback when updating versions

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/Messages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/Messages.java
@@ -149,6 +149,7 @@ public class Messages extends NLS {
 	public static String TargetLocationsGroup_1;
 
 	public static String TargetLocationsGroup_TargetUpdateErrorDialog;
+	public static String TargetLocationsGroup_TargetUpdateNoChange;
 	public static String TargetStatus_NoActiveTargetPlatformStatus;
 	public static String TargetStatus_TargetStatusDefaultString;
 	public static String TargetStatus_UnresolvedTarget;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetLocationHandlerAdapter.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetLocationHandlerAdapter.java
@@ -100,6 +100,10 @@ class TargetLocationHandlerAdapter implements ITargetLocationHandler {
 		for (Entry<ITargetLocationHandler, List<TreePath>> entry : handlerMap.entrySet()) {
 			status.add(entry.getKey().update(target, entry.getValue().toArray(TreePath[]::new), subMonitor.split(100)));
 		}
+		IStatus[] children = status.getChildren();
+		if (children.length == 1) {
+			return children[0];
+		}
 		return status;
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/messages.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/messages.properties
@@ -139,6 +139,7 @@ TargetLocationsGroup_update=Looks for newer versions of the target contents and 
 TargetLocationsGroup_refresh=Clears the cached target data and resolves the target, looking for newer versions of any artifacts
 TargetLocationsGroup_1=&Show location content
 TargetLocationsGroup_TargetUpdateErrorDialog=Problems Updating Target Definition
+TargetLocationsGroup_TargetUpdateNoChange=All versions are up-to-date
 TargetStatus_NoActiveTargetPlatformStatus=No active target platform
 TargetStatus_TargetStatusDefaultString=Target Platform
  TargetStatus_UnresolvedTarget=Unresolved ''{0}''


### PR DESCRIPTION
One current issue is that users are confused about the meaning of buttons, especially as pressing them gives no immediate feedback.

This now do the following:
- disable the update button while update is running (or user selects another location)
- after completion gives a message to the user what was the outcome of the most recent operation