### PR TITLE
Disambiguate "repository" in importFromRepository

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.properties
+++ b/ui/org.eclipse.pde.ui/plugin.properties
@@ -239,8 +239,8 @@ pluginsearch.action.name = Open Plug-in Artifact
 pluginsearch.action.menu.name = Open &Plug-in Artifact...
 pluginsearch.action.desc = Open a plug-in artifact in the manifest editor
 
-importFromRepository.action.name = Import Plug-in from a Repository
-importFromRepository.action.menu.name = I&mport from Repository...
+importFromRepository.action.name = Import from a Source Repository
+importFromRepository.action.menu.name = I&mport from Source Repository...
 importFromRepository.action.desc = Imports a plug-in from a source repository
 
 addpluginstojavasearch.action.name = Add All Plug-ins to Java Workspace Scope


### PR DESCRIPTION
Repository can mean p2 or source, let's disambiguate it. Also drop the "plug-in" part of importFromRepository labels as this action only shows up in the context of a plugin already.