### PR TITLE
Allow  Eclipse 4 contributions to select svg files via the find dialog

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/AbstractIconDialogWithScopeAndFilter.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/AbstractIconDialogWithScopeAndFilter.java
@@ -326,6 +326,7 @@ public abstract class AbstractIconDialogWithScopeAndFilter extends FilteredContr
 		private final StringMatcher matcherGif;
 		private final StringMatcher matcherJpg;
 		private final StringMatcher matcherPng;
+		private final StringMatcher matcherSvg;
 		private final StringMatcher matcherBinFolder;
 		private final Filter filter;
 		private boolean includeNonBundles;
@@ -335,6 +336,7 @@ public abstract class AbstractIconDialogWithScopeAndFilter extends FilteredContr
 			matcherGif = new StringMatcher("*" + filter.namePattern + "*.gif", true, false); //$NON-NLS-1$//$NON-NLS-2$
 			matcherJpg = new StringMatcher("*" + filter.namePattern + "*.jpg", true, false); //$NON-NLS-1$//$NON-NLS-2$
 			matcherPng = new StringMatcher("*" + filter.namePattern + "*.png", true, false); //$NON-NLS-1$//$NON-NLS-2$
+			matcherSvg = new StringMatcher("*" + filter.namePattern + "*.svg", true, false); //$NON-NLS-1$//$NON-NLS-2$
 			matcherBinFolder = new StringMatcher("bin/*", true, false); //$NON-NLS-1$
 			this.callback = callback;
 			this.filter = filter;
@@ -383,7 +385,8 @@ public abstract class AbstractIconDialogWithScopeAndFilter extends FilteredContr
 						} else if (resource.getType() == IResource.FILE && !resource.isLinked()) {
 							final String path = resource.getProjectRelativePath().toString();
 							if (!matcherBinFolder.match(path)
-									&& (matcherGif.match(path) || matcherPng.match(path) || matcherJpg.match(path))) {
+									&& (matcherGif.match(path) || matcherPng.match(path)
+											|| matcherJpg.match(path) | matcherSvg.match(path))) {
 								if (E.notEmpty(filter.getPackages())) {
 									if (!filter.getPackages().contains(
 											resource.getProjectRelativePath().removeLastSegments(1).toOSString())) {


### PR DESCRIPTION
With the svg support in SWT we should also allow the selection of svg files for Eclipse 4 application model elements.

Fixes #https://github.com/eclipse-platform/eclipse.platform.ui/issues/2911