### PR TITLE
Wrap viewer in CheckboxTablePart within a FilteredTable

### DIFF
--- a/ui/org.eclipse.pde.ui/.settings/.api_filters
+++ b/ui/org.eclipse.pde.ui/.settings/.api_filters
@@ -120,6 +120,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/pde/internal/ui/shared/CachedCheckboxTableViewer.java" type="org.eclipse.pde.internal.ui.shared.CachedCheckboxTableViewer">
+        <filter comment="Extends CheckboxTableViewer to match CachedCheckboxTreeviewer" id="571473929">
+            <message_arguments>
+                <message_argument value="CheckboxTableViewer"/>
+                <message_argument value="CachedCheckboxTableViewer"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/pde/internal/ui/shared/target/EditTargetContainerPage.java" type="org.eclipse.pde.internal.ui.shared.target.EditTargetContainerPage">
         <filter id="640712815">
             <message_arguments>

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -77,6 +77,7 @@ Require-Bundle:
  org.eclipse.pde.core;bundle-version="[3.17.200,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.e4.core.services;bundle-version="[2.4.200,3.0.0)",
+ org.eclipse.e4.ui.dialogs;bundle-version="[1.6.0,2.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.21.200,4.0.0)",
  org.eclipse.ui.views;bundle-version="[3.12.100,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.24.200,4.0.0)",

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/CheckboxTablePart.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/CheckboxTablePart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2018 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -13,15 +13,17 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.parts;
 
-import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.pde.internal.ui.shared.CachedCheckboxTableViewer;
+import org.eclipse.pde.internal.ui.shared.FilteredCheckboxTable;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
 public class CheckboxTablePart extends StructuredViewerPart {
+
 	public CheckboxTablePart(String[] buttonLabels) {
 		super(buttonLabels);
 	}
@@ -34,15 +36,16 @@ public class CheckboxTablePart extends StructuredViewerPart {
 		} else {
 			style |= toolkit.getBorderStyle();
 		}
-		CheckboxTableViewer tableViewer = CheckboxTableViewer.newCheckList(parent, style);
+		FilteredCheckboxTable filteredTable = new FilteredCheckboxTable(parent, toolkit, style);
+		CachedCheckboxTableViewer tableViewer = filteredTable.getViewer();
 		tableViewer
 				.addSelectionChangedListener(e -> CheckboxTablePart.this.selectionChanged(e.getStructuredSelection()));
 		tableViewer.addCheckStateListener(event -> elementChecked(event.getElement(), event.getChecked()));
 		return tableViewer;
 	}
 
