### PR TITLE
Add FreeBSD platforms' build.

### DIFF
--- a/build/org.eclipse.pde.build/scripts/productBuild/allElements.xml
+++ b/build/org.eclipse.pde.build/scripts/productBuild/allElements.xml
@@ -1,5 +1,5 @@
 <!--
-     Copyright (c) 2006, 2008 IBM Corporation and others.
+     Copyright (c) 2006, 2025 IBM Corporation and others.
 
      This program and the accompanying materials
      are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
     
      Contributors:
          IBM Corporation - initial API and implementation
+         Tue Ton - support for FreeBSD
  -->
 <project name="Product Build allElements Delegator">
 	<property name="defaultAssemblyEnabled" value="true" />
@@ -66,6 +67,13 @@
 		</ant>
  	</target>
 	
+	<property name="assemble.org.eclipse.pde.build.container.feature.freebsd.gtk.x86_64" value="true" />
+	<target name="assemble.org.eclipse.pde.build.container.feature.freebsd.gtk.x86_64">
+		<ant antfile="${assembleScriptName}" dir="${buildDirectory}">
+			<property name="archiveName" value="${archiveNamePrefix}-freebsd.gtk.x86_64"/>
+		</ant>
+	</target>
+
 	<property name="assemble.org.eclipse.pde.build.container.feature.group.group.group" value="true" />
  	<target name="assemble.org.eclipse.pde.build.container.feature.group.group.group">
  		<ant antfile="${assembleScriptName}" dir="${buildDirectory}">			

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/Utils.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *      IBM Corporation - initial API and implementation
+ *      Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.build;
 
@@ -615,7 +616,7 @@ public final class Utils implements IPDEBuildConstants, IBuildPropertiesConstant
 			arguments.add("-sf"); //$NON-NLS-1$
 			arguments.add(links[i]);
 			arguments.add(links[i + 1]);
-			script.printExecTask("ln", dir, arguments, "Linux"); //$NON-NLS-1$ //$NON-NLS-2$
+			script.printExecTask("ln", dir, arguments, "Linux,FreeBSD"); //$NON-NLS-1$ //$NON-NLS-2$
 			arguments.clear();
 		}
 	}

--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/builder/ModelBuildScriptGenerator.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/builder/ModelBuildScriptGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which accompanies this distribution,
@@ -10,6 +10,7 @@
  * 
  * Contributors: IBM - Initial API and implementation Prosyst - create proper
  * OSGi bundles (bug 174157)
+ *     Tue Ton - support for FreeBSD
  ******************************************************************************/
 package org.eclipse.pde.internal.build.builder;
 
@@ -954,7 +955,7 @@ public class ModelBuildScriptGenerator extends AbstractBuildScriptGenerator {
 		for (int i = 0; i < links.length; i += 2) {
 			arguments.add(links[i]);
 			arguments.add(links[i + 1]);
-			script.printExecTask("ln -s", dir, arguments, "Linux"); //$NON-NLS-1$ //$NON-NLS-2$
+			script.printExecTask("ln -s", dir, arguments, "Linux,FreeBSD"); //$NON-NLS-1$ //$NON-NLS-2$
 			arguments.clear();
 		}
 	}

--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/JNLPGenerator.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/JNLPGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2021 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     G&H Softwareentwicklung GmbH - internationalization implementation (bug 150933)
  *     Michael Seele -  remove offline-allowed  (bug 153403)
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 
 package org.eclipse.pde.internal.build.tasks;
