### PR TITLE
Prefer explicitly included plugins for Eclipse/OSGi launches

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -262,7 +262,7 @@ public class DependencyManager {
 	 *
 	 * @return a set of bundle ids
 	 */
-	private static Collection<NameVersionDescriptor> getImplicitDependencies() {
+	public static Collection<NameVersionDescriptor> getImplicitDependencies() {
 		try {
 			ITargetPlatformService service = PDECore.getDefault().acquireService(ITargetPlatformService.class);
 			if (service != null) {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathresolver/ClasspathResolverTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathresolver/ClasspathResolverTest.java
@@ -357,8 +357,7 @@ public class ClasspathResolverTest {
 	@SafeVarargs
 	private static void createWorkspacePluginProjects(
 			Entry<NameVersionDescriptor, Map<String, String>>... workspacePlugins) throws CoreException {
-		Set<NameVersionDescriptor> descriptions = Map.ofEntries(workspacePlugins).keySet();
-		List<IProject> pluginProjects = ProjectUtils.createWorkspacePluginProjects(descriptions);
+		List<IProject> pluginProjects = ProjectUtils.createWorkspacePluginProjects(Map.ofEntries(workspacePlugins));
 		while (pluginProjects.stream().anyMatch(ClasspathResolverTest::isUpdatePending)) {
 			Thread.yield(); // await async classpath update of projects
 		}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/LaunchConfigurationMigrationTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/LaunchConfigurationMigrationTest.java
@@ -34,8 +34,8 @@ public class LaunchConfigurationMigrationTest extends AbstractLaunchTest {
 
 	@BeforeClass
 	public static void setupPluginProjects() throws Exception {
-		ProjectUtils.createPluginProject("org.eclipse.pde.plugin1", "org.eclipse.pde.plugin1", null);
-		ProjectUtils.createPluginProject("org.eclipse.pde.plugin2", "org.eclipse.pde.plugin2", null);
+		ProjectUtils.createPluginProject("org.eclipse.pde.plugin1", "org.eclipse.pde.plugin1", "0.0.0");
+		ProjectUtils.createPluginProject("org.eclipse.pde.plugin2", "org.eclipse.pde.plugin2", "0.0.0");
 	}
 
 	@Test


### PR DESCRIPTION
When launching an application create a new Equinox resolver state, where explicitly included plugins/bundles are preferred and compute the requirements closure from that state. This avoids adding other providers of a capability if another provider is already (explicitly) included in a launch, just because the former is wired to the requirement in the target-platform state. Potentially this also makes the set of launched plugins more compact.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1604

Alternative approach to https://github.com/eclipse-pde/eclipse.pde/pull/1618.

Requires (and currently includes)
- https://github.com/eclipse-pde/eclipse.pde/pull/1724