### PR TITLE
If there are duplicate packages use the first declaration

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/BaseApiAnalyzer.java
@@ -2301,10 +2301,10 @@ public class BaseApiAnalyzer implements IApiAnalyzer {
 			IDelta[] breakingChanges, IDelta[] compatibleChanges) throws CoreException {
 		Map<String, ExportPackageDescription> referencePackages = Arrays
 				.stream(referenceBundle.getBundleDescription().getExportPackages())
-				.collect(Collectors.toMap(ExportPackageDescription::getName, Function.identity()));
+				.collect(Collectors.toMap(ExportPackageDescription::getName, Function.identity(), (a, b) -> a));
 		Map<String, ExportPackageDescription> componentPackages = Arrays
 				.stream(componentBundle.getBundleDescription().getExportPackages())
-				.collect(Collectors.toMap(ExportPackageDescription::getName, Function.identity()));
+				.collect(Collectors.toMap(ExportPackageDescription::getName, Function.identity(), (a, b) -> a));
 		// a mapping between a package name and a required change
 		Map<String, RequiredPackageVersionChange> requiredChanges = new HashMap<>();
 		// we must compare compatible changes first, so these where overwritten later by


### PR DESCRIPTION
In some rare cases it can happen that duplicate exports are present (seen in org.eclipse.osgi with java.io package resolved from jre), in this case API tools fails with an error.

THis now simply always ever use the first declared package for analysis.