### PR TITLE
Quick fix to provide an option to update user directive to mandatory singleton true directive(if not present)

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
@@ -431,7 +431,6 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 		// must check the existence of plugin.xml file instead of using IPluginBase because if the bundle is not a singleton,
 		// it won't be registered with the extension registry and will always return 0 when querying extensions/extension points
 		boolean hasExtensions = base != null && PDEProject.getPluginXml(fProject).exists();
-
 		if (hasExtensions) {
 			if (TargetPlatformHelper.getTargetVersion() >= 3.1) {
 				if (!"true".equals(singletonDir)) { //$NON-NLS-1$
@@ -444,6 +443,21 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 							return;
 						}
 					} else {
+						Enumeration<String> attrKeys = element.getDirectiveKeys();
+						int length = 0;
+						String key = null;
+						while (attrKeys.hasMoreElements()) {
+							key = attrKeys.nextElement();
+							length++;
+						}
+						if (length == 1) {
+							String message = NLS.bind(PDECoreMessages.BundleErrorReporter_singletonRequired,
+									Constants.SINGLETON_DIRECTIVE);
+							VirtualMarker marker = report(message, header.getLineNumber(), CompilerFlags.ERROR,
+									PDEMarkerFactory.M_SINGLETON_DIR_CHANGE, PDEMarkerFactory.CAT_FATAL);
+							addMarkerAttribute(marker, "userDirective", key); //$NON-NLS-1$
+							return;
+						}
 						String message = NLS.bind(PDECoreMessages.BundleErrorReporter_singletonRequired, Constants.SINGLETON_DIRECTIVE);
 						report(message, header.getLineNumber(), CompilerFlags.ERROR, PDEMarkerFactory.M_SINGLETON_DIR_NOT_SET, PDEMarkerFactory.CAT_FATAL);
 						return;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
@@ -76,6 +76,7 @@ public class PDEMarkerFactory {
 	public static final int M_EXEC_ENV_TOO_LOW = 0x1029; // other problem
 	public static final int M_CONFLICTING_AUTOMATIC_MODULE = 0x1030; // other
 																		// problem
+	public static final int M_SINGLETON_DIR_CHANGE = 0x1033; // other problem
 
 	// build properties fixes
 	public static final int B_APPEND_SLASH_FOLDER_ENTRY = 0x2001;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -716,6 +716,8 @@ public class PDEUIMessages extends NLS {
 	public static String Errors_CreationError;
 	public static String Errors_CreationError_NoWizard;
 
+	public static String UpdateSingleton_dir_label;
+
 	public static String UpdateSplashHandlerInModelAction_msgAddingExtension;
 
 	public static String UpdateSplashHandlerInModelAction_msgAddingExtensionPoint;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
@@ -64,6 +64,8 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 				return new IMarkerResolution[] {new CreateJREBundleHeaderResolution(AbstractPDEMarkerResolution.CREATE_TYPE, marker)};
 			case PDEMarkerFactory.M_SINGLETON_DIR_NOT_SET :
 				return new IMarkerResolution[] {new AddSingletonToSymbolicName(AbstractPDEMarkerResolution.RENAME_TYPE, true, marker)};
+			case PDEMarkerFactory.M_SINGLETON_DIR_CHANGE:
+				return updateSingletonProposal(marker);
 			case PDEMarkerFactory.M_SINGLETON_ATT_NOT_SET :
 				return new IMarkerResolution[] {new AddSingletonToSymbolicName(AbstractPDEMarkerResolution.RENAME_TYPE, false,marker)};
 			case PDEMarkerFactory.M_SINGLETON_DIR_NOT_SUPPORTED :
@@ -148,6 +150,13 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 					new RemoveRedundantAutomaticModuleHeader(AbstractPDEMarkerResolution.REMOVE_TYPE, marker) };
 		}
 		return NO_RESOLUTIONS;
+	}
+
+	private IMarkerResolution[] updateSingletonProposal(IMarker marker) {
+		return new IMarkerResolution[] {
+				new UpdateSingletonToSymbolicName(AbstractPDEMarkerResolution.RENAME_TYPE, true, marker),
+				new AddSingletonToSymbolicName(AbstractPDEMarkerResolution.RENAME_TYPE, true, marker) };
+
 	}
 
 	/**

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/UpdateSingletonToSymbolicName.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/UpdateSingletonToSymbolicName.java
@@ -1,0 +1,49 @@
+package org.eclipse.pde.internal.ui.correction;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.pde.internal.core.TargetPlatformHelper;
+import org.eclipse.pde.internal.core.ibundle.IBundle;
+import org.eclipse.pde.internal.core.ibundle.IManifestHeader;
+import org.eclipse.pde.internal.core.text.bundle.Bundle;
+import org.eclipse.pde.internal.core.text.bundle.BundleModel;
+import org.eclipse.pde.internal.core.text.bundle.BundleSymbolicNameHeader;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.osgi.framework.Constants;
+
+public class UpdateSingletonToSymbolicName extends AbstractManifestMarkerResolution {
+
+	private final boolean fisDirective;
+
+	public UpdateSingletonToSymbolicName(int type, boolean directive, IMarker marker) {
+		super(type, marker);
+		fisDirective = directive;
+	}
+
+	@Override
+	public String getLabel() {
+		String userDirective = marker.getAttribute("userDirective", null); //$NON-NLS-1$
+		return NLS.bind(PDEUIMessages.UpdateSingleton_dir_label, userDirective);
+	}
+
+	@Override
+	protected void createChange(BundleModel model) {
+		IBundle bundle = model.getBundle();
+		if (bundle instanceof Bundle bun) {
+			IManifestHeader header = bun.getManifestHeader(Constants.BUNDLE_SYMBOLICNAME);
+			if (header instanceof BundleSymbolicNameHeader) {
+				if (fisDirective && TargetPlatformHelper.getTargetVersion() >= 3.1)
+					bundle.setHeader(Constants.BUNDLE_MANIFESTVERSION, "2"); //$NON-NLS-1$
+				else if (!fisDirective && TargetPlatformHelper.getTargetVersion() < 3.1)
+					bundle.setHeader(Constants.BUNDLE_MANIFESTVERSION, null);
+				String entry = ((BundleSymbolicNameHeader) header).getValue();
+				int ind1 = entry.indexOf(';');
+				int ind2 = entry.indexOf(':');
+				String invalidDir = entry.substring(ind1 + 1, ind2);
+				((BundleSymbolicNameHeader) header).setDirective(invalidDir, null);
+				((BundleSymbolicNameHeader) header).setDirective(Constants.SINGLETON_DIRECTIVE, String.valueOf(true));
+			}
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2520,6 +2520,7 @@ ControlValidationUtility_errorMsgKeyNotFound=The specified key is not present in
 ControlValidationUtility_errorMsgFilterInvalidSyntax=The specified platform filter contains invalid syntax
 PackageFinder_taskName=Searching class files for package references
 
+UpdateSingleton_dir_label=Update ''{0}'' to 'singleton' directive true
 UpdateSplashHandlerInModelAction_nameEmbedded=Embedded
 UpdateSplashHandlerInModelAction_nameRCP=RCP
 UpdateSplashHandlerInModelAction_templateTypeBrowser=Browser - An embedded HTML browser


### PR DESCRIPTION
This is to provide quick fix:
In case, user has not entered any singleton directive to true, this change will provide an option to update the same to singleton:=true
this will provide the update option only when there is one set of directive. For multiple sets, we already have an option to add 'singleton' directive to true.

for example: 
before the fix:
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/51da9afb-3148-4172-ab87-fb6fc254fe80" />

after applying the **Update** fix:
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/33001750-4070-472e-a04e-3f2354afea07" />
