### PR TITLE
Add a family to UpdateClasspathsJob

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
@@ -90,6 +90,11 @@ public class PluginModelManager implements IModelProviderListener {
 		}
 
 		@Override
+		public boolean belongsTo(Object family) {
+			return family == PluginModelManager.class;
+		}
+
+		@Override
 		protected IStatus run(IProgressMonitor monitor) {
 			try {
 				boolean more = false;


### PR DESCRIPTION
In some cases it is good to wait for a certain type of jobs to complete, this now adds a family to UpdateClasspathsJob so it can be used to wait for such kind of jobs to complete (e.g. used in Tycho api-analysis-mojo).