### PR TITLE
Rename "Close" to "Apply" in DependencyPropertiesDialog

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -77,7 +77,7 @@ public class PDEUIMessages extends NLS {
 	public static String DependenciesViewPage_showOptional;
 
 	public static String DependencyPropertiesDialog_exportGroupText;
-	public static String DependencyPropertiesDialog_closeButtonLabel;
+	public static String DependencyPropertiesDialog_applyButtonLabel;
 
 	public static String ExtensionsPage_toggleExpandState;
 	public static String ExternalizeStringsOperation_editNames_addComment;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyPropertiesDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependencyPropertiesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2015 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -83,7 +83,7 @@ public class DependencyPropertiesDialog extends StatusDialog {
 
 	@Override
 	protected void createButtonsForButtonBar(Composite parent) {
-		createButton(parent, IDialogConstants.OK_ID, PDEUIMessages.DependencyPropertiesDialog_closeButtonLabel, true);
+		createButton(parent, IDialogConstants.OK_ID, PDEUIMessages.DependencyPropertiesDialog_applyButtonLabel, true);
 		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2024 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -1454,7 +1454,7 @@ DependencyPropertiesDialog_comboExclusive=Exclusive
 DependencyPropertiesDialog_minimumVersion=&Minimum version:
 DependencyPropertiesDialog_maximumVersion=Ma&ximum version:
 DependencyPropertiesDialog_exportGroupText=Version exported
-DependencyPropertiesDialog_closeButtonLabel=&Close
+DependencyPropertiesDialog_applyButtonLabel=&Apply
 DependencyAnalysisSection_plugin_notEditable = <form>\
 <p><img href="hierarchy"/> <a href="hierarchy">Show the plug-in dependency hierarchy</a></p>\
 <p><img href="dependencies"/> <a href="references">Show dependent plug-ins and fragments</a></p>\


### PR DESCRIPTION
This changes the name of the OK button to "Close", to avoid any confusion with the similarly named "Cancel" button.

Closes https://github.com/eclipse-pde/eclipse.pde/issues/1632