### PR TITLE
Making ordering of relevances more explicit

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/FilterProblemResolution.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/FilterProblemResolution.java
@@ -30,6 +30,7 @@ import org.eclipse.pde.api.tools.internal.util.Util;
 import org.eclipse.pde.api.tools.ui.internal.ApiUIPlugin;
 import org.eclipse.pde.api.tools.ui.internal.IApiToolsConstants;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.IMarkerResolutionRelevance;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 
 /**
@@ -38,7 +39,7 @@ import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
  *
  * @since 1.0.0
  */
-public class FilterProblemResolution extends WorkbenchMarkerResolution {
+public class FilterProblemResolution extends WorkbenchMarkerResolution implements IMarkerResolutionRelevance {
 
 	protected IMarker fBackingMarker = null;
 	protected IJavaElement fResolvedElement = null;

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/FilterProblemWithCommentResolution.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/FilterProblemWithCommentResolution.java
@@ -81,4 +81,10 @@ public class FilterProblemWithCommentResolution extends FilterProblemResolution 
 		op.setSystem(true);
 		op.schedule();
 	}
+
+	@Override
+	public int getRelevanceForResolution() {
+		return IApiToolProposalRelevance.FILTER_PROBLEM_WITH_COMMENT;
+	}
+
 }

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/IApiToolProposalRelevance.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/IApiToolProposalRelevance.java
@@ -20,6 +20,8 @@ package org.eclipse.pde.api.tools.ui.internal.markers;
 public interface IApiToolProposalRelevance {
 
 
-	public static final int CONFIGURE_PROBLEM_SEVERITY = -1;
+	public static final int CONFIGURE_PROBLEM_SEVERITY = -10;
+	public static final int REMOVE_UNUSED_FILTER = 10;
+	public static final int FILTER_PROBLEM_WITH_COMMENT = 5;
 
 }

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/RemoveFilterProblemResolution.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/RemoveFilterProblemResolution.java
@@ -39,6 +39,7 @@ import org.eclipse.pde.api.tools.internal.util.Util;
 import org.eclipse.pde.api.tools.ui.internal.ApiUIPlugin;
 import org.eclipse.pde.api.tools.ui.internal.IApiToolsConstants;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.IMarkerResolutionRelevance;
 import org.eclipse.ui.texteditor.MarkerUtilities;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 
@@ -48,7 +49,7 @@ import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
  *
  * @since 1.0.0
  */
-public class RemoveFilterProblemResolution extends WorkbenchMarkerResolution {
+public class RemoveFilterProblemResolution extends WorkbenchMarkerResolution implements IMarkerResolutionRelevance {
 
 	/**
 	 * The {@link IApiProblemFilter} to remove
@@ -165,5 +166,10 @@ public class RemoveFilterProblemResolution extends WorkbenchMarkerResolution {
 		int size = mset.size();
 		plural = size > 0;
 		return mset.toArray(new IMarker[size]);
+	}
+
+	@Override
+	public int getRelevanceForResolution() {
+		return IApiToolProposalRelevance.REMOVE_UNUSED_FILTER;
 	}
 }


### PR DESCRIPTION
Currently the suggestions are not always totally ordered (e.g. there are some with default of 0), even though Eclipse then fall back to comparing strings, it would be much better to have an explicit ordering.

This now:
- make creating a commented compatibility filter "more recommended"
- make removing an unused filter "more recommended"
- make configure the problem category "less recommended"