### PR TITLE
Inline call to BundleHelper.getPlatformAdmin().getFactory()

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
@@ -49,7 +49,6 @@ import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateDelta;
-import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -111,16 +110,10 @@ public class MinimalState {
 
 	private boolean fNoProfile;
 
-	protected static StateObjectFactory stateObjectFactory;
-
 	protected String fSystemBundle = IPDEBuildConstants.BUNDLE_OSGI;
 
-	static {
-		stateObjectFactory = BundleHelper.getPlatformAdmin().getFactory();
-	}
-
 	protected MinimalState(MinimalState state) {
-		this.fState = stateObjectFactory.createState(state.fState);
+		this.fState = BundleHelper.getPlatformAdmin().getFactory().createState(state.fState);
 		this.fState.setPlatformProperties(state.fState.getPlatformProperties());
 		this.fState.setResolver(BundleHelper.getPlatformAdmin().createResolver());
 		this.fId = state.fId;
@@ -213,8 +206,8 @@ public class MinimalState {
 		try {
 			// OSGi requires a dictionary over any map
 			Dictionary<String, String> dictionaryManifest = FrameworkUtil.asDictionary(manifest);
-			BundleDescription descriptor = stateObjectFactory.createBundleDescription(fState, dictionaryManifest,
-					bundleLocation.getAbsolutePath(), bundleId == -1 ? getNextId() : bundleId);
+			BundleDescription descriptor = BundleHelper.getPlatformAdmin().getFactory().createBundleDescription(fState,
+					dictionaryManifest, bundleLocation.getAbsolutePath(), bundleId == -1 ? getNextId() : bundleId);
 			// new bundle
 			if (bundleId == -1 || !fState.updateBundle(descriptor)) {
 				fState.addBundle(descriptor);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,7 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.target.LoadTargetDefinitionJob;
+import org.eclipse.pde.internal.build.BundleHelper;
 import org.eclipse.pde.internal.core.plugin.ExternalFragmentModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModelBase;
@@ -77,7 +78,7 @@ public class PDEState extends MinimalState {
 	}
 
 	private void createNewTargetState(boolean resolve, URI[] uris, IProgressMonitor monitor) {
-		fState = stateObjectFactory.createState(resolve);
+		fState = BundleHelper.getPlatformAdmin().getFactory().createState(resolve);
 		if (resolve) {
 			final String systemBSN = getSystemBundle();
 			Comparator<BaseDescription> policy = systemBundlesFirst(systemBSN)


### PR DESCRIPTION
As a result of 14f66ae9e57d5f7a03973a41f01ef77a6f77c474, it might happen
that the MinimalState is shut down, even though it was never started. In
such a case, the class is implicitly loaded while stopping the plug-in.

When loading this class, the "stateObjectFactory" is initialized using
the PlatformAdmin provided by the PDE Build bundle. If this bundle is
stopped before the PDE Core bundle, an exception is thrown because the
PlatformAdmin is no longer available.

The BundleHelper is already cached by the PDE Build plug-in and can
therefore be called directly, making the "stateObjectFactory" field
obsolete.

Closes https://github.com/eclipse-pde/eclipse.pde/issues/1714