### PR TITLE
Fail if a workspace is disposed outside the manager

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.600.qualifier
+Bundle-Version: 1.3.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
@@ -128,7 +128,7 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 	/**
 	 * The current workspace baseline
 	 */
-	private volatile IApiBaseline workspacebaseline;
+	private volatile WorkspaceBaseline workspacebaseline;
 
 	/**
 	 * The default save location for persisting the cache from this manager.
@@ -548,7 +548,7 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 			}
 			synchronized (this) {
 				if (workspacebaseline != null) {
-					workspacebaseline.dispose();
+					workspacebaseline.disposeInternal();
 				}
 			}
 			if (handlecache != null) {
@@ -620,12 +620,12 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 	 * the next request.
 	 */
 	public void disposeWorkspaceBaseline() {
-		final IApiBaseline originalBaseline = workspacebaseline;
+		final WorkspaceBaseline originalBaseline = workspacebaseline;
 		if (originalBaseline == null) {
 			return;
 		}
 		IJobFunction runnable = m -> {
-			IApiBaseline oldBaseline = null;
+			WorkspaceBaseline oldBaseline = null;
 			synchronized (ApiBaselineManager.this) {
 				if (workspacebaseline != null && originalBaseline == workspacebaseline) {
 					if (ApiPlugin.DEBUG_BASELINE_MANAGER) {
@@ -637,7 +637,7 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 				}
 			}
 			if (oldBaseline != null) {
-				oldBaseline.dispose();
+				oldBaseline.disposeInternal();
 			}
 			return Status.OK_STATUS;
 		};
@@ -681,9 +681,9 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 	 *
 	 * @return a new workspace {@link IApiBaseline} or <code>null</code>
 	 */
-	private IApiBaseline createWorkspaceBaseline() throws CoreException {
+	private WorkspaceBaseline createWorkspaceBaseline() throws CoreException {
 		long time = System.currentTimeMillis();
-		IApiBaseline baseline = new WorkspaceBaseline();
+		WorkspaceBaseline baseline = new WorkspaceBaseline();
 		try {
 			// populate it with only projects that are API aware
 			List<IPluginModelBase> models = Arrays.asList(PluginRegistry.getWorkspaceModels());

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/WorkspaceBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/WorkspaceBaseline.java
@@ -52,6 +52,14 @@ public class WorkspaceBaseline extends ApiBaseline {
 
 	@Override
 	public void dispose() {
+		throw new UnsupportedOperationException(
+				"ApiBaselineManager.disposeWorkspaceBaseline() must be used to dispose the workspace baseline"); //$NON-NLS-1$
+	}
+
+	/**
+	 * <b>Only public for technical reasons</b> do not call directly!
+	 */
+	public void disposeInternal() {
 		doDispose();
 		mismatch.clear();
 	}


### PR DESCRIPTION
Currently one can obtain a workspace baseline and dispose it leading to hard to track errors.

This now fails if someone tries to dispose the baseline without using the manager.