-	public CheckboxTableViewer getTableViewer() {
-		return (CheckboxTableViewer) getViewer();
+	public CachedCheckboxTableViewer getTableViewer() {
+		return (CachedCheckboxTableViewer) getViewer();
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/CachedCheckboxTableViewer.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/CachedCheckboxTableViewer.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.shared;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jface.viewers.CheckboxTableViewer;
+import org.eclipse.jface.viewers.CheckboxTreeViewer;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Tree;
+
+/**
+ * Counterpart of the {@link CachedCheckboxTreeViewer} which is specialized for
+ * use with {@link FilteredCheckboxTable}. This viewer caches the check state of
+ * the table items. When a filter is applied the cache stores which nodes are
+ * checked. When a filter is removed the viewer can be told to restore check
+ * state from the cache.
+ * <p>
+ * Note: If duplicate items are added to the table the cache will treat them as
+ * a single entry.
+ * </p>
+ */
+public class CachedCheckboxTableViewer extends CheckboxTableViewer {
+
+	private Set<Object> checkState = new HashSet<>();
+	private static final Object[] NO_ELEMENTS = new Object[0];
+
+	/**
+	 * Constructor for ContainerCheckedTreeViewer.
+	 * @see CheckboxTreeViewer#CheckboxTreeViewer(Tree)
+	 */
+	protected CachedCheckboxTableViewer(Table table) {
+		super(table);
+		addCheckStateListener(event -> updateCheckState(event.getElement(), event.getChecked()));
+		setUseHashlookup(true);
+	}
+
+	protected void updateCheckState(Object element, boolean state) {
+		if (state) {
+			checkState.add(element);
+		} else {
+			checkState.remove(element);
+		}
+	}
+
+	/**
+	 * Restores the checked state of items based on the cached check state.No
+	 * events will be fired.
+	 */
+	public void restoreCachedState() {
+		getTable().setRedraw(false);
+		// Call the super class so we don't mess up the cache
+		super.setCheckedElements(NO_ELEMENTS);
+		setGrayedElements(NO_ELEMENTS);
+		// Now we are only going to set the check state of the leaf nodes
+		// and rely on our container checked code to update the parents properly.
+		super.setCheckedElements(checkState.toArray());
+		getTable().setRedraw(true);
+	}
+
+	@Override
+	protected void preservingSelection(Runnable updateCode) {
+		super.preservingSelection(updateCode);
+		// The super class implementation will preserve a root element's check
+		// mark but that can cause newly unfiltered children to become check
+		// marked.
+		// See https://github.com/eclipse-pde/eclipse.pde/issues/62
+		restoreCachedState();
+	}
+
+	/**
+	 * Returns the contents of the cached check state.  The contents will be all
+	 * checked leaf nodes ignoring any filters.
+	 *
+	 * @return checked leaf elements
+	 */
+	public Object[] getUnfilteredCheckedElements() {
+		return checkState.toArray(Object[]::new);
+	}
+
+	/**
+	 * Returns the number of checked nodes. This method uses its internal check
+	 * state cache to determine what has been checked, not what is visible in
+	 * the viewer. The cache does not count duplicate items in the table.
+	 *
+	 * @return number of elements checked according to the cached check state
+	 */
+	public int getUnfilteredCheckedCount() {
+		return checkState.size();
+	}
+
+	/**
+	 * Returns whether {@code element} is checked. This method uses its internal
+	 * check state cache to determine what has been checked, not what is visible
+	 * in the viewer.
+	 */
+	public boolean isCheckedElement(Object element) {
+		return checkState.contains(element);
+	}
+
+	@Override
+	public boolean setChecked(Object element, boolean state) {
+		updateCheckState(element, state);
+		return super.setChecked(element, state);
+	}
+
+	@Override
+	public void setCheckedElements(Object[] elements) {
+		checkState.clear();
+		Collections.addAll(checkState, elements);
+		super.setCheckedElements(elements);
+	}
+
+	@Override
+	public void setAllChecked(boolean state) {
+		super.setAllChecked(state);
+		if (state) {
+			// Find all visible children and check them
+			Object[] visible = getFilteredChildren(getRoot());
+			Collections.addAll(checkState, visible);
+		} else {
+			// Remove any item in the check state that is visible (passes the filters)
+			Object[] visible = filter(checkState.toArray());
+			for (Object visibleObject : visible) {
+				checkState.remove(visibleObject);
+			}
+		}
+	}
+
+	@Override
+	public void remove(Object[] elements) {
+		for (Object element : elements) {
+			updateCheckState(element, false);
+		}
+		super.remove(elements);
+	}
+
+	@Override
+	public void remove(Object element) {
+		updateCheckState(element, false);
+		super.remove(element);
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/FilteredCheckboxTable.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/FilteredCheckboxTable.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ *  Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.shared;
+
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.e4.ui.dialogs.filteredtree.FilteredTable;
+import org.eclipse.e4.ui.dialogs.filteredtree.PatternFilter;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+
+/**
+ * A FilteredCheckboxTable implementation to be used internally in PDE UI code.
+ * This table stores all the table elements internally, and keeps the check
+ * state in sync. This way, even if an element is filtered, the caller can get
+ * and set the checked state.
+ *
+ * @since 3.16.100
+ */
+public class FilteredCheckboxTable extends FilteredTable {
+
+	private static final long FILTER_DELAY = 400;
+	private final FormToolkit toolkit;
+
+	/**
+	 * Constructor that creates a table with preset style bits and a
+	 * CheckboxTableViewer for the table.
+	 *
+	 * @param parent
+	 *            parent composite
+	 * @param toolkit
+	 *            optional toolkit to create UI elements with, required if the
+	 *            table is being created in a form editor
+	 */
+	public FilteredCheckboxTable(Composite parent, FormToolkit toolkit) {
+		this(parent, toolkit, SWT.NONE);
+	}
+
+	/**
+	 * Constructor that creates a table with preset style bits and a
+	 * CheckboxTableViewer for the table.
+	 *
+	 * @param parent
+	 *            parent composite
+	 * @param toolkit
+	 *            optional toolkit to create UI elements with, required if the
+	 *            table is being created in a form editor
+	 */
+	public FilteredCheckboxTable(Composite parent, FormToolkit toolkit, int tableStyle) {
+		this(parent, toolkit, tableStyle, new PatternFilter());
+	}
+
+	/**
+	 * Constructor that creates a table with preset style bits and a
+	 * CheckboxTableViewer for the table.
+	 *
+	 * @param parent
+	 *            parent composite
+	 * @param toolkit
+	 *            optional toolkit to create UI elements with, required if the
+	 *            table is being created in a form editor
+	 * @param filter
+	 *            pattern filter to use in the filter control
+	 */
+	public FilteredCheckboxTable(Composite parent, FormToolkit toolkit, int tableStyle, PatternFilter filter) {
+		super(parent);
+		this.parent = parent;
+		this.toolkit = toolkit;
+		init(tableStyle, filter);
+	}
+
+	@Override
+	protected TableViewer doCreateTableViewer(Composite parent, int style) {
+		int tableStyle = style | SWT.CHECK | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL | SWT.BORDER;
+		Table table = null;
+		if (toolkit != null) {
+			table = toolkit.createTable(parent, tableStyle);
+		} else {
+			table = new Table(parent, tableStyle);
+		}
+
+		return new CachedCheckboxTableViewer(table);
+	}
+
+	/*
+	 * Overridden to hook a listener on the job and set the deferred content
+	 * provider to synchronous mode before a filter is done.
+	 *
+	 * @see
+	 * org.eclipse.e4.ui.dialogs.filteredtree.FilteredTable#doCreateRefreshJob()
+	 */
+	@Override
+	protected Job doCreateRefreshJob() {
+		Job filterJob = super.doCreateRefreshJob();
+		filterJob.addJobChangeListener(new JobChangeAdapter() {
+			@Override
+			public void done(IJobChangeEvent event) {
+				getDisplay().asyncExec(() -> {
+					if (getViewer().getTable().isDisposed()) {
+						return;
+					}
+					getViewer().restoreCachedState();
+				});
+			}
+		});
+		return filterJob;
+	}
+
+	@Override
+	protected Text doCreateFilterText(Composite parent) {
+		// Overridden so the text gets create using the toolkit if we have one
+		Text parentText = super.doCreateFilterText(parent);
+		if (toolkit != null) {
+			int style = parentText.getStyle();
+			parentText.dispose();
+			return toolkit.createText(parent, null, style);
+		}
+		return parentText;
+	}
+
+	@Override
+	public CachedCheckboxTableViewer getViewer() {
+		return (CachedCheckboxTableViewer) super.getViewer();
+	}
+
+	@Override
+	protected long getRefreshJobDelay() {
+		return FILTER_DELAY;
+	}
+
+	/**
+	 * Add wildcard at the beginning of filter string if user did not added
+	 * wildcard himself.
+	 */
+	@Override
+	protected String getFilterString() {
+		String original = super.getFilterString();
+		String asterisk = "*"; //$NON-NLS-1$
+		if (original != null && !original.equals(getInitialText()) && !original.startsWith(asterisk)) {
+			return asterisk + original;
+		}
+		return original;
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/BaseExportWizardPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/BaseExportWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,16 +28,16 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.window.Window;
 import org.eclipse.pde.core.IModel;
 import org.eclipse.pde.internal.core.FeatureModelManager;
 import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
-import org.eclipse.pde.internal.ui.parts.WizardCheckboxTreePart;
-import org.eclipse.pde.internal.ui.shared.CachedCheckboxTreeViewer;
+import org.eclipse.pde.internal.ui.parts.WizardCheckboxTablePart;
+import org.eclipse.pde.internal.ui.shared.CachedCheckboxTableViewer;
 import org.eclipse.pde.internal.ui.wizards.ListUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -47,7 +47,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
-import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.PlatformUI;
@@ -62,29 +62,14 @@ public abstract class BaseExportWizardPage extends AbstractExportWizardPage {
 	protected JARSigningTab fJARSiginingTab;
 	protected TabFolder fTabFolder;
 
-	private class ExportListProvider implements ITreeContentProvider {
+	private class ExportListProvider implements IStructuredContentProvider {
 		@Override
 		public Object[] getElements(Object parent) {
 			return getListElements();
 		}
-
-		@Override
-		public Object[] getChildren(Object parentElement) {
-			return new Object[0];
-		}
-
-		@Override
-		public Object getParent(Object element) {
-			return null;
-		}
-
-		@Override
-		public boolean hasChildren(Object element) {
-			return false;
-		}
 	}
 
-	class ExportPart extends WizardCheckboxTreePart {
+	class ExportPart extends WizardCheckboxTablePart {
 		public ExportPart(String label, String[] buttonLabels) {
 			super(label, buttonLabels);
 		}
@@ -183,13 +168,13 @@ public abstract class BaseExportWizardPage extends AbstractExportWizardPage {
 		gd.widthHint = 150;
 		gd.horizontalSpan = 2;
 
-		CachedCheckboxTreeViewer viewer = fExportPart.getTreeViewer();
+		CachedCheckboxTableViewer viewer = fExportPart.getTableViewer();
 		viewer.setContentProvider(new ExportListProvider());
 		viewer.setLabelProvider(PDEPlugin.getDefault().getLabelProvider());
 		viewer.setComparator(ListUtil.PLUGIN_COMPARATOR);
 		viewer.addDoubleClickListener(event -> {
-			TreeItem firstTI = fExportPart.getTreeViewer().getTree().getSelection()[0];
-			fExportPart.getTreeViewer().setChecked(firstTI.getData(), !firstTI.getChecked());
+			TableItem firstTI = fExportPart.getTableViewer().getTable().getSelection()[0];
+			fExportPart.getTableViewer().setChecked(firstTI.getData(), !firstTI.getChecked());
 			fExportPart.updateCounterLabel();
 		});
 		Object input = getInput();
@@ -201,7 +186,7 @@ public abstract class BaseExportWizardPage extends AbstractExportWizardPage {
 				}
 			}
 		}
-		fExportPart.getTreeViewer().setInput(getInput());
+		fExportPart.getTableViewer().setInput(getInput());
 	}
 
 	protected abstract Object getInput();
@@ -243,7 +228,7 @@ public abstract class BaseExportWizardPage extends AbstractExportWizardPage {
 		//scroll-down viewer to first one
 		fExportPart.setSelection(checked.toArray());
 		if (!checked.isEmpty()) {
-			fExportPart.getTreeViewer().reveal(checked.get(0));
+			fExportPart.getTableViewer().reveal(checked.get(0));
 		}
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/CrossPlatformExportPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/CrossPlatformExportPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -78,8 +78,8 @@ public class CrossPlatformExportPage extends AbstractExportWizardPage {
 		}
 
 		@Override
-		public void updateCounter(int count) {
-			super.updateCounter(count);
+		public void updateCounterLabel() {
+			super.updateCounterLabel();
 			pageChanged();
 		}
 
@@ -148,7 +148,7 @@ public class CrossPlatformExportPage extends AbstractExportWizardPage {
 				Configuration c = (Configuration) item.getData();
 				if (c.equals(config)) {
 					fPlatformPart.getTableViewer().setChecked(c, true);
-					fPlatformPart.updateCounter(1);
+					fPlatformPart.updateCounterLabel();
 				}
 			}
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/imports/PluginImportWizardExpressPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/imports/PluginImportWizardExpressPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2003, 2019 IBM Corporation and others.
+ *  Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -77,11 +77,6 @@ public class PluginImportWizardExpressPage extends BaseImportWizardSecondPage {
 	class TablePart extends WizardCheckboxTablePart {
 		public TablePart(String mainLabel, String[] buttonLabels) {
 			super(mainLabel, buttonLabels);
-		}
-
-		@Override
-		public void updateCounter(int count) {
-			super.updateCounter(count);
 		}
 
 		@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/templates/TemplateSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/templates/TemplateSelectionPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2018 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -64,8 +64,8 @@ public class TemplateSelectionPage extends WizardPage {
 		}
 
 		@Override
-		protected void updateCounter(int amount) {
-			super.updateCounter(amount);
+		public void updateCounterLabel() {
+			super.updateCounterLabel();
 			if (getContainer() != null) {
 				getContainer().updateButtons();
 			}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateBuildpathWizardPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateBuildpathWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2016 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -54,8 +54,8 @@ public class UpdateBuildpathWizardPage extends WizardPage {
 		}
 
 		@Override
-		public void updateCounter(int count) {
-			super.updateCounter(count);
+		public void updateCounterLabel() {
+			super.updateCounterLabel();
 			dialogChanged();
 		}
 


### PR DESCRIPTION
By using the FilteredTable, we get a quick-filter for all extending parts for free. This includes:

- The Cross-platform page of the "Deployable features" export wizard.
- The Update Java Classpath page of the "Update classpath..." action
- The Selection page of the "Import Plug-ins and Fragments" wizard
- The Update Java Classpath page of the "Plug-in from Existing JAR Archives" wizard.
- The Template Selection page of the "Plug-in Project" page.

Together with the quick-filter comes a caching of the checked table items. Those elements remain checked, even if currently hidden by the filter and will be restored once they become visible again.

Furthermore, the PluginListPage has been adapted to use a CheckboxTablePart rather than a CheckboxTreePart (effectively reverting 4c1edad836207649d0dd9fbeee29de301c7d2a86), to match the list of plugins that it displays.

Contributes to https://github.com/eclipse-pde/eclipse.pde/issues/1497