### PR TITLE
Reduce re-computation of plugins included in Eclipse/OSGi launches

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 https://github.com/eclipse-pde/eclipse.pde/pull/1665
+https://github.com/eclipse-pde/eclipse.pde/pull/1724

--- a/ui/org.eclipse.pde.launching/.settings/.api_filters
+++ b/ui/org.eclipse.pde.launching/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.pde.launching" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="Removal of overriden EquinoxLaunchConfiguration.preLaunchCheck() method is falsely considered a addition." id="924844039">
+            <message_arguments>
+                <message_argument value="3.13.400"/>
+                <message_argument value="3.13.300"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
@@ -207,7 +207,7 @@ public class LaunchArgumentsHelper {
 		return dir;
 	}
 
-	public static Map<String, Object> getVMSpecificAttributesMap(ILaunchConfiguration config) throws CoreException {
+	public static Map<String, Object> getVMSpecificAttributesMap(ILaunchConfiguration config, Set<IPluginModelBase> plugins) throws CoreException {
 		Map<String, Object> map = new HashMap<>(2);
 		String javaCommand = config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_JAVA_COMMAND, (String) null);
 		map.put(IJavaLaunchConfigurationConstants.ATTR_JAVA_COMMAND, javaCommand);
@@ -215,7 +215,7 @@ public class LaunchArgumentsHelper {
 		if (TargetPlatform.getOS().equals("macosx")) { //$NON-NLS-1$
 			ModelEntry entry = PluginRegistry.findEntry("org.eclipse.jdt.debug"); //$NON-NLS-1$
 			if (entry != null) {
-				IVMInstall vmInstall = VMHelper.getVMInstall(config);
+				IVMInstall vmInstall = VMHelper.getVMInstall(config, plugins);
 				if (vmInstall instanceof AbstractVMInstall) {
 					String javaVersion = ((AbstractVMInstall) vmInstall).getJavaVersion();
 					String[] javaVersionSegments = javaVersion.split("\\."); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchValidationOperation.java
@@ -84,7 +84,7 @@ public class LaunchValidationOperation implements IWorkspaceRunnable {
 	}
 
 	protected IExecutionEnvironment[] getMatchingEnvironments() throws CoreException {
-		IVMInstall install = VMHelper.getVMInstall(fLaunchConfiguration);
+		IVMInstall install = VMHelper.getVMInstall(fLaunchConfiguration, fModels);
 		return install == null ? new IExecutionEnvironment[0] : getMatchingEEs(install);
 	}
 

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -206,8 +207,7 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 	}
 
 	@Override
-	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
-		fWorkspaceLocation = null;
+	Set<IPluginModelBase> computeLaunchedPlugins(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
 		if (configuration.getAttribute(IPDELauncherConstants.GENERATE_PROFILE, false)) {
 			fFeatures = new HashMap<>();
 		} else {
@@ -215,7 +215,12 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 		}
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, false, fFeatures);
 		fAllBundles = fModels.keySet().stream().collect(Collectors.groupingBy(m -> m.getPluginBase().getId()));
+		return fModels.keySet();
+	}
 
+	@Override
+	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
+		fWorkspaceLocation = null;
 		validateConfigIni(configuration);
 		super.preLaunchCheck(configuration, launch, monitor);
 	}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EquinoxLaunchConfiguration.java
@@ -23,13 +23,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.pde.core.plugin.IFragmentModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -185,15 +185,14 @@ public class EquinoxLaunchConfiguration extends AbstractPDELaunchConfiguration {
 	}
 
 	@Override
-	protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
+	Set<IPluginModelBase> computeLaunchedPlugins(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, true);
 
 		if (!RequirementHelper.addApplicationLaunchRequirements(List.of(IPDEBuildConstants.BUNDLE_OSGI), configuration, fModels)) {
 			throw new CoreException(Status.error(PDEMessages.EquinoxLaunchConfiguration_oldTarget));
 		}
 		fAllBundles = fModels.keySet().stream().collect(Collectors.groupingBy(m -> m.getPluginBase().getId(), HashMap::new, Collectors.toCollection(ArrayList::new)));
-
-		super.preLaunchCheck(configuration, launch, monitor);
+		return fModels.keySet();
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -128,7 +128,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 
 	@Override
 	public IVMRunner getVMRunner(ILaunchConfiguration configuration, String mode) throws CoreException {
-		IVMInstall launcher = VMHelper.createLauncher(configuration);
+		IVMInstall launcher = VMHelper.createLauncher(configuration, fModels.keySet());
 		return launcher.getVMRunner(mode);
 	}
 
@@ -279,7 +279,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		programArgs.add("-testpluginname"); //$NON-NLS-1$
 		programArgs.add(testPlugin.getId());
 
-		IVMInstall launcher = VMHelper.createLauncher(configuration);
+		IVMInstall launcher = VMHelper.createLauncher(configuration, fModels.keySet());
 		boolean isModular = JavaRuntime.isModularJava(launcher);
 		if (isModular) {
 			VMHelper.addNewArgument(vmArguments, "--add-modules", "ALL-SYSTEM"); //$NON-NLS-1$//$NON-NLS-2$
@@ -412,7 +412,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 
 	@Override
 	public Map<String, Object> getVMSpecificAttributesMap(ILaunchConfiguration configuration) throws CoreException {
-		return LaunchArgumentsHelper.getVMSpecificAttributesMap(configuration);
+		return LaunchArgumentsHelper.getVMSpecificAttributesMap(configuration, fModels.keySet());
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/JREBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/JREBlock.java
@@ -18,6 +18,7 @@ import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -29,7 +30,9 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.util.VMUtil;
+import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
 import org.eclipse.pde.internal.launching.launcher.VMHelper;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.SWTFactory;
@@ -227,7 +230,10 @@ public class JREBlock {
 			}
 			// Try to get a default EE based on the selected plug-ins in the config
 			if (eeId == null) {
-				eeId = VMHelper.getDefaultEEName(config);
+				boolean isOSGiLaunch = config.getType().getIdentifier()
+						.equals(IPDELauncherConstants.OSGI_CONFIGURATION_TYPE);
+				Set<IPluginModelBase> plugins = BundleLauncherHelper.getMergedBundleMap(config, isOSGiLaunch).keySet();
+				eeId = VMHelper.getDefaultEEName(plugins);
 			}
 			if (eeId == null) {
 				vmInstallName = VMHelper.getDefaultVMInstallName(config);

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -547,11 +547,10 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 
 		// Specify the output folder names
 		programArgs.add("-dev"); //$NON-NLS-1$
-		programArgs
-				.add(ClasspathHelper
-						.getDevEntriesProperties(
-								getConfigurationDirectory(configuration).toString() + "/dev.properties", fAllBundles) //$NON-NLS-1$
-						.toUri().toString());
+		programArgs.add(ClasspathHelper
+				.getDevEntriesProperties(getConfigurationDirectory(configuration).toString() + "/dev.properties", //$NON-NLS-1$
+						fAllBundles)
+				.toUri().toString());
 
 		// Create the .options file if tracing is turned on
 		if (configuration.getAttribute(IPDELauncherConstants.TRACING, false) && !IPDELauncherConstants.TRACING_NONE
@@ -589,7 +588,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 
 		programArgs.add("-testpluginname"); //$NON-NLS-1$
 		programArgs.add(getTestPluginId(configuration));
-		IVMInstall launcher = VMHelper.createLauncher(configuration);
+		IVMInstall launcher = VMHelper.createLauncher(configuration, fModels.keySet());
 		boolean isModular = JavaRuntime.isModularJava(launcher);
 		if (isModular) {
 			VMHelper.addNewArgument(vmArguments, "--add-modules", "ALL-SYSTEM"); //$NON-NLS-1$//$NON-NLS-2$
@@ -1024,7 +1023,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 
 	@Override
 	public IVMRunner getVMRunner(ILaunchConfiguration configuration, String mode) throws CoreException {
-		IVMInstall launcher = VMHelper.createLauncher(configuration);
+		IVMInstall launcher = VMHelper.createLauncher(configuration, fModels.keySet());
 		return launcher.getVMRunner(mode);
 	}
 
@@ -1157,7 +1156,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 
 	@Override
 	public Map<String, Object> getVMSpecificAttributesMap(ILaunchConfiguration configuration) throws CoreException {
-		return LaunchArgumentsHelper.getVMSpecificAttributesMap(configuration);
+		return LaunchArgumentsHelper.getVMSpecificAttributesMap(configuration, fModels.keySet());
 	}
 
 	@Override


### PR DESCRIPTION
This ensures consistency and reduces calls of `DependencyManager.findRequirementsClosure()`.