### PR TITLE
Add potentially missing null checks

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Signatures.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Signatures.java
@@ -584,15 +584,18 @@ public final class Signatures {
 							}
 							if (typeParameters != null) {
 								for (TypeParameter typeParameter : typeParameters) {
-									if (fullyQualifiedName.equals(typeParameter.getName().getFullyQualifiedName())) {
-										if (typeParameter.typeBounds().isEmpty()) {
-											yield Signature.createTypeSignature("Object", false); //$NON-NLS-1$
-										} else {
-											// the erasure of a type
-											// variable is the erasure of
-											// its leftmost bound
-											Type bound = (Type) typeParameter.typeBounds().get(0);
-											yield getTypeSignature(bound, erased);
+									if (typeParameter != null) {
+										if (fullyQualifiedName
+												.equals(typeParameter.getName().getFullyQualifiedName())) {
+											if (typeParameter.typeBounds().isEmpty()) {
+												yield Signature.createTypeSignature("Object", false); //$NON-NLS-1$
+											} else {
+												// the erasure of a type
+												// variable is the erasure of
+												// its leftmost bound
+												Type bound = (Type) typeParameter.typeBounds().get(0);
+												yield getTypeSignature(bound, erased);
+											}
 										}
 									}
 								}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/P2TargetUtils.java
@@ -1554,8 +1554,10 @@ public class P2TargetUtils {
 			Collection<IRepositoryReference> repos = new org.eclipse.equinox.internal.p2.engine.ProfileMetadataRepository(
 					getGlobalAgent(), dataArea, null).getReferences();
 			for (IRepositoryReference reference : repos) {
-				if (reference.getType() == IRepository.TYPE_ARTIFACT && reference.getLocation() != null) {
-					additionalRepos.add(reference.getLocation());
+				if (reference != null) {
+					if (reference.getType() == IRepository.TYPE_ARTIFACT && reference.getLocation() != null) {
+						additionalRepos.add(reference.getLocation());
+					}
 				}
 			}
 		} catch (CoreException e) {


### PR DESCRIPTION
This fixes a potential regression introduced in
34b8e38ef25242a4992f61c8676569a8dcffc7f7 When that commit was done some instanceof checks were removed.
The result of removing the instanceof checks had the side effect of removing the implicit null check that instanceof essentially does.

I reviewed all the removed instanceof checks in 34b8e38ef25242a4992f61c8676569a8dcffc7f7 and this PR, along with https://github.com/eclipse-pde/eclipse.pde/pull/1609 restores the null check.

I don't know how to trigger these potential NPEs.