@@ -333,6 +334,9 @@ public class JNLPGenerator extends DefaultHandler {
 		}
 		if ("linux".equalsIgnoreCase(os)) { //$NON-NLS-1$
 			return "Linux"; //$NON-NLS-1$
+		}
+		if ("freebsd".equalsIgnoreCase(os)) { //$NON-NLS-1$
+			return "FreeBSD"; //$NON-NLS-1$
 		}
 		if ("solaris".equalsIgnoreCase(os)) { //$NON-NLS-1$
 			return "Solaris"; //$NON-NLS-1$

--- a/build/org.eclipse.pde.build/templates/packager/customTargets.xml
+++ b/build/org.eclipse.pde.build/templates/packager/customTargets.xml
@@ -25,4 +25,10 @@
 		</ant>
 	</target>
 		
+	<target name="assemble.freebsd.gtk.x86_64.xml">
+		<ant antfile="${assembleScriptName}" >
+			<property name="archiveName" value="${archiveNamePrefix}-freebsd.gtk.x86_64.zip"/>
+		</ant>
+	</target>
+
 </project>

--- a/build/org.eclipse.pde.build/templates/packager/packaging.properties
+++ b/build/org.eclipse.pde.build/templates/packager/packaging.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2006, 2016 IBM Corporation and others.
+# Copyright (c) 2006, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 #
 # Contributors:
 #     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
 ###############################################################################
 # The chmod and links must indicate a path relative to the root directory.
 
@@ -20,3 +21,4 @@ root.permissions.755=eclipse,*.so*
 
 root.win32.win32.x86_64=eclipse.exe, eclipsec.exe
 root.linux.gtk.x86_64=eclipse,libcairo-swt.so,about_files/,about.html,icon.xpm
+root.freebsd.gtk.x86_64=eclipse,libcairo-swt.so,about_files/,about.html,icon.xpm

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/ProductExportOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/exports/ProductExportOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2022 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 477527
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.core.exports;
 
@@ -374,6 +375,9 @@ public class ProductExportOperation extends FeatureExportOperation {
 				switch (config[0]) {
 					case "win32": //$NON-NLS-1$
 					images = getWin32Images(info);
+					break;
+				case "freebsd": //$NON-NLS-1$
+					images = getExpandedPath(info.getIconPath(ILauncherInfo.FREEBSD_ICON));
 					break;
 				case "linux": //$NON-NLS-1$
 					images = getExpandedPath(info.getIconPath(ILauncherInfo.LINUX_ICON));

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IArgumentsInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/IArgumentsInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2018 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -11,17 +11,20 @@
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.core.iproduct;
 
 public interface IArgumentsInfo extends IProductObject {
 
 	public static final String P_PROG_ARGS = "programArgs"; //$NON-NLS-1$
+	public static final String P_PROG_ARGS_FBSD = "programArgsFbsd"; //$NON-NLS-1$
 	public static final String P_PROG_ARGS_LIN = "programArgsLin"; //$NON-NLS-1$
 	public static final String P_PROG_ARGS_MAC = "programArgsMac"; //$NON-NLS-1$
 	public static final String P_PROG_ARGS_WIN = "programArgsWin"; //$NON-NLS-1$
 
 	public static final String P_VM_ARGS = "vmArgs"; //$NON-NLS-1$
+	public static final String P_VM_ARGS_FBSD = "vmArgsFbsd"; //$NON-NLS-1$
 	public static final String P_VM_ARGS_LIN = "vmArgsLin"; //$NON-NLS-1$
 	public static final String P_VM_ARGS_MAC = "vmArgsMac"; //$NON-NLS-1$
 	public static final String P_VM_ARGS_WIN = "vmArgsWin"; //$NON-NLS-1$
@@ -33,6 +36,7 @@ public interface IArgumentsInfo extends IProductObject {
 	public static final int L_ARGS_LINUX = 1;
 	public static final int L_ARGS_MACOS = 2;
 	public static final int L_ARGS_WIN32 = 3;
+	public static final int L_ARGS_FREEBSD = 4;
 
 	public static final int L_ARGS_ARCH_ALL = 0;
 	public static final int L_ARGS_ARCH_X86 = 1;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/ILauncherInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/iproduct/ILauncherInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2024 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
  *     SAP SE - support macOS bundle URL types
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.core.iproduct;
 
@@ -19,6 +20,7 @@ import java.util.List;
 
 public interface ILauncherInfo extends IProductObject {
 
+	String FREEBSD_ICON = "freebsdIcon"; //$NON-NLS-1$
 	String LINUX_ICON = "linuxIcon"; //$NON-NLS-1$
 
 	String MACOSX_ICON = "macosxIcon"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ArgumentsInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/ArgumentsInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2018 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.core.product;
 
@@ -24,12 +25,14 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 
 	private static final long serialVersionUID = 1L;
 	private final String[] fProgramArgs = new String[8];
+	private final String[] fProgramArgsFbsd = new String[8];
 	private final String[] fProgramArgsLin = new String[8];
 	private final String[] fProgramArgsMac = new String[8];
 	private final String[] fProgramArgsSol = new String[8];
 	private final String[] fProgramArgsWin = new String[8];
 
 	private final String[] fVMArgs = new String[8];
+	private final String[] fVMArgsFbsd = new String[8];
 	private final String[] fVMArgsLin = new String[8];
 	private final String[] fVMArgsMac = new String[8];
 	private final String[] fVMArgsSol = new String[8];
@@ -38,11 +41,13 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 	public ArgumentsInfo(IProductModel model) {
 		super(model);
 		this.initializeArgs(fProgramArgs);
+		this.initializeArgs(fProgramArgsFbsd);
 		this.initializeArgs(fProgramArgsLin);
 		this.initializeArgs(fProgramArgsMac);
 		this.initializeArgs(fProgramArgsSol);
 		this.initializeArgs(fProgramArgsWin);
 		this.initializeArgs(fVMArgs);
+		this.initializeArgs(fVMArgsFbsd);
 		this.initializeArgs(fVMArgsLin);
 		this.initializeArgs(fVMArgsMac);
 		this.initializeArgs(fVMArgsSol);
@@ -72,6 +77,13 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 				fProgramArgs[arch] = args;
 				if (isEditable()) {
 					firePropertyChanged(P_PROG_ARGS, old, fProgramArgs[arch]);
+				}
+				break;
+			case L_ARGS_FREEBSD :
+				old = fProgramArgsFbsd[arch];
+				fProgramArgsFbsd[arch] = args;
+				if (isEditable()) {
+					firePropertyChanged(P_PROG_ARGS_FBSD, old, fProgramArgsFbsd[arch]);
 				}
 				break;
 			case L_ARGS_LINUX :
@@ -108,6 +120,8 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 		switch (platform) {
 			case L_ARGS_ALL :
 				return fProgramArgs[arch];
+			case L_ARGS_FREEBSD :
+				return fProgramArgsFbsd[arch];
 			case L_ARGS_LINUX :
 				return fProgramArgsLin[arch];
 			case L_ARGS_MACOS :
@@ -138,6 +152,9 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 		if (Platform.OS_WIN32.equals(os)) {
 			archArgs = archIndex > 0 ? getProgramArguments(L_ARGS_WIN32, archIndex) + " " + archArgsAllPlatforms : archArgsAllPlatforms; //$NON-NLS-1$
 			return getCompleteArgs(archArgs, getProgramArguments(L_ARGS_WIN32), fProgramArgs[L_ARGS_ARCH_ALL]);
+		} else if (Platform.OS_FREEBSD.equals(os)) {
+			archArgs = archIndex > 0 ? getProgramArguments(L_ARGS_FREEBSD, archIndex) + " " + archArgsAllPlatforms : archArgsAllPlatforms; //$NON-NLS-1$
+			return getCompleteArgs(archArgs, getProgramArguments(L_ARGS_FREEBSD), fProgramArgs[L_ARGS_ARCH_ALL]);
 		} else if (Platform.OS_LINUX.equals(os)) {
 			archArgs = archIndex > 0 ? getProgramArguments(L_ARGS_LINUX, archIndex) + " " + archArgsAllPlatforms : archArgsAllPlatforms; //$NON-NLS-1$
 			return getCompleteArgs(archArgs, getProgramArguments(L_ARGS_LINUX), fProgramArgs[L_ARGS_ARCH_ALL]);
@@ -166,6 +183,13 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 				fVMArgs[arch] = args;
 				if (isEditable()) {
 					firePropertyChanged(P_VM_ARGS, old, fVMArgs[arch]);
+				}
+				break;
+			case L_ARGS_FREEBSD :
+				old = fVMArgsFbsd[arch];
+				fVMArgsFbsd[arch] = args;
+				if (isEditable()) {
+					firePropertyChanged(P_VM_ARGS_FBSD, old, fVMArgsFbsd[arch]);
 				}
 				break;
 			case L_ARGS_LINUX :
@@ -202,6 +226,8 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 		switch (platform) {
 			case L_ARGS_ALL :
 				return fVMArgs[arch];
+			case L_ARGS_FREEBSD :
+				return fVMArgsFbsd[arch];
 			case L_ARGS_LINUX :
 				return fVMArgsLin[arch];
 			case L_ARGS_MACOS :
@@ -233,6 +259,9 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 		if (Platform.OS_WIN32.equals(os)) {
 			archArgs = archIndex > 0 ? getVMArguments(L_ARGS_WIN32, archIndex) + " " + archArgsAllPlatforms : archArgsAllPlatforms; //$NON-NLS-1$
 			return getCompleteArgs(archArgs, getVMArguments(L_ARGS_WIN32), fVMArgs[L_ARGS_ARCH_ALL]);
+		} else if (Platform.OS_FREEBSD.equals(os)) {
+			archArgs = archIndex > 0 ? getVMArguments(L_ARGS_FREEBSD, archIndex) + " " + archArgsAllPlatforms : archArgsAllPlatforms; //$NON-NLS-1$
+			return getCompleteArgs(archArgs, getVMArguments(L_ARGS_FREEBSD), fVMArgs[L_ARGS_ARCH_ALL]);
 		} else if (Platform.OS_LINUX.equals(os)) {
 			archArgs = archIndex > 0 ? getVMArguments(L_ARGS_LINUX, archIndex) + " " + archArgsAllPlatforms : archArgsAllPlatforms; //$NON-NLS-1$
 			return getCompleteArgs(archArgs, getVMArguments(L_ARGS_LINUX), fVMArgs[L_ARGS_ARCH_ALL]);
@@ -267,6 +296,10 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 					parentArgs = fProgramArgs;
 					fProgramArgs[L_ARGS_ARCH_ALL] = getText(child).trim();
 					break;
+				case P_PROG_ARGS_FBSD:
+					parentArgs = fProgramArgsFbsd;
+					fProgramArgsFbsd[L_ARGS_ARCH_ALL] = getText(child).trim();
+					break;
 				case P_PROG_ARGS_LIN:
 					parentArgs = fProgramArgsLin;
 					fProgramArgsLin[L_ARGS_ARCH_ALL] = getText(child).trim();
@@ -282,6 +315,10 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 				case P_VM_ARGS:
 					parentArgs = fVMArgs;
 					fVMArgs[L_ARGS_ARCH_ALL] = getText(child).trim();
+					break;
+				case P_VM_ARGS_FBSD:
+					parentArgs = fVMArgsFbsd;
+					fVMArgsFbsd[L_ARGS_ARCH_ALL] = getText(child).trim();
 					break;
 				case P_VM_ARGS_LIN:
 					parentArgs = fVMArgsLin;
@@ -336,6 +373,15 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 			writeArchArgs(fProgramArgs, subIndent, writer);
 			writer.println(subIndent + "</" + P_PROG_ARGS + ">"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
+		if (hasArgs(fProgramArgsFbsd)) {
+			writer.print(subIndent + "<" + P_PROG_ARGS_FBSD + ">"); //$NON-NLS-1$ //$NON-NLS-2$
+			if (fProgramArgsFbsd[L_ARGS_ARCH_ALL].length() > 0) {
+				writer.print(getWritableString(fProgramArgsFbsd[L_ARGS_ARCH_ALL]));
+			}
+			writer.println();
+			writeArchArgs(fProgramArgsFbsd, subIndent, writer);
+			writer.println(subIndent + "</" + P_PROG_ARGS_FBSD + ">"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		if (hasArgs(fProgramArgsLin)) {
 			writer.print(subIndent + "<" + P_PROG_ARGS_LIN + ">"); //$NON-NLS-1$ //$NON-NLS-2$
 			if (fProgramArgsLin[L_ARGS_ARCH_ALL].length() > 0) {
@@ -371,6 +417,15 @@ public class ArgumentsInfo extends ProductObject implements IArgumentsInfo {
 			writer.println();
 			writeArchArgs(fVMArgs, subIndent, writer);
 			writer.println(subIndent + "</" + P_VM_ARGS + ">"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		if (hasArgs(fVMArgsFbsd)) {
+			writer.print(subIndent + "<" + P_VM_ARGS_FBSD + ">"); //$NON-NLS-1$ //$NON-NLS-2$
+			if (fVMArgsFbsd[L_ARGS_ARCH_ALL].length() > 0) {
+				writer.print(getWritableString(fVMArgsFbsd[L_ARGS_ARCH_ALL]));
+			}
+			writer.println();
+			writeArchArgs(fVMArgsFbsd, subIndent, writer);
+			writer.println(subIndent + "</" + P_VM_ARGS_FBSD + ">"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (hasArgs(fVMArgsLin)) {
 			writer.print(subIndent + "<" + P_VM_ARGS_LIN + ">"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/JREInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/JREInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2016 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.core.product;
 
@@ -28,17 +29,20 @@ import org.w3c.dom.NodeList;
 
 public class JREInfo extends ProductObject implements IJREInfo {
 
+	private static final String JRE_FBSD = "freebsd"; //$NON-NLS-1$
 	private static final String JRE_LIN = "linux"; //$NON-NLS-1$
 	private static final String JRE_MAC = "macos"; //$NON-NLS-1$
 	private static final String JRE_SOL = "solaris"; //$NON-NLS-1$
 	private static final String JRE_WIN = "windows"; //$NON-NLS-1$
 
 	private static final long serialVersionUID = 1L;
+	private IPath fJVMFbsd;
 	private IPath fJVMLin;
 	private IPath fJVMMac;
 	private IPath fJVMSol;
 	private IPath fJVMWin;
 
+	private boolean bIncludeFbsd;
 	private boolean bIncludeLin;
 	private boolean bIncludeMac;
 	private boolean bIncludeSol;
@@ -52,6 +56,8 @@ public class JREInfo extends ProductObject implements IJREInfo {
 	public IPath getJREContainerPath(String os) {
 		if (Platform.OS_WIN32.equals(os)) {
 			return fJVMWin;
+		} else if (Platform.OS_FREEBSD.equals(os)) {
+			return fJVMFbsd;
 		} else if (Platform.OS_LINUX.equals(os)) {
 			return fJVMLin;
 		} else if (Platform.OS_MACOSX.equals(os)) {
@@ -67,6 +73,12 @@ public class JREInfo extends ProductObject implements IJREInfo {
 			fJVMWin = jreContainerPath;
 			if (isEditable()) {
 				firePropertyChanged(JRE_WIN, old, fJVMWin);
+			}
+		} else if (Platform.OS_FREEBSD.equals(os)) {
+			IPath old = fJVMFbsd;
+			fJVMFbsd = jreContainerPath;
+			if (isEditable()) {
+				firePropertyChanged(JRE_FBSD, old, fJVMFbsd);
 			}
 		} else if (Platform.OS_LINUX.equals(os)) {
 			IPath old = fJVMLin;
@@ -105,6 +117,10 @@ public class JREInfo extends ProductObject implements IJREInfo {
 				Node includeNode = child.getAttributes().getNamedItem("include"); //$NON-NLS-1$
 				boolean include = includeNode != null ? Boolean.parseBoolean(includeNode.getNodeValue()) : true;
 				switch (child.getNodeName()) {
+				case JRE_FBSD:
+					fJVMFbsd = getPath(child);
+					bIncludeFbsd = include;
+					break;
 				case JRE_LIN:
 					fJVMLin = getPath(child);
 					bIncludeLin = include;
@@ -148,6 +164,12 @@ public class JREInfo extends ProductObject implements IJREInfo {
 	@Override
 	public void write(String indent, PrintWriter writer) {
 		writer.println(indent + "<vm>"); //$NON-NLS-1$
+		if (fJVMFbsd != null) {
+			writer.print(indent);
+			writer.print("   <" + JRE_FBSD + " include=\"" + bIncludeFbsd + "\">"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			writer.print(fJVMFbsd.toPortableString());
+			writer.println("</" + JRE_FBSD + ">"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		if (fJVMLin != null) {
 			writer.print(indent);
 			writer.print("   <" + JRE_LIN + " include=\"" + bIncludeLin + "\">"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -179,6 +201,8 @@ public class JREInfo extends ProductObject implements IJREInfo {
 	public boolean includeJREWithProduct(String os) {
 		if (Platform.OS_WIN32.equals(os)) {
 			return bIncludeWin;
+		} else if (Platform.OS_FREEBSD.equals(os)) {
+			return bIncludeFbsd;
 		} else if (Platform.OS_LINUX.equals(os)) {
 			return bIncludeLin;
 		} else if (Platform.OS_MACOSX.equals(os)) {
@@ -194,6 +218,12 @@ public class JREInfo extends ProductObject implements IJREInfo {
 			bIncludeWin = includeJRE;
 			if (isEditable()) {
 				firePropertyChanged(JRE_WIN, old, Boolean.valueOf(bIncludeWin));
+			}
+		} else if (Platform.OS_FREEBSD.equals(os)) {
+			Boolean old = Boolean.valueOf(bIncludeFbsd);
+			bIncludeFbsd = includeJRE;
+			if (isEditable()) {
+				firePropertyChanged(JRE_FBSD, old, Boolean.valueOf(bIncludeFbsd));
 			}
 		} else if (Platform.OS_LINUX.equals(os)) {
 			Boolean old = Boolean.valueOf(bIncludeLin);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/LauncherInfo.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/product/LauncherInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2024 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
  *     SAP SE - support macOS bundle URL types
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.core.product;
 
@@ -98,6 +99,9 @@ public class LauncherInfo extends ProductObject implements ILauncherInfo {
 				if (child.getNodeType() == Node.ELEMENT_NODE) {
 					String name = child.getNodeName();
 					switch (name) {
+					case "freebsd": //$NON-NLS-1$
+						parseFreeBSD((Element) child);
+						break;
 					case "linux": //$NON-NLS-1$
 						parseLinux((Element) child);
 						break;
@@ -161,6 +165,10 @@ public class LauncherInfo extends ProductObject implements ILauncherInfo {
 		}
 	}
 
+	private void parseFreeBSD(Element element) {
+		fIcons.put(FREEBSD_ICON, element.getAttribute("icon")); //$NON-NLS-1$
+	}
+
 	private void parseLinux(Element element) {
 		fIcons.put(LINUX_ICON, element.getAttribute("icon")); //$NON-NLS-1$
 	}
@@ -173,6 +181,7 @@ public class LauncherInfo extends ProductObject implements ILauncherInfo {
 		}
 		writer.println(">"); //$NON-NLS-1$
 
+		writeFreeBSD(indent + "   ", writer); //$NON-NLS-1$
 		writeLinux(indent + "   ", writer); //$NON-NLS-1$
 		writeMac(indent + "   ", writer); //$NON-NLS-1$
 		writerWin(indent + "   ", writer); //$NON-NLS-1$
@@ -224,6 +233,13 @@ public class LauncherInfo extends ProductObject implements ILauncherInfo {
 				writer.println(indent + "   </bundleUrlTypes>"); //$NON-NLS-1$
 				writer.println(indent + "</macosx>"); //$NON-NLS-1$
 			}
+		}
+	}
+
+	private void writeFreeBSD(String indent, PrintWriter writer) {
+		String icon = fIcons.get(FREEBSD_ICON);
+		if (icon != null && icon.length() > 0) {
+			writer.println(indent + "<freebsd icon=\"" + getWritableString(icon) + "\"/>"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 

--- a/ui/org.eclipse.pde.ui.templates/src/org/eclipse/pde/internal/ui/templates/rcp/IntroTemplate.java
+++ b/ui/org.eclipse.pde.ui.templates/src/org/eclipse/pde/internal/ui/templates/rcp/IntroTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473694, 486261
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 
 package org.eclipse.pde.internal.ui.templates.rcp;
@@ -173,7 +174,7 @@ public class IntroTemplate extends PDETemplateSection {
 		presentationElement.setAttribute("home-page-id", "root"); //$NON-NLS-1$ //$NON-NLS-2$
 		IPluginElement implementationElement = factory.createElement(presentationElement);
 		implementationElement.setName("implementation"); //$NON-NLS-1$
-		implementationElement.setAttribute("os", "win32,linux,macosx"); //$NON-NLS-1$ //$NON-NLS-2$
+		implementationElement.setAttribute("os", "win32,linux,macosx,freebsd"); //$NON-NLS-1$ //$NON-NLS-2$
 		if (getTargetVersion() == 3.0) {
 			implementationElement.setAttribute("style", "content/shared.css"); //$NON-NLS-1$//$NON-NLS-2$
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -18,6 +18,7 @@
  *     Kit Lo (IBM) - Bug 244461 - Duplicating colon in error message
  *     Alexander Fedorov <alexander.fedorov@arsysop.ru> - Bug 547222
  *     SAP SE - support macOS bundle URL types
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui;
 
@@ -1175,6 +1176,7 @@ public class PDEUIMessages extends NLS {
 	public static String LauncherSection_48Low;
 	public static String LauncherSection_48High;
 	public static String LauncherSection_256High;
+	public static String LauncherSection_freebsdLabel;
 	public static String LauncherSection_linuxLabel;
 	public static String LauncherSection_macLabel;
 	public static String LauncherSection_macBundleUrlTypes_DialogTitle;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ArgumentsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ArgumentsSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2019 IBM Corporation and others.
+ *  Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
@@ -52,9 +53,10 @@ import org.eclipse.ui.forms.widgets.Section;
 
 public class ArgumentsSection extends PDESection {
 
-	private static final String[] TAB_LABELS = new String[4];
+	private static final String[] TAB_LABELS = new String[5];
 	static {
 		TAB_LABELS[IArgumentsInfo.L_ARGS_ALL] = PDEUIMessages.ArgumentsSection_allPlatforms;
+		TAB_LABELS[IArgumentsInfo.L_ARGS_FREEBSD] = "freebsd"; //$NON-NLS-1$
 		TAB_LABELS[IArgumentsInfo.L_ARGS_LINUX] = "linux"; //$NON-NLS-1$
 		TAB_LABELS[IArgumentsInfo.L_ARGS_MACOS] = "macosx"; //$NON-NLS-1$
 		TAB_LABELS[IArgumentsInfo.L_ARGS_WIN32] = "win32"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ConfigurationSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ConfigurationSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
@@ -69,8 +70,8 @@ public class ConfigurationSection extends PDESection {
 	private FormEntry fCustomEntry;
 	private boolean fBlockChanges;
 
-	private static final String[] TAB_LABELS = { "linux", "macosx", "win32" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-	private static final String[] TAB_OS = { Platform.OS_LINUX, Platform.OS_MACOSX, Platform.OS_WIN32 };
+	private static final String[] TAB_LABELS = { "linux", "macosx", "win32", "freebsd" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	private static final String[] TAB_OS = { Platform.OS_LINUX, Platform.OS_MACOSX, Platform.OS_WIN32, Platform.OS_FREEBSD };
 
 	private CTabFolder fTabFolder;
 	private int fLastTab;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/JRESection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/JRESection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Benjamin Cabe <benjamin.cabe@anyware-tech.com> - bug 217908
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
@@ -81,8 +82,8 @@ public class JRESection extends PDESection {
 	private ComboViewerPart fEEsCombo;
 	private boolean fBlockChanges;
 
-	private static final String[] TAB_LABELS = { "linux", "macosx", "win32" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-	private static final String[] TAB_OS = { Platform.OS_LINUX, Platform.OS_MACOSX, Platform.OS_WIN32 };
+	private static final String[] TAB_LABELS = { "linux", "macosx", "win32", "freebsd" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	private static final String[] TAB_OS = { Platform.OS_LINUX, Platform.OS_MACOSX, Platform.OS_WIN32, Platform.OS_FREEBSD };
 
 	private CTabFolder fTabFolder;
 	private int fLastTab;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/LauncherSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/LauncherSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2024 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
  *     SAP SE - support macOS bundle URL types
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
@@ -115,6 +116,7 @@ public class LauncherSection extends PDESection {
 	private CTabFolder fTabFolder;
 	private Composite fNotebook;
 	private StackLayout fNotebookLayout;
+	private Composite fFreeBSDSection;
 	private Composite fLinuxSection;
 	private Composite fMacSection;
 	private Composite fWin32Section;
@@ -209,6 +211,7 @@ public class LauncherSection extends PDESection {
 		fNotebookLayout = new StackLayout();
 		fNotebook.setLayout(fNotebookLayout);
 
+		fFreeBSDSection = addFreeBSDSection(fNotebook, toolkit);
 		fLinuxSection = addLinuxSection(fNotebook, toolkit);
 		fMacSection = addMacSection(fNotebook, toolkit);
 		fWin32Section = addWin32Section(fNotebook, toolkit);
@@ -234,6 +237,7 @@ public class LauncherSection extends PDESection {
 		addTab("linux"); //$NON-NLS-1$
 		addTab("macosx"); //$NON-NLS-1$
 		addTab("win32"); //$NON-NLS-1$
+		addTab("freebsd"); //$NON-NLS-1$
 
 		String currentTarget = TargetPlatform.getOS();
 		if (currentTarget == null) {
@@ -248,6 +252,10 @@ public class LauncherSection extends PDESection {
 		case "macosx": //$NON-NLS-1$
 			fTabFolder.setSelection(1);
 			fNotebookLayout.topControl = fMacSection;
+			break;
+		case "freebsd": //$NON-NLS-1$
+			fTabFolder.setSelection(0);
+			fNotebookLayout.topControl = fFreeBSDSection;
 			break;
 		default:
 			fTabFolder.setSelection(0);
@@ -339,6 +347,14 @@ public class LauncherSection extends PDESection {
 			td.colspan = span;
 			label.setLayoutData(td);
 		}
+	}
+
+	private Composite addFreeBSDSection(Composite parent, FormToolkit toolkit) {
+		Composite comp = createComposite(parent, toolkit);
+		createLabel(comp, toolkit, PDEUIMessages.LauncherSection_freebsdLabel, 3);
+		fIcons.add(new IconEntry(comp, toolkit, PDEUIMessages.LauncherSection_icon, ILauncherInfo.FREEBSD_ICON));
+		toolkit.paintBordersFor(comp);
+		return comp;
 	}
 
 	private Composite addLinuxSection(Composite parent, FormToolkit toolkit) {
@@ -712,6 +728,9 @@ public class LauncherSection extends PDESection {
 	}
 
 	private String getExtension(String iconId) {
+		if (iconId.equals(ILauncherInfo.FREEBSD_ICON)) {
+			return "xpm"; //$NON-NLS-1$
+		}
 		if (iconId.equals(ILauncherInfo.LINUX_ICON)) {
 			return "xpm"; //$NON-NLS-1$
 		}
@@ -742,6 +761,9 @@ public class LauncherSection extends PDESection {
 				break;
 			case 2 :
 				fNotebookLayout.topControl = fWin32Section;
+				break;
+			case 3 :
+				fNotebookLayout.topControl = fFreeBSDSection;
 				break;
 		}
 		if (oldPage != fNotebookLayout.topControl) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PropertiesSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/PropertiesSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - Initial API and implementation
  *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 438509
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.product;
 
@@ -131,7 +132,7 @@ public class PropertiesSection extends TableSection {
 		private final Set<IConfigurationProperty> fExistingProperties;
 
 		private final String[] COMBO_OSLABELS = new String[] { PDEUIMessages.PropertiesSection_All, Platform.OS_LINUX,
-				Platform.OS_MACOSX, Platform.OS_WIN32 };
+				Platform.OS_MACOSX, Platform.OS_WIN32, Platform.OS_FREEBSD };
 		private final String[] COMBO_ARCHLABELS = new String[] { PDEUIMessages.PropertiesSection_All,
 				IArgumentsInfo.ARCH_X86,
 				Platform.ARCH_X86_64 };

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -20,6 +20,7 @@
 #     Kit Lo (IBM) - Bug 244461 - Duplicating colon in error message
 #     Alexander Fedorov <alexander.fedorov@arsysop.ru> - Bug 547222
 #     SAP SE - support macOS bundle URL types
+#     Tue Ton - support for FreeBSD
 ###############################################################################
 #####################################
 # PDE resource strings
@@ -670,6 +671,7 @@ LauncherSection_32High=32x32 (32-bit):
 LauncherSection_48Low=48x48 (8-bit):
 LauncherSection_48High=48x48 (32-bit):
 LauncherSection_256High=256x256 (32-bit):
+LauncherSection_freebsdLabel=A single XPM icon is required:
 LauncherSection_linuxLabel=A single XPM icon is required:
 LauncherSection_macLabel=A single ICNS file is required:
 LauncherSection_macBundleUrlTypes_DialogTitle=Scheme

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/product/ProductIntroOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/product/ProductIntroOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2015 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     EclipseSource Corporation - ongoing enhancements
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.wizards.product;
 
@@ -149,7 +150,7 @@ public class ProductIntroOperation extends BaseManifestOperation implements IVar
 		implementation.setName("implementation"); //$NON-NLS-1$
 		implementation.setAttribute("kind", "html"); //$NON-NLS-1$ //$NON-NLS-2$
 		implementation.setAttribute("style", "content/shared.css"); //$NON-NLS-1$ //$NON-NLS-2$
-		implementation.setAttribute("os", "win32,linux,macosx"); //$NON-NLS-1$ //$NON-NLS-2$
+		implementation.setAttribute("os", "win32,linux,freebsd,macosx"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		presentation.add(implementation);
 

--- a/ui/org.eclipse.ui.trace/src/org/eclipse/ui/trace/internal/TracingPreferencePage.java
+++ b/ui/org.eclipse.ui.trace/src/org/eclipse/ui/trace/internal/TracingPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     SAP - ongoing enhancements
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.ui.trace.internal;
 
@@ -92,7 +93,7 @@ public class TracingPreferencePage extends PreferencePage implements IWorkbenchP
 	 * On Linux, however, space is used as default key on ComboBoxes, leading to the editor being deactivated.
 	 * We use F2 instead.
 	 */
-	private static final int VALUE_EDITOR_ACTIVATION_KEY = Util.isLinux() ? SWT.F2 : SWT.SPACE;
+	private static final int VALUE_EDITOR_ACTIVATION_KEY = (Util.isLinux() || Util.isFreeBSD()) ? SWT.F2 : SWT.SPACE;
 
 	/** A list of {@link TracingComponent} objects to display in the UI */
 	private Map<String, TracingComponent> displayableTracingComponents = null;


### PR DESCRIPTION
Part of eclipse-platform/eclipse.platform.releng.aggregator#2959

Most changes are made to the parser of the `.product` file and its GUI editor, to support relevant elements for FreeBSD such as:
```
programArgsFbsd
vmArgsFbsd
etc.
```
