### PR TITLE
template description grayed out fix for plugin and rcp project

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
@@ -266,11 +266,15 @@ public class TemplateListSelectionPage extends WizardListSelectionPage {
 			if (((PluginFieldData) fContentPage.getData()).isRCPApplicationPlugin()) {
 				fUseTemplate.setSelection(true);
 				fUseTemplate.setEnabled(false);
+				fUseTemplate.setVisible(false);
 				wizardSelectionViewer.getControl().setEnabled(true);
-
+				setDescriptionEnabled(true);
 			} else {
+				fUseTemplate.setVisible(true);
 				if (fUseTemplate.getSelection() == false)
 					wizardSelectionViewer.getControl().setEnabled(false);
+				else
+					setDescriptionEnabled(true);
 				fUseTemplate.setEnabled(true);
 			}
 			wizardSelectionViewer.refresh();


### PR DESCRIPTION
This commit fixes the inconsistent graying out of template description for plug-in and rcp project.

Also to hide the checkbox for 'Create a plug-in using a template' when while creating a plug-in project with Rich client application as YES

Fixes: #1547