### PR TITLE
Fix launch -configuration param to always be proper URI 

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
@@ -124,7 +124,7 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 		boolean showSplash = prop.containsKey("osgi.splashPath") || prop.containsKey("splashLocation"); //$NON-NLS-1$ //$NON-NLS-2$
 		TargetPlatformHelper.checkPluginPropertiesConsistency(fAllBundles, getConfigDir(configuration));
 		programArgs.add("-configuration"); //$NON-NLS-1$
-		programArgs.add("file:" + IPath.fromOSString(getConfigDir(configuration).getPath()).addTrailingSeparator().toString()); //$NON-NLS-1$
+		programArgs.add(IPath.fromOSString(getConfigDir(configuration).getPath()).addTrailingSeparator().toPath().toUri().toString());
 
 		// add the output folder names
 		programArgs.add("-dev"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
@@ -88,7 +88,7 @@ public class EquinoxLaunchConfiguration extends AbstractPDELaunchConfiguration {
 
 		saveConfigurationFile(configuration);
 		programArgs.add("-configuration"); //$NON-NLS-1$
-		programArgs.add("file:" + IPath.fromOSString(getConfigDir(configuration).getPath()).addTrailingSeparator().toString()); //$NON-NLS-1$
+		programArgs.add(IPath.fromOSString(getConfigDir(configuration).getPath()).addTrailingSeparator().toPath().toUri().toString());
 
 		String[] args = super.getProgramArguments(configuration);
 		Collections.addAll(programArgs, args);

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -223,7 +223,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		TargetPlatformHelper.checkPluginPropertiesConsistency(fAllBundles, getConfigurationDirectory(configuration));
 
 		programArgs.add("-configuration"); //$NON-NLS-1$
-		programArgs.add("file:" + IPath.fromOSString(getConfigurationDirectory(configuration).getPath()).addTrailingSeparator().toString()); //$NON-NLS-1$
+		programArgs.add(IPath.fromOSString(getConfigurationDirectory(configuration).getPath()).addTrailingSeparator().toPath().toUri().toString());
 
 		// Specify the output folder names
 		programArgs.add("-dev"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
@@ -27,9 +27,7 @@ import static org.osgi.framework.Constants.RESOLUTION_OPTIONAL;
 
 import java.io.File;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -1052,18 +1050,13 @@ public class PluginBasedLaunchTest extends AbstractLaunchTest {
 	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
 	private Path getConfigurationFolder(ILaunchConfigurationWorkingCopy launchConfig)
-			throws CoreException, MalformedURLException {
+			throws CoreException {
 		ILaunch launch = new Launch(launchConfig, ILaunchManager.RUN_MODE, null);
 		var config = new EclipseApplicationLaunchConfiguration();
 		String commandLine = config.showCommandLine(launchConfig, ILaunchManager.RUN_MODE, launch, null);
 		String configURL = WHITESPACE.splitAsStream(commandLine) //
 				.dropWhile(t -> !"-configuration".equals(t)).skip(1).findFirst().get();
-		// The configURL is not properly build, therefore this hack is necessary
-		try {
-			return Path.of(URI.create(configURL));
-		} catch (IllegalArgumentException e) {
-			return Path.of(new URL(configURL).getPath());
-		}
+		return Path.of(URI.create(configURL));
 	}
 
 	private static String getInstallLocation(IPluginModelBase plugin) {


### PR DESCRIPTION
Ensures that the parameter can always we be converted back to URI.
It's been already done for -dev param value.
Fixed PluginBasedLaunchTest to no longer try to "workaround"
-configuration values that can't be converted to URI.