### PR TITLE
Remove (almost) unused method from provisional IApiBaselineManager

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.api.tools.tests
-Bundle-Version: 1.3.700.qualifier
+Bundle-Version: 1.3.800.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.pde.api.tools;bundle-version="1.0.600",

--- a/apitools/org.eclipse.pde.api.tools.tests/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools.tests/pom.xml
@@ -18,7 +18,7 @@
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.pde.api.tools.tests</artifactId>
-	<version>1.3.700-SNAPSHOT</version>
+	<version>1.3.800-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
@@ -61,6 +61,7 @@ import org.eclipse.pde.api.tools.internal.problems.ApiProblemFactory;
 import org.eclipse.pde.api.tools.internal.provisional.ApiPlugin;
 import org.eclipse.pde.api.tools.internal.provisional.IApiBaselineManager;
 import org.eclipse.pde.api.tools.internal.provisional.IApiMarkerConstants;
+import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiComponent;
 import org.eclipse.pde.api.tools.internal.provisional.problems.IApiProblemTypes;
 import org.eclipse.pde.api.tools.internal.util.Util;
@@ -1199,7 +1200,9 @@ public abstract class ApiBuilderTest extends BuilderTests {
 
 	private static void exportComponent(IApiBaselineManager manager, IPath baselineLocation, IProject currentProject,
 			int retry) throws Exception {
-		IApiComponent component = manager.getWorkspaceComponent(currentProject.getName());
+		IApiBaseline bl = manager.getWorkspaceBaseline();
+		assertNotNull("No Workspace baseline set", bl); //$NON-NLS-1$
+		IApiComponent component = bl.getApiComponent(currentProject.getName());
 		assertNotNull("The project was not found in the workspace baseline: " + currentProject.getName(), //$NON-NLS-1$
 				component);
 		try {

--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.600.qualifier
+Bundle-Version: 1.3.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiBaselineManager.java
@@ -706,12 +706,4 @@ public final class ApiBaselineManager implements IApiBaselineManager, ISaveParti
 		return baseline;
 	}
 
-	@Override
-	public IApiComponent getWorkspaceComponent(String symbolicName) {
-		IApiBaseline baseline = getWorkspaceBaseline();
-		if (baseline != null) {
-			return baseline.getApiComponent(symbolicName);
-		}
-		return null;
-	}
 }

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/IApiBaselineManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/IApiBaselineManager.java
@@ -14,7 +14,6 @@
 package org.eclipse.pde.api.tools.internal.provisional;
 
 import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
-import org.eclipse.pde.api.tools.internal.provisional.model.IApiComponent;
 
 /**
  * Interface describing the {@link IApiBaselineManager}
@@ -98,12 +97,4 @@ public interface IApiBaselineManager {
 	 */
 	public IApiBaseline getWorkspaceBaseline();
 
-	/**
-	 * Returns the API component the workspace baseline with the given symbolic
-	 * name or <code>null</code> if none.
-	 *
-	 * @param symbolicName bundle symbolic name
-	 * @return API component from the workspace baseline or <code>null</code>
-	 */
-	public IApiComponent getWorkspaceComponent(String symbolicName);
 }


### PR DESCRIPTION
The `IApiBaselineManager` contains a helper method
`IApiBaselineManager#getWorkspaceComponent `that is only used in one test. The method has the drawback that one can't distinguish the case if no baseline is set or the component is not found additionally it might later depend on a disposed component.

Because of that the method is now removed and the single reference changed accordingly.