### PR TITLE
Add OSGi test classpath support

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -28,6 +28,13 @@
       <import plugin="org.bndtools.templates.template"/>
       <import plugin="biz.aQute.repository"/>
       <import plugin="bndtools.jareditor"/>
+      <import plugin="org.osgi.test.common"/>
+      <import plugin="org.osgi.test.junit5"/>
+      <import plugin="org.osgi.test.junit5.cm"/>
+      <import plugin="org.osgi.test.junit4"/>
+      <import plugin="org.osgi.test.assertj.framework"/>
+      <import plugin="org.osgi.test.assertj.log"/>
+      <import plugin="org.osgi.test.assertj.promise"/>
    </requires>
 
    <plugin

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -134,4 +134,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.pde.core
 Service-Component: OSGI-INF/org.eclipse.pde.internal.core.annotations.OSGiAnnotationsClasspathContributor.xml,
- OSGI-INF/org.eclipse.pde.internal.core.bnd.PdeBndAdapter.xml
+ OSGI-INF/org.eclipse.pde.internal.core.bnd.PdeBndAdapter.xml,
+ OSGI-INF/org.eclipse.pde.internal.core.osgitest.OSGiTestClasspathContributor.xml

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -33,6 +34,7 @@ import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.build.IBuild;
 import org.eclipse.pde.core.build.IBuildModel;
 import org.eclipse.pde.core.plugin.IFragment;
