### PR TITLE
Persist the sequence number if it changes to the document

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
@@ -124,7 +124,7 @@ public class TargetDefinition implements ITargetDefinition {
 	private TargetFeature[] fFeatures;
 	private TargetBundle[] fOtherBundles;
 
-	private int fSequenceNumber = -1;
+	private int fSequenceNumber;
 
 	/**
 	 * Constructs a target definition based on the given handle.
@@ -1123,7 +1123,8 @@ public class TargetDefinition implements ITargetDefinition {
 	 * @return the current sequence number after it has been increased
 	 */
 	public int incrementSequenceNumber() {
-		return ++fSequenceNumber;
+		setSequenceNumber(getSequenceNumber() + 1);
+		return getSequenceNumber();
 	}
 
 	/**
@@ -1132,7 +1133,16 @@ public class TargetDefinition implements ITargetDefinition {
 	 * @param value value to set the sequence number to
 	 */
 	void setSequenceNumber(int value) {
-		fSequenceNumber = value;
+		if (value != fSequenceNumber) {
+			fSequenceNumber = value;
+			if (fRoot != null) {
+				if (value > 0) {
+					fRoot.setAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER, Integer.toString(value));
+				} else {
+					fRoot.removeAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
+				}
+			}
+		}
 	}
 
 	private void removeElement(String... childNames) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence36Helper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence36Helper.java
@@ -165,13 +165,15 @@ public class TargetPersistence36Helper {
 				}
 			}
 		}
-
-		// Set the sequence number at the very end
-		String sequenceNumber = root.getAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
-		try {
-			((TargetDefinition) definition).setSequenceNumber(Integer.parseInt(sequenceNumber));
-		} catch (NumberFormatException e) {
-			((TargetDefinition) definition).setSequenceNumber(0);
+		if (definition instanceof TargetDefinition impl) {
+			// Set the sequence number at the very end
+			String sequenceNumber = root.getAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
+			try {
+				if (!sequenceNumber.isBlank()) {
+					impl.setSequenceNumber(Integer.parseInt(sequenceNumber));
+				}
+			} catch (NumberFormatException e) {
+			}
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence38Helper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence38Helper.java
@@ -193,13 +193,15 @@ public class TargetPersistence38Helper {
 				}
 			}
 		}
-
-		// Set the sequence number at the very end
-		String sequenceNumber = root.getAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
-		try {
-			((TargetDefinition) definition).setSequenceNumber(Integer.parseInt(sequenceNumber));
-		} catch (NumberFormatException e) {
-			((TargetDefinition) definition).setSequenceNumber(0);
+		if (definition instanceof TargetDefinition impl) {
+			// Set the sequence number at the very end
+			String sequenceNumber = root.getAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
+			try {
+				if (!sequenceNumber.isBlank()) {
+					impl.setSequenceNumber(Integer.parseInt(sequenceNumber));
+				}
+			} catch (NumberFormatException e) {
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently the targetdefinition is maintaining a sequence number that should roughly reflect the number of times a relevant property of the target file changes. Currently this number is never written out to the XML making it only effective at runtime but not e.g. when committed to a VCS if not maintained manually.

This now makes sure that the number is correctly persisted in the XML.