### PR TITLE
Touch for javadoc switch to java 21

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Rebuild with Java 21
+Touch for javadoc switch to java 21


### PR DESCRIPTION
To fix comparator errors https://download.eclipse.org/eclipse/downloads/drops4/I20241229-0520/