### PR TITLE
Add support for checking package exports for changed API

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/RequiredPackageVersionChange.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/RequiredPackageVersionChange.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.api.tools.internal.builder;
+
+import org.osgi.framework.Version;
+
+record RequiredPackageVersionChange(int category, Version baseline, Version current, Version suggested) {
+
+}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/ApiProblemFactory.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/ApiProblemFactory.java
@@ -590,7 +590,10 @@ public class ApiProblemFactory {
 						return 58;
 					case IApiProblem.MINOR_VERSION_CHANGE_UNNECESSARILY:
 						return 59;
-
+					case IApiProblem.MAJOR_VERSION_CHANGE_PACKAGE:
+						return 65;
+					case IApiProblem.MINOR_VERSION_CHANGE_PACKAGE:
+						return 63;
 					default:
 						break;
 				}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/problemmessages.properties
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/problems/problemmessages.properties
@@ -11,7 +11,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-# available message ids  63, 65, 68, 70, 71, 75, 80,
+# available message ids  68, 70, 71, 75, 80,
 # 82, 83, 88, 90, 93
 
 #API baseline 
@@ -37,6 +37,8 @@
 19 = The major version should be incremented in version {0}, because the modification of the version range for the re-exported bundle {1} requires a major version change
 20 = The minor version should be incremented in version {0}, because the modification of the version range for the re-exported bundle {1} requires a minor version change
 62 = The major version should be incremented in version {0}, because the bundle {1} is no longer re-exported
+63 = The minor version for the package ''{0}'' should be incremented to version {1}, since new APIs have been added since version {2}
+65 = The major version for the package ''{0}'' should be incremented to version {1}, since API breakage occurred since version {2}
 
 #API usage problems
 #{0} = referenced type name

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/problems/IApiProblem.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/provisional/problems/IApiProblem.java
@@ -242,6 +242,26 @@ public interface IApiProblem {
 	 * @see #CATEGORY_USAGE
 	 */
 
+	/**
+	 * Constant representing the value of the major version change
+	 * {@link IApiProblem} kind for a package. <br>
+	 * Value is: <code>11</code>
+	 *
+	 * @see #getKind()
+	 * @see #CATEGORY_VERSION
+	 */
+	public static final int MAJOR_VERSION_CHANGE_PACKAGE = 11;
+
+	/**
+	 * Constant representing the value of the minor version change
+	 * {@link IApiProblem} kind for a package. <br>
+	 * Value is: <code>12</code>
+	 *
+	 * @see #getKind()
+	 * @see #CATEGORY_VERSION
+	 */
+	public static final int MINOR_VERSION_CHANGE_PACKAGE = 12;
+
 	public static final int ILLEGAL_EXTEND = 1;
 
 	/**


### PR DESCRIPTION
Currently API tools only check for API changes on the bundle level, but even more important are checks on the exported packages. If the package version is not properly incremented this can lead to method not found or similar errors, also consumers of the package can not depend on the package version reliable to get new API.

This now adds some basic checks to check for API changes on the package level, compare it with the baseline and suggest a new version based on the resulting delta being a breaking or non breaking change.

This is a very basic first step. We need (see TODOs) and likely want to further improve this when we use it, for example currently all deltas are assumed to be important, we might discover places where it is actually not required to make a minor change but only a micro change (currently not used at all).