### PR TITLE
Quick fix for adding a space after the colon

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
@@ -181,6 +181,7 @@ public class PDECoreMessages extends NLS {
 	public static String BundleErrorReporter_noMainSection;
 	public static String BundleErrorReporter_duplicateHeader;
 	public static String BundleErrorReporter_noColon;
+	public static String BundleErrorReporter_noSpaceAfterColon;
 	public static String BundleErrorReporter_noSpaceValue;
 	public static String BundleErrorReporter_nameHeaderInMain;
 	public static String BundleErrorReporter_noNameHeader;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/JarManifestErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/JarManifestErrorReporter.java
@@ -177,6 +177,11 @@ public class JarManifestErrorReporter extends ErrorReporter {
 					report(PDECoreMessages.BundleErrorReporter_invalidHeaderName, lineNumber, CompilerFlags.ERROR, PDEMarkerFactory.CAT_FATAL);
 					return;
 				}
+				if (line.length() >= colon + 2 && line.charAt(colon + 1) != ' ') {
+					report(PDECoreMessages.BundleErrorReporter_noSpaceAfterColon, lineNumber, CompilerFlags.ERROR,
+							PDEMarkerFactory.M_NO_SPACE_AFTER_COLON, PDEMarkerFactory.CAT_FATAL);
+					return;
+				}
 				if (line.length() < colon + 2 || line.charAt(colon + 1) != ' ') {
 					report(PDECoreMessages.BundleErrorReporter_noSpaceValue, lineNumber, CompilerFlags.ERROR, PDEMarkerFactory.CAT_FATAL);
 					return;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
@@ -76,6 +76,7 @@ public class PDEMarkerFactory {
 	public static final int M_EXEC_ENV_TOO_LOW = 0x1029; // other problem
 	public static final int M_CONFLICTING_AUTOMATIC_MODULE = 0x1030; // other
 																		// problem
+	public static final int M_NO_SPACE_AFTER_COLON = 0x1032; // other problem
 
 	// build properties fixes
 	public static final int B_APPEND_SLASH_FOLDER_ENTRY = 0x2001;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
@@ -139,6 +139,7 @@ BundleErrorReporter_lineTooLong = The line is too long
 BundleErrorReporter_noMainSection = Manifest has no main section
 BundleErrorReporter_duplicateHeader = Header already defined
 BundleErrorReporter_noColon = ':' is required after the header name
+BundleErrorReporter_noSpaceAfterColon=Single space is required after the colon
 BundleErrorReporter_noSpaceValue = Single space and a value is required after the header name
 BundleErrorReporter_nameHeaderInMain = 'Name' header is not allowed in the main section
 BundleErrorReporter_noNameHeader = Extraneous empty line causes the file to be invalid

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3227,6 +3227,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String AddSourceBuildEntryResolution_label;
 
+	public static String AddSpaceAfterColon_add;
+
 	public static String RemoveSeperatorBuildEntryResolution_label;
 
 	public static String ExternalizeStringsResolution_desc;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/AddSpaceBeforeValue.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/AddSpaceBeforeValue.java
@@ -1,0 +1,43 @@
+package org.eclipse.pde.internal.ui.correction;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.pde.internal.core.text.bundle.BundleModel;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+
+public class AddSpaceBeforeValue extends AbstractManifestMarkerResolution {
+
+	public AddSpaceBeforeValue(int type, IMarker marker) {
+		super(type, marker);
+	}
+
+	@Override
+	public String getLabel() {
+		return PDEUIMessages.AddSpaceAfterColon_add;
+	}
+
+	@Override
+	protected void createChange(BundleModel model) {
+		IDocument doc = model.getDocument();
+		try {
+			int lineNum = (int) marker.getAttribute(IMarker.LINE_NUMBER);
+			IRegion lineInfo = doc.getLineInformation(lineNum - 1);
+			int offset = lineInfo.getOffset();
+			int length = lineInfo.getLength();
+
+			String getLine = doc.get(offset, length);
+			int colonInd = getLine.indexOf(':');
+
+			if (colonInd > 0 && getLine.charAt(colonInd + 1) != ' ') {
+				String userHeader = getLine.substring(0, colonInd + 1);
+				userHeader = userHeader + " "; //$NON-NLS-1$
+				doc.replace(offset, colonInd + 1, userHeader);
+			}
+
+		} catch (Exception e) {
+
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
@@ -146,6 +146,9 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 		case PDEMarkerFactory.M_CONFLICTING_AUTOMATIC_MODULE:
 			return new IMarkerResolution[] {
 					new RemoveRedundantAutomaticModuleHeader(AbstractPDEMarkerResolution.REMOVE_TYPE, marker) };
+		case PDEMarkerFactory.M_NO_SPACE_AFTER_COLON:
+			return new IMarkerResolution[] {
+					new AddSpaceBeforeValue(AbstractPDEMarkerResolution.CREATE_TYPE, marker) };
 		}
 		return NO_RESOLUTIONS;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -590,6 +590,7 @@ AdvancedPluginExportPage_signButton=Si&gn the JAR archives using a keystore (a p
 AdvancedPluginExportPage_noKeystore=Keystore location is not set
 AdvancedPluginExportPage_noPassword=Password is not set
 AddSourceBuildEntryResolution_label=Add a {0} entry.
+AddSpaceAfterColon_add=Add a space after the colon
 AdvancedFeatureExportPage_createJNLP=&Create JNLP manifests for the JAR archives
 AdvancedFeatureExportPage_jreVersion=&JRE version:
 AdvancedPluginExportPage_qualifier = &Qualifier replacement (default value is today's date):


### PR DESCRIPTION
This is to provide a quick fix for situations when no space is added after the colon in the MANIFEST.MF file, and the value is entered by the user.

For example, in line 12, there is no space after the colon before the value 'test'. To address this, we are providing a quick fix to add a space there, as shown below:

Attaching the screenshot before and after applying the quick fix.

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/e87fb257-e73d-474e-a835-4b89a11e0fe0" />

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/8066725c-f7f5-402e-8575-2f2a6001e404" />