@@ -50,6 +52,10 @@ import org.eclipse.pde.internal.core.natures.PluginProject;
 import org.eclipse.pde.internal.core.plugin.Fragment;
 import org.eclipse.pde.internal.core.plugin.Plugin;
 import org.eclipse.pde.internal.core.plugin.PluginBase;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.resource.Resource;
 
 public class ClasspathUtilCore {
@@ -87,34 +93,92 @@ public class ClasspathUtilCore {
 	}
 
 	public static Stream<IClasspathEntry> classpathEntriesForBundle(String id) {
+		return classpathEntriesForBundle(id, false, new IClasspathAttribute[0]);
+	}
+
+	public static Stream<IClasspathEntry> classpathEntriesForBundle(String id, boolean includeRequired,
+			IClasspathAttribute[] extra) {
 		// first look if we have something in the workspace...
 		IPluginModelBase model = PluginRegistry.findModel(id);
 		if (model != null && model.isEnabled()) {
-			IResource resource = model.getUnderlyingResource();
-			if (resource != null && PluginProject.isJavaProject(resource.getProject())) {
-				IJavaProject javaProject = JavaCore.create(resource.getProject());
-				return Stream.of(JavaCore.newProjectEntry(javaProject.getPath()));
+			Stream<IClasspathEntry> modelBundleClasspath = classpathEntriesForModelBundle(model, extra);
+			if (includeRequired) {
+				return Stream.concat(modelBundleClasspath,
+						getRequiredByDescription(model.getBundleDescription(), extra));
 			}
-			String location = model.getInstallLocation();
-			if (location == null) {
-				return Stream.empty();
-			}
-			boolean isJarShape = new File(location).isFile();
-			IPluginLibrary[] libraries = model.getPluginBase().getLibraries();
-			if (isJarShape || libraries.length == 0) {
-				return Stream.of(getEntryForPath(IPath.fromOSString(location)));
-			}
-			return Arrays.stream(libraries).filter(library -> !IPluginLibrary.RESOURCE.equals(library.getType()))
-					.map(library -> {
-						String name = library.getName();
-						String expandedName = ClasspathUtilCore.expandLibraryName(name);
-						return ClasspathUtilCore.getPath(model, expandedName, isJarShape);
-					}).filter(Objects::nonNull).map(ClasspathUtilCore::getEntryForPath);
+			return modelBundleClasspath;
 		}
 		// if not found in the models, try to use one from the running eclipse
-		return Optional.ofNullable(Platform.getBundle(id)).map(bundle -> bundle.adapt(File.class)).filter(File::exists)
+		Bundle runtimeBundle = Platform.getBundle(id);
+		if (runtimeBundle == null) {
+			return Stream.empty();
+		}
+		Stream<IClasspathEntry> bundleClasspath = classpathEntriesForRuntimeBundle(runtimeBundle, extra).stream();
+		if (includeRequired) {
+			return Stream.concat(bundleClasspath, getRequiredByWire(runtimeBundle, extra));
+		}
+		return bundleClasspath;
+	}
+
+	private static Stream<IClasspathEntry> getRequiredByDescription(BundleDescription description,
+			IClasspathAttribute[] extra) {
+		BundleWiring wiring = description.getWiring();
+		if (wiring == null) {
+			return Stream.empty();
+		}
+
+		List<BundleWire> wires = wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE);
+		return wires.stream().map(wire -> {
+			return wire.getProvider();
+		}).distinct().flatMap(provider -> {
+			IPluginModelBase model = PluginRegistry.findModel(provider);
+			if (model != null && model.isEnabled()) {
+				return classpathEntriesForModelBundle(model, extra);
+			}
+			return Stream.empty();
+		});
+	}
+
+	protected static Stream<IClasspathEntry> classpathEntriesForModelBundle(IPluginModelBase model,
+			IClasspathAttribute[] extra) {
+		IResource resource = model.getUnderlyingResource();
+		if (resource != null && PluginProject.isJavaProject(resource.getProject())) {
+			IJavaProject javaProject = JavaCore.create(resource.getProject());
+			return Stream.of(JavaCore.newProjectEntry(javaProject.getPath()));
+		}
+		String location = model.getInstallLocation();
+		if (location == null) {
+			return Stream.empty();
+		}
+		boolean isJarShape = new File(location).isFile();
+		IPluginLibrary[] libraries = model.getPluginBase().getLibraries();
+		if (isJarShape || libraries.length == 0) {
+			return Stream.of(getEntryForPath(IPath.fromOSString(location), extra));
+		}
+		return Arrays.stream(libraries).filter(library -> !IPluginLibrary.RESOURCE.equals(library.getType()))
+				.map(library -> {
+					String name = library.getName();
+					String expandedName = ClasspathUtilCore.expandLibraryName(name);
+					return ClasspathUtilCore.getPath(model, expandedName, isJarShape);
+				}).filter(Objects::nonNull).map(entry -> getEntryForPath(entry, extra));
+	}
+
+	public static Stream<IClasspathEntry> getRequiredByWire(Bundle bundle, IClasspathAttribute[] extra) {
+		BundleWiring wiring = bundle.adapt(BundleWiring.class);
+		if (wiring == null) {
+			return Stream.empty();
+		}
+		List<BundleWire> wires = wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE);
+		return wires.stream().map(wire -> wire.getProviderWiring().getBundle()).distinct()
+				.filter(b -> b.getBundleId() != 0)
+				.flatMap(b -> classpathEntriesForRuntimeBundle(b, extra).stream());
+	}
+
+	private static Optional<IClasspathEntry> classpathEntriesForRuntimeBundle(Bundle bundle,
+			IClasspathAttribute[] extra) {
+		return Optional.ofNullable(bundle.adapt(File.class)).filter(File::exists)
 				.map(File::toPath).map(Path::normalize).map(path -> IPath.fromOSString(path.toString()))
-				.map(ClasspathUtilCore::getEntryForPath).stream();
+				.map(entry -> getEntryForPath(entry, extra));
 	}
 
 	public static boolean isEntryForModel(IClasspathEntry entry, IPluginModelBase projectModel) {
@@ -127,8 +191,8 @@ public class ClasspathUtilCore {
 		return false;
 	}
 
-	private static IClasspathEntry getEntryForPath(IPath path) {
-		return JavaCore.newLibraryEntry(path, path, IPath.ROOT, new IAccessRule[0], new IClasspathAttribute[0], false);
+	private static IClasspathEntry getEntryForPath(IPath path, IClasspathAttribute[] extra) {
+		return JavaCore.newLibraryEntry(path, path, IPath.ROOT, new IAccessRule[0], extra, false);
 	}
 
 	private static void addLibraryEntry(IPluginLibrary library, Collection<ClasspathLibrary> entries) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/osgitest/OSGiTestClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/osgitest/OSGiTestClasspathContributor.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.osgitest;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.osgi.service.resolver.BundleDelta;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateDelta;
+import org.eclipse.pde.core.IClasspathContributor;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.core.ClasspathUtilCore;
+import org.eclipse.pde.internal.core.IStateDeltaListener;
+import org.eclipse.pde.internal.core.PDECore;
+import org.osgi.resource.Resource;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * If the users chose to add JUNIT container to a PDE project and OSGi test is
+ * in the target platform this contributor automatically adds the OSGi test
+ * extensions to the classpath.
+ */
+@Component(service = IClasspathContributor.class)
+public class OSGiTestClasspathContributor implements IClasspathContributor, IStateDeltaListener {
+
+	private static final IPath PATH = new Path("org.eclipse.jdt.junit.JUNIT_CONTAINER"); //$NON-NLS-1$
+
+	private static final IPath JUNIT5_CONTAINER_PATH = PATH.append("5"); //$NON-NLS-1$
+	private static final IPath JUNIT4_CONTAINER_PATH = PATH.append("4"); //$NON-NLS-1$
+
+	private static final int CHANGE_FLAGS = BundleDelta.ADDED | BundleDelta.REMOVED | BundleDelta.UPDATED;
+
+	private static final IClasspathAttribute TEST_ATTRIBUTE = JavaCore.newClasspathAttribute(IClasspathAttribute.TEST,
+			"true"); //$NON-NLS-1$
+
+	private static final Collection<String> OSGI_TEST_BUNDLES = List.of("org.osgi.test.common", //$NON-NLS-1$
+			"org.osgi.test.assertj.framework", "org.osgi.test.assertj.log", "org.osgi.test.assertj.promise"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+	private static final Collection<String> OSGI_TEST_JUNIT5_BUNDLES = List.of("org.osgi.test.junit5", //$NON-NLS-1$
+			"org.osgi.test.junit5.cm"); //$NON-NLS-1$
+
+	private static final Collection<String> OSGI_TEST_JUNIT4_BUNDLES = List.of("org.osgi.test.junit4"); //$NON-NLS-1$
+
+	private final ConcurrentMap<String, Collection<IClasspathEntry>> entryMap = new ConcurrentHashMap<>();
+
+	@Activate
+	void registerListener() {
+		// TODO we need to listen to classpath changes as well, eg. container
+		// added/removed/changed/...
+		PDECore.getDefault().getModelManager().addStateDeltaListener(this);
+	}
+
+	@Deactivate
+	void undregisterListener() {
+		PDECore.getDefault().getModelManager().removeStateDeltaListener(this);
+	}
+
+	/**
+	 * @return s stream of all osgi test bundles
+	 */
+	public static Stream<String> bundles(boolean junit5) {
+		return Stream.concat(OSGI_TEST_BUNDLES.stream(),
+				junit5 ? OSGI_TEST_JUNIT5_BUNDLES.stream() : OSGI_TEST_JUNIT4_BUNDLES.stream());
+	}
+
+	@Override
+	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {
+		IPluginModelBase projectModel = PluginRegistry.findModel((Resource) project);
+		return junitBundles(projectModel)
+				.map(bundleId -> entryMap.computeIfAbsent(bundleId,
+						id -> ClasspathUtilCore
+								.classpathEntriesForBundle(id, true, new IClasspathAttribute[] { TEST_ATTRIBUTE })
+								.toList()))
+				.flatMap(Collection::stream)
+				.filter(Predicate.not(entry -> ClasspathUtilCore.isEntryForModel(entry, projectModel))).toList();
+	}
+
+	protected Stream<String> junitBundles(IPluginModelBase projectModel) {
+		IResource resource = projectModel.getUnderlyingResource();
+		if (resource != null) {
+			IProject eclipseProject = resource.getProject();
+			IJavaProject javaProject = JavaCore.create(eclipseProject);
+			try {
+				IClasspathEntry[] classpath = javaProject.getRawClasspath();
+				for (IClasspathEntry cp : classpath) {
+					if (cp.getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
+						if (JUNIT5_CONTAINER_PATH.equals(cp.getPath())) {
+							return bundles(true);
+						}
+						if (JUNIT4_CONTAINER_PATH.equals(cp.getPath())) {
+							return bundles(false);
+						}
+					}
+				}
+			} catch (JavaModelException e) {
+				// can't check, fall through and assume not enabled...
+			}
+		}
+		return Stream.empty();
+	}
+
+	@Override
+	public List<IClasspathEntry> getEntriesForDependency(BundleDescription project, BundleDescription addedDependency) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void stateResolved(StateDelta delta) {
+		if (delta == null) {
+			stateChanged(null);
+		} else {
+			// just refresh the items in the map if they have any changes...
+			for (BundleDelta bundleDelta : delta.getChanges(CHANGE_FLAGS, false)) {
+				entryMap.remove(bundleDelta.getBundle().getSymbolicName());
+			}
+		}
+
+	}
+
+	@Override
+	public void stateChanged(State newState) {
+		// we need to refresh everything
+		entryMap.clear();
+	}
+
+}


### PR DESCRIPTION
Similar to what we have for OSGi annotations, PDE should have OSGi Testing Support as it is a great library for testing OSGi applications. The most hindering thing in this regard is that it is rater complex to setup until one can make the first steps.

This now adds a new classpath contributor that detects if a PDE project is already using JUNIT classpath container and then adds OSGi test dependencies automatically as test dependencies if they are part of the target platform or alternatively from the running platform.

See https://github.com/eclipse-pde/eclipse.pde/issues/877