### PR TITLE
Resolve NPE when Ids don't have associated configuration elements

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/rows/IdAttributeRow.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/rows/IdAttributeRow.java
@@ -53,26 +53,28 @@ public class IdAttributeRow extends ButtonAttributeRow {
 				Entry<String, IConfigurationElement> entry = (Entry<String, IConfigurationElement>) element;
 				String text = entry.getKey();
 				IConfigurationElement value = entry.getValue();
-				String name = value.getAttribute("name"); //$NON-NLS-1$
-				if (name == null) {
-					name = value.getAttribute("label"); //$NON-NLS-1$
+				if (value != null) {
+					String name = value.getAttribute("name"); //$NON-NLS-1$
 					if (name == null) {
-						name = value.getAttribute("description"); //$NON-NLS-1$
+						name = value.getAttribute("label"); //$NON-NLS-1$
+						if (name == null) {
+							name = value.getAttribute("description"); //$NON-NLS-1$
+						}
 					}
-				}
 
-				String contributor = value.getContributor().getName();
+					String contributor = value.getContributor().getName();
 
-				if (input != null && name != null && name.startsWith("%") && contributor != null) { //$NON-NLS-1$
-					IPluginModelBase model = PluginRegistry.findModel(contributor);
-					name = model.getResourceString(name);
-				}
+					if (input != null && name != null && name.startsWith("%") && contributor != null) { //$NON-NLS-1$
+						IPluginModelBase model = PluginRegistry.findModel(contributor);
+						name = model.getResourceString(name);
+					}
 
-				if (name != null) {
-					text += " - " + name; //$NON-NLS-1$
-				}
-				if (contributor != null) {
-					text += " [" + contributor + "]"; //$NON-NLS-1$ //$NON-NLS-2$
+					if (name != null) {
+						text += " - " + name; //$NON-NLS-1$
+					}
+					if (contributor != null) {
+						text += " [" + contributor + "]"; //$NON-NLS-1$ //$NON-NLS-2$
+					}
 				}
 				return text;
 			}


### PR DESCRIPTION
This fixes a regression introduced in 34b8e38ef25242a4992f61c8676569a8dcffc7f7 When that commit was done some instanceof checks were removed. The result of removing the instanceof checks had the side effect of removing the implicit null check that instanceof essentially does.

This change restores the null check for when IConfigurationElement is null.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1608