### PR TITLE
Return Path instead of URL-String in ClasspathHelper.writeDevEntries()

### DIFF
--- a/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.build;singleton:=true
-Bundle-Version: 3.12.600.qualifier
+Bundle-Version: 3.12.700.qualifier
 Bundle-ClassPath: pdebuild.jar
 Bundle-Activator: org.eclipse.pde.internal.build.BuildActivator
 Bundle-Vendor: %providerName

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/BuildScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/BuildScriptGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -469,9 +470,10 @@ public class BuildScriptGenerator extends AbstractScriptGenerator {
 		this.children = children;
 	}
 
-	public void setDevEntries(String devEntries) {
-		if (devEntries != null)
+	public void setDevEntries(Path devEntries) {
+		if (devEntries != null) {
 			this.devEntries = new DevClassPathHelper(devEntries);
+		}
 	}
 
 	public void setElements(String[] elements) {

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/builder/AbstractBuildScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/builder/AbstractBuildScriptGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.pde.internal.build.builder;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -67,7 +68,7 @@ public abstract class AbstractBuildScriptGenerator extends AbstractScriptGenerat
 		return executionEnvironmentMappings;
 	}
 
-	public void setDevEntries(String entries) {
+	public void setDevEntries(Path entries) {
 		devEntries = new DevClassPathHelper(entries);
 	}
 

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/builder/DevClassPathHelper.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/builder/DevClassPathHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corporation and others.
+ * Copyright (c) 2004, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,8 @@ package org.eclipse.pde.internal.build.builder;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.eclipse.core.runtime.IStatus;
@@ -32,18 +32,11 @@ public class DevClassPathHelper {
 	protected String[] devDefaultClasspath;
 	protected Properties devProperties = null;
 
-	public DevClassPathHelper(String devInfo) {
-		// Check the osgi.dev property to see if dev classpath entries have been defined.
-		String osgiDev = devInfo;
+	public DevClassPathHelper(Path osgiDev) {
 		if (osgiDev != null) {
-			try {
-				inDevelopmentMode = true;
-				URL location = new URL(osgiDev);
-				devProperties = load(location);
-				devDefaultClasspath = Utils.getArrayFromString(devProperties.getProperty("*")); //$NON-NLS-1$
-			} catch (MalformedURLException e) {
-				devDefaultClasspath = Utils.getArrayFromString(osgiDev);
-			}
+			inDevelopmentMode = true;
+			devProperties = load(osgiDev);
+			devDefaultClasspath = Utils.getArrayFromString(devProperties.getProperty("*")); //$NON-NLS-1$
 		}
 	}
 
@@ -66,12 +59,12 @@ public class DevClassPathHelper {
 	/*
 	 * Load the given properties file
 	 */
-	private static Properties load(URL url) {
+	private static Properties load(Path path) {
 		Properties props = new Properties();
-		try (InputStream is = url.openStream()) {
+		try (InputStream is = Files.newInputStream(path)) {
 			props.load(is);
 		} catch (IOException e) {
-			String message = NLS.bind(Messages.exception_missingFile, url.toExternalForm());
+			String message = NLS.bind(Messages.exception_missingFile, path);
 			BundleHelper.getDefault().getLog().log(new Status(IStatus.WARNING, IPDEBuildConstants.PI_PDEBUILD, IPDEBuildConstants.EXCEPTION_READING_FILE, message, null));
 		}
 		return props;

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/BuildScriptGeneratorTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/BuildScriptGeneratorTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.pde.internal.build.tasks;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Properties;
 
@@ -59,7 +60,7 @@ public class BuildScriptGeneratorTask extends Task {
 	 *  
 	 * @param devEntries the classpath dev entries
 	 */
-	public void setDevEntries(String devEntries) {
+	public void setDevEntries(Path devEntries) {
 		generator.setDevEntries(devEntries);
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/FeatureExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/FeatureExportOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2022 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -113,7 +114,7 @@ public class FeatureExportOperation extends Job {
 	// Location where the build takes place
 	protected String fBuildTempLocation;
 	protected String fBuildTempMetadataLocation;
-	private String fDevProperties;
+	private Path fDevProperties;
 	private static boolean fHasErrors;
 	protected HashMap<String, String> fAntBuildProperties;
 	protected WorkspaceExportHelper fWorkspaceExportHelper;
@@ -823,7 +824,7 @@ public class FeatureExportOperation extends Job {
 		fStateCopy.setPlatformProperties(state.getPlatformProperties());
 	}
 
-	private String getDevProperties() throws CoreException {
+	private Path getDevProperties() throws CoreException {
 		if (fDevProperties == null) {
 			fDevProperties = ClasspathHelper.getDevEntriesProperties(fBuildTempLocation + "/dev.properties", false); //$NON-NLS-1$
 		}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -128,7 +128,7 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 
 		// add the output folder names
 		programArgs.add("-dev"); //$NON-NLS-1$
-		programArgs.add(ClasspathHelper.getDevEntriesProperties(getConfigDir(configuration).toString() + "/dev.properties", fAllBundles)); //$NON-NLS-1$
+		programArgs.add(ClasspathHelper.getDevEntriesProperties(getConfigDir(configuration).toString() + "/dev.properties", fAllBundles).toUri().toString()); //$NON-NLS-1$
 
 		String[] args = super.getProgramArguments(configuration);
 		Collections.addAll(programArgs, args);

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2022 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -84,7 +84,7 @@ public class EquinoxLaunchConfiguration extends AbstractPDELaunchConfiguration {
 		ArrayList<String> programArgs = new ArrayList<>();
 
 		programArgs.add("-dev"); //$NON-NLS-1$
-		programArgs.add(ClasspathHelper.getDevEntriesProperties(getConfigDir(configuration).toString() + "/dev.properties", fAllBundles)); //$NON-NLS-1$
+		programArgs.add(ClasspathHelper.getDevEntriesProperties(getConfigDir(configuration).toString() + "/dev.properties", fAllBundles).toUri().toString()); //$NON-NLS-1$
 
 		saveConfigurationFile(configuration);
 		programArgs.add("-configuration"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2022 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -240,7 +240,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 						ClasspathHelper.addDevClasspath(testPlugin, devProperties, relativePath.toString(), true);
 					});
 		}
-		programArgs.add(ClasspathHelper.writeDevEntries(getConfigurationDirectory(configuration).toString() + "/dev.properties", devProperties)); //$NON-NLS-1$
+		programArgs.add(ClasspathHelper.writeDevEntries(getConfigurationDirectory(configuration).toString() + "/dev.properties", devProperties).toUri().toString()); //$NON-NLS-1$
 
 		// Create the .options file if tracing is turned on
 		if (configuration.getAttribute(IPDELauncherConstants.TRACING, false) && !IPDELauncherConstants.TRACING_NONE.equals(configuration.getAttribute(IPDELauncherConstants.TRACING_CHECKED, (String) null))) {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathresolver/ClasspathResolverTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathresolver/ClasspathResolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Sonatype, Inc. and others.
+ * Copyright (c) 2011, 2024 Sonatype, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,11 +23,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -133,9 +131,9 @@ public class ClasspathResolverTest {
 		mockTPWithRunningPlatformAndBundles(); // running-platform only
 
 		File devProperties = tempFolder.newFile("dev.properties").getCanonicalFile();
-		String devPropertiesURL = ClasspathHelper.getDevEntriesProperties(devProperties.getPath(), false);
+		Path devPropertiesFile = ClasspathHelper.getDevEntriesProperties(devProperties.getPath(), false);
 
-		Properties properties = loadProperties(devPropertiesURL);
+		Properties properties = loadProperties(devPropertiesFile);
 
 		String expectedDevCP = project.getFolder("cpe").getLocation().toPortableString();
 		assertEquals(expectedDevCP, properties.get(bundleName));
@@ -404,14 +402,13 @@ public class ClasspathResolverTest {
 			throws IOException, CoreException {
 		File devPropertiesFile = tempFolder.newFile("dev.properties").getCanonicalFile();
 		Map<String, List<IPluginModelBase>> bundlesMap = Map.of(HOST_BUNDLE_ID, launchedBundles);
-		String devPropertiesURL = ClasspathHelper.getDevEntriesProperties(devPropertiesFile.getPath(), bundlesMap);
-		return loadProperties(devPropertiesURL);
+		Path devProperties = ClasspathHelper.getDevEntriesProperties(devPropertiesFile.getPath(), bundlesMap);
+		return loadProperties(devProperties);
 	}
 
-	private static Properties loadProperties(String devPropertiesURL) throws IOException {
-		File propertiesFile = new File(new URL(devPropertiesURL).getPath());
+	private static Properties loadProperties(Path devPropertiesFile) throws IOException {
 		Properties devProperties = new Properties();
-		try (InputStream stream = new FileInputStream(propertiesFile)) {
+		try (InputStream stream = Files.newInputStream(devPropertiesFile )) {
 			devProperties.load(stream);
 		}
 		return devProperties;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/build/GenerateFeatureBuildFileAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/build/GenerateFeatureBuildFileAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *  Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
 package org.eclipse.pde.internal.ui.build;
 
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -55,8 +56,8 @@ public class GenerateFeatureBuildFileAction extends BaseBuildAction {
 		generator.setChildren(true);
 		AbstractScriptGenerator.setEmbeddedSource(AbstractScriptGenerator.getDefaultEmbeddedSource());
 
-		String url = ClasspathHelper.getDevEntriesProperties(fManifestFile.getProject().getLocation().addTrailingSeparator().toString() + "dev.properties", false); //$NON-NLS-1$
-		generator.setDevEntries(url);
+		Path path = ClasspathHelper.getDevEntriesProperties(fManifestFile.getProject().getLocation().addTrailingSeparator().toString() + "dev.properties", false); //$NON-NLS-1$
+		generator.setDevEntries(path);
 		generator.setWorkingDirectory(fManifestFile.getProject().getLocation().toOSString());
 		String configInfo = TargetPlatform.getOS() + ", " + TargetPlatform.getWS() + ", " + TargetPlatform.getOSArch(); //$NON-NLS-1$ //$NON-NLS-2$
 		AbstractScriptGenerator.setConfigInfo(configInfo); //This needs to be set before we set the format

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/build/GeneratePluginBuildFileAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/build/GeneratePluginBuildFileAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@
 package org.eclipse.pde.internal.ui.build;
 
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.eclipse.core.resources.IProject;
@@ -55,8 +56,8 @@ public class GeneratePluginBuildFileAction extends BaseBuildAction {
 		AbstractScriptGenerator.setConfigInfo(AbstractScriptGenerator.getDefaultConfigInfos());
 
 		generator.setWorkingDirectory(project.getLocation().toOSString());
-		String url = ClasspathHelper.getDevEntriesProperties(project.getLocation().addTrailingSeparator().toString() + "dev.properties", false); //$NON-NLS-1$
-		generator.setDevEntries(url);
+		Path path = ClasspathHelper.getDevEntriesProperties(project.getLocation().addTrailingSeparator().toString() + "dev.properties", false); //$NON-NLS-1$
+		generator.setDevEntries(path);
 		generator.setPDEState(TargetPlatformHelper.getState());
 		generator.setNextId(TargetPlatformHelper.getPDEState().getNextId());
 		generator.setStateExtraData(TargetPlatformHelper.getBundleClasspaths(TargetPlatformHelper.getPDEState()), TargetPlatformHelper.getPatchMap(TargetPlatformHelper.getPDEState()));

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -545,8 +545,11 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 
 		// Specify the output folder names
 		programArgs.add("-dev"); //$NON-NLS-1$
-		programArgs.add(ClasspathHelper.getDevEntriesProperties(
-				getConfigurationDirectory(configuration).toString() + "/dev.properties", fAllBundles)); //$NON-NLS-1$
+		programArgs
+				.add(ClasspathHelper
+						.getDevEntriesProperties(
+								getConfigurationDirectory(configuration).toString() + "/dev.properties", fAllBundles) //$NON-NLS-1$
+						.toUri().toString());
 
 		// Create the .options file if tracing is turned on
 		if (configuration.getAttribute(IPDELauncherConstants.TRACING, false) && !IPDELauncherConstants.TRACING_NONE


### PR DESCRIPTION
Instead returning a file-URL in it's string representation better use the actual type of value, i.e. a Path.