### PR TITLE
Updating marker to disable Quick Fix option if 'Configure problem severity' is the only available options

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
@@ -159,7 +159,7 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 	 */
 	int getProblemId(IMarker marker) {
 		int problemID = marker.getAttribute(PDEMarkerFactory.PROBLEM_ID, PDEMarkerFactory.NO_RESOLUTION);
-		if (problemID != PDEMarkerFactory.NO_RESOLUTION) {
+		if (problemID != PDEMarkerFactory.NO_RESOLUTION && problemID != PDEMarkerFactory.M_ONLY_CONFIG_SEV) {
 			return problemID;
 		}
 		return marker.getAttribute("id", PDEMarkerFactory.NO_RESOLUTION); //$NON-NLS-1$


### PR DESCRIPTION
This commit fixes the Quick fix option when 'Configure problem severity' is the only available options for the selected problem in the problems tab.

It in turns greys out the Quick fix option when there is no fix attached to the respective problem. This will into misleads developers into thinking that a quick fix is available for the problem when there is no available fix
Previously, it was showing a pop-up saying 'No quick fixes available.'
Attaching the screenshot of the fix
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/5d547c13-0d7d-44a7-95a8-67c53bf19041" />

Fixes: #1614