### PR TITLE
Quick fix added for invalid characters in MANIFEST header

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
@@ -74,8 +74,8 @@ public class PDEMarkerFactory {
 	public static final int M_ONLY_CONFIG_SEV = 0x1027; // other problem
 	public static final int M_NO_AUTOMATIC_MODULE = 0x1028; // other problem
 	public static final int M_EXEC_ENV_TOO_LOW = 0x1029; // other problem
-	public static final int M_CONFLICTING_AUTOMATIC_MODULE = 0x1030; // other
-																		// problem
+	public static final int M_CONFLICTING_AUTOMATIC_MODULE = 0x1030; // other problem
+	public static final int M_HEADER_INCORRECT = 0x1031; // other problem
 	public static final int M_SINGLETON_DIR_CHANGE = 0x1033; // other problem
 
 	// build properties fixes

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -695,6 +695,7 @@ public class PDEUIMessages extends NLS {
 
 	public static String UpdateClasspathResolution_label;
 	public static String UpdateExecutionEnvironment_label;
+	public static String RemoveInvalidCharacters;
 
 	//
 	// PDE resource strings

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
@@ -149,6 +149,9 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 		case PDEMarkerFactory.M_CONFLICTING_AUTOMATIC_MODULE:
 			return new IMarkerResolution[] {
 					new RemoveRedundantAutomaticModuleHeader(AbstractPDEMarkerResolution.REMOVE_TYPE, marker) };
+		case PDEMarkerFactory.M_HEADER_INCORRECT:
+			return new IMarkerResolution[] {
+					new UpdateCorrectHeaderName(AbstractPDEMarkerResolution.RENAME_TYPE, marker) };
 		}
 		return NO_RESOLUTIONS;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/UpdateCorrectHeaderName.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/UpdateCorrectHeaderName.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.correction;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.pde.internal.core.text.bundle.BundleModel;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+
+/**
+ * Resolution to remove invalid characters from header in MANIFEST. Remove all
+ * the invalid characters (characters other than alpha numeric characters, '-'
+ * and '_') Also adding a space after 'Require-Bundle' header(before the colon)
+ * when not present.
+ */
+public class UpdateCorrectHeaderName extends AbstractManifestMarkerResolution {
+
+	private static final Logger logger = Logger.getLogger(UpdateCorrectHeaderName.class.getName());
+
+	public UpdateCorrectHeaderName(int type, IMarker marker) {
+		super(type, marker);
+	}
+
+	@Override
+	public String getLabel() {
+		return PDEUIMessages.RemoveInvalidCharacters;
+	}
+
+	private String removeInvalidChars(String userHeader) {
+		return userHeader.replaceAll("[^a-zA-Z0-9-_]", ""); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Override
+	protected void createChange(BundleModel model) {
+		model.getBundle();
+		IDocument doc = model.getDocument();
+		try {
+			int lineNum = marker.getAttribute(IMarker.LINE_NUMBER, -1);
+			IRegion lineInfo = doc.getLineInformation(lineNum - 1);
+			int offset = lineInfo.getOffset();
+			int length = lineInfo.getLength();
+
+			String getLine = doc.get(offset, length);
+			int colonInd = getLine.indexOf(':');
+
+			if (colonInd > 0) {
+				String userHeader = getLine.substring(0, colonInd);
+				String correctHeader = removeInvalidChars(userHeader);
+				doc.replace(offset, colonInd, correctHeader);
+			}
+
+		} catch (BadLocationException e) {
+			logger.log(Level.SEVERE,
+					"Failed to apply UpdateCorrectHeaderName quick fix, unexpected location in the doc", //$NON-NLS-1$
+					e);
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2425,6 +2425,7 @@ LocationSection_0=&Locations
 AppendSeperatorBuildEntryResolution_label=Append a trailing separator to {0}.
 AddExportPackageResolution_Label=Add missing packages
 AddExportPackageInternalDirectiveResolution_Label=Add missing packages with x-internal directive
+RemoveInvalidCharacters=Remove invalid characters from header
 
 DependencyManagementSection_jobName=Analyzing Code
 DescriptionSection_nameLabel=Name:


### PR DESCRIPTION
This is to provide quick fix for invalid header name in MANIFEST.MF
It will provide fix by removing all the invalid characters (characters other than alpha numeric characters, '-' and '_')
for eg. in the below image, added a space after 'Require-Bundle' header
the added quick fix label is 'Remove invalid characters from header'. Once user clicks on 'Finish', it updates the header

<img width="1397" alt="image" src="https://github.com/user-attachments/assets/0e2d3690-cbd1-417f-b7f3-daa82bfec8c1" />

Attaching another example
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/5a03b82b-1757-40fd-b1b7-4d778ebc71ea" />

