### PR TITLE
Use the project component api baseline to lookup the component

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.600.qualifier
+Bundle-Version: 1.3.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescriptionManager.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescriptionManager.java
@@ -120,17 +120,17 @@ public final class ApiDescriptionManager implements ISaveParticipant {
 	public synchronized IApiDescription getApiDescription(ProjectComponent component, BundleDescription bundle) {
 		IJavaProject project = component.getJavaProject();
 		ProjectApiDescription description = (ProjectApiDescription) fDescriptions.get(project);
-		if (description == null) {
+		if (description == null || description.baseline != component.getBaseline()) {
 			if (Util.isApiProject(project)) {
-				description = new ProjectApiDescription(project);
+				description = new ProjectApiDescription(project, component.getBaseline());
 			} else {
-				description = new NonApiProjectDescription(project);
+				description = new NonApiProjectDescription(project, component.getBaseline());
 			}
 			try {
 				restoreDescription(project, description);
 			} catch (CoreException e) {
 				ApiPlugin.log(e.getStatus());
-				description = new ProjectApiDescription(project);
+				description = new ProjectApiDescription(project, component.getBaseline());
 			}
 			fDescriptions.put(project, description);
 		}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/NonApiProjectDescription.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/NonApiProjectDescription.java
@@ -15,6 +15,7 @@ package org.eclipse.pde.api.tools.internal;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.pde.api.tools.internal.provisional.descriptors.IElementDescriptor;
+import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
 
 /**
  * An API description for a project that does not have an API Tools nature.
@@ -26,9 +27,11 @@ public class NonApiProjectDescription extends ProjectApiDescription {
 
 	/**
 	 * Constructs API description for the given project.
+	 *
+	 * @param baseline
 	 */
-	public NonApiProjectDescription(IJavaProject project) {
-		super(project);
+	NonApiProjectDescription(IJavaProject project, IApiBaseline baseline) {
+		super(project, baseline);
 	}
 
 	@Override


### PR DESCRIPTION
Currently the api-tools heavily rely on a common shared "workspace baseline" this baseline can be disposed and then changes at any time. While this can work in an IDE context, it makes it quite hard for other tools to use this standalone because there is no way to reliable use an alternative mean of "workspace baseline".

This now changes the ProjectApiDescription in a way where the baseline is passed in from the project component and it only fall back to the static singleton if the baseline is disposed.