### PR TITLE
Support extra classpath with no inner jar specification

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -522,7 +522,8 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 				addExtraLibrary(path, null, entries);
 			} else {
 				int count = path.getDevice() == null ? 4 : 3;
-				if (path.segmentCount() >= count) {
+				int segments = path.segmentCount();
+				if (segments >= count - 1) {
 					String pluginID = path.segment(count - 2);
 					IPluginModelBase model = PluginRegistry.findModel(pluginID);
 					if (model != null && model.isEnabled()) {
@@ -530,10 +531,17 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 						path = path.removeFirstSegments(count - 1);
 						IResource underlyingResource = model.getUnderlyingResource();
 						if (underlyingResource == null) {
-							IPath result = PDECore.getDefault().getModelManager().getExternalModelManager()
-									.getNestedLibrary(model, path.toString());
-							if (result != null) {
-								addExtraLibrary(result, model, entries);
+							if (path.segmentCount() == 0) {
+								String installLocation = model.getInstallLocation();
+								if (installLocation != null) {
+									addExtraLibrary(IPath.fromOSString(installLocation), model, entries);
+								}
+							} else {
+								IPath result = PDECore.getDefault().getModelManager().getExternalModelManager()
+										.getNestedLibrary(model, path.toString());
+								if (result != null) {
+									addExtraLibrary(result, model, entries);
+								}
 							}
 						} else {
 							IFile file = underlyingResource.getProject().getFile(path);


### PR DESCRIPTION
Currently one can only reference an inner jar with extra-classpath but not the bundle itself.

As this is actually something useful and this is even used in platform builds (even though it seem not effective due to this bug), PDE should support it as well.