### PR TITLE
Do not load sequence number from target files anymore

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
@@ -1126,15 +1126,6 @@ public class TargetDefinition implements ITargetDefinition {
 		return ++fSequenceNumber;
 	}
 
-	/**
-	 * Convenience method to set the sequence number to a specific
-	 * value. Used when loading a target from a persisted file.
-	 * @param value value to set the sequence number to
-	 */
-	void setSequenceNumber(int value) {
-		fSequenceNumber = value;
-	}
-
 	private void removeElement(String... childNames) {
 		if (fRoot != null) {
 			TargetDefinitionDocumentTools.removeElement(fRoot, childNames);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinitionPersistenceHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinitionPersistenceHelper.java
@@ -90,7 +90,6 @@ public class TargetDefinitionPersistenceHelper {
 	static final String ATTR_FOLLOW_REPOSITORY_REFERENCES = "followRepositoryReferences"; //$NON-NLS-1$
 	static final String ATTR_VERSION = "version"; //$NON-NLS-1$
 	static final String ATTR_CONFIGURATION = "configuration"; //$NON-NLS-1$
-	static final String ATTR_SEQUENCE_NUMBER = "sequenceNumber"; //$NON-NLS-1$
 	static final String CONTENT = "content"; //$NON-NLS-1$
 	static final String ATTR_USE_ALL = "useAllPlugins"; //$NON-NLS-1$
 	static final String PLUGINS = "plugins"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence36Helper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence36Helper.java
@@ -165,14 +165,6 @@ public class TargetPersistence36Helper {
 				}
 			}
 		}
-
-		// Set the sequence number at the very end
-		String sequenceNumber = root.getAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
-		try {
-			((TargetDefinition) definition).setSequenceNumber(Integer.parseInt(sequenceNumber));
-		} catch (NumberFormatException e) {
-			((TargetDefinition) definition).setSequenceNumber(0);
-		}
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence38Helper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPersistence38Helper.java
@@ -193,14 +193,6 @@ public class TargetPersistence38Helper {
 				}
 			}
 		}
-
-		// Set the sequence number at the very end
-		String sequenceNumber = root.getAttribute(TargetDefinitionPersistenceHelper.ATTR_SEQUENCE_NUMBER);
-		try {
-			((TargetDefinition) definition).setSequenceNumber(Integer.parseInt(sequenceNumber));
-		} catch (NumberFormatException e) {
-			((TargetDefinition) definition).setSequenceNumber(0);
-		}
 	}
 
 	/**


### PR DESCRIPTION
As the sequence number is not persisted into a target file by the target editor, there is actually no point in loading it as it only can lead to inconsistent state.