### PR TITLE
Remove listeners in MinimalState if bundle is stopped

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -424,6 +424,8 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		workspace.removeSaveParticipant(PLUGIN_ID);
 		workspace.removeResourceChangeListener(bndResourceChangeListener);
+
+		MinimalState.shutdown();
 	}
 
 	/**


### PR DESCRIPTION
This change adapts the listeners that have been added with 24e9bb548b0de8c8ea79ee70d28096e28202da31 so that they are removed again, once the bundle is shut down and thus makes the classloader eligible for garbage collection.