### PR TITLE
[API-Tools] Do not assume a project is named like its directory

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.700.qualifier
+Bundle-Version: 1.3.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiModelFactory.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiModelFactory.java
@@ -122,7 +122,7 @@ public class ApiModelFactory {
 		IResource resource = model.getUnderlyingResource();
 		IProject project = resource != null ? resource.getProject() : null;
 		if (project != null && project.exists() && !Util.isBinaryProject(project)) {
-			component = new ProjectComponent(baseline, location, model, getBundleID());
+			component = new ProjectComponent(baseline, location, project, model, getBundleID());
 		} else {
 			component = new BundleComponent(baseline, location, getBundleID());
 		}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectComponent.java
@@ -101,10 +101,8 @@ public class ProjectComponent extends BundleComponent {
 	 * @param model the given model
 	 * @throws CoreException if unable to create the API component
 	 */
-	public ProjectComponent(IApiBaseline baseline, String location, IPluginModelBase model, long bundleid) throws CoreException {
+	public ProjectComponent(IApiBaseline baseline, String location, IProject project, IPluginModelBase model, long bundleid) throws CoreException {
 		super(baseline, location, bundleid);
-		IPath path = IPath.fromOSString(location);
-		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(path.lastSegment());
 		this.fProject = JavaCore.create(project);
 		this.fModel = model;
 	}


### PR DESCRIPTION
Use the existing IProject, do not (incorrectly) derive it from the directory name.

Fixes #1687.