### PR TITLE
Add support for the 'deprecated' directive on required bundles

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
@@ -222,6 +222,7 @@ public class PDECoreMessages extends NLS {
 	public static String BundleErrorReporter_unecessaryDependencyDueToFragmentHost;
 	public static String BundleErrorReporter_missingPackagesInProject;
 	public static String BundleErrorReporter_noExecutionEnvironmentSet;
+	public static String BundleErrorReporter_deprecatedBundle;
 
 	public static String BundleErrorReporter_startHeader_autoStartDeprecated;
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
@@ -198,6 +198,7 @@ BundleErrorReporter_eclipse_genericRequireDeprecated=''{0}'' header is deprecate
 BundleErrorReporter_unecessaryDependencyDueToFragmentHost=The ''{0}'' dependency is not necessary as it is already specified in Fragment-Host header
 BundleErrorReporter_localization_properties_file_not_exist=no valid properties files exist in the localization directory specified
 BundleErrorReporter_illegalManifestVersion=The bundle manifest version is invalid. Valid ranges are 1-2.
+BundleErrorReporter_deprecatedBundle=The bundle {0} is deprecated: {1}
 BundleErrorReporter_serviceComponentLazyStart=Bundles with a Service-Component should set the Bundle-ActivationPolicy to lazy.
 BundleManifestSourceLocationManager_problemProcessBundleManifestHeaderAttributeMissing=Problem processing bundle manifest header in source bundle {0}, plugin name and version must both be specified.
 BundleValidationOperation_multiple_singletons={0} versions of singleton ''{1}'' exist


### PR DESCRIPTION
OSGi recently has added support for a 'deprecated' directive that can be used by tools to inform users that the bundle supplier in one way or another has deprecated a capability and it will likely removed in the future.

This now adds support to PDE to show a deprecation warning if such a bundle is used in require bundles.

![grafik](https://github.com/user-attachments/assets/d0a6614a-806f-438f-92ac-28dc15558242)
