### PR TITLE
Prevent NPE in ApiBaseline.getApiComponent(String, Version)

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
@@ -674,6 +674,9 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 			return component;
 		}
 		Set<IApiComponent> allComponents = fAllComponentsById.get(id);
+		if (allComponents == null) {
+			return null;
+		}
 		return allComponents.stream().filter(c -> hasSameMMMVersion(version, c)).findFirst().orElse(null);
 	}
 


### PR DESCRIPTION
- Guard against fAllComponentsById.get(id) yielding null.

https://github.com/eclipse-pde/eclipse.pde/issues/1569