### PR TITLE
Add SVGs to org.eclipse.pde.api.tools.ui

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.ui/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.ui/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Export-Package: org.eclipse.pde.api.tools.ui.internal;x-friends:="org.eclipse.pd
  org.eclipse.pde.api.tools.ui.internal.views;x-internal:=true,
  org.eclipse.pde.api.tools.ui.internal.wizards;x-friends:="org.eclipse.pde.api.tools.tests"
 Automatic-Module-Name: org.eclipse.pde.api.tools.ui
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/compare_apis.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/compare_apis.svg
@@ -1,0 +1,764 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="compare_apis.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4817">
+      <stop
+         style="stop-color:#7695b8;stop-opacity:1"
+         offset="0"
+         id="stop4819" />
+      <stop
+         style="stop-color:#8daac8;stop-opacity:1"
+         offset="1"
+         id="stop4821" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4805">
+      <stop
+         style="stop-color:#4b82b6;stop-opacity:1"
+         offset="0"
+         id="stop4807" />
+      <stop
+         id="stop4815"
+         offset="0.79358917"
+         style="stop-color:#9ab7d5;stop-opacity:1" />
+      <stop
+         style="stop-color:#a2bcd8;stop-opacity:1"
+         offset="1"
+         id="stop4809" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817"
+       id="linearGradient4823"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#91c168;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1-7"
+       id="linearGradient3929-5-9"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539"
+       gradientTransform="matrix(0.37647059,0,0,0.37647062,-135.61764,864.58459)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-7">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-5"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-6" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-1"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient6323-7-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,1046.6356)"
+       x1="10"
+       y1="5"
+       x2="10.007812"
+       y2="6.9843998" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5068-6-9-4-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5070-8-0-4-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5072-3-6-1-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5084-3-3-2-6"
+       x1="12"
+       y1="1043.3622"
+       x2="12"
+       y2="1045.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5086-8-0-8-5"
+       x1="13"
+       y1="1043.3622"
+       x2="15.007812"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5082-1-0-8-1"
+       x1="12"
+       y1="1042.3622"
+       x2="10.007812"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5078-8-2-1-4"
+       x1="10"
+       y1="1041.3622"
+       x2="8.0078125"
+       y2="1041.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5076-5-2-9-8"
+       x1="10"
+       y1="1040.3622"
+       x2="10.007812"
+       y2="1038.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1038.3622"
+       x1="12"
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3500-5"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5088-1-4-8-6"
+       x1="14"
+       y1="1041.3622"
+       x2="14"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <radialGradient
+       r="3.4803574"
+       fy="-738.83777"
+       fx="-757.20496"
+       cy="-738.83777"
+       cx="-757.20496"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3091-1-9-6-4-6"
+       xlink:href="#linearGradient4528-9-5-7-9-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="7.549418"
+       x2="0.9375"
+       y1="4.8437853"
+       x1="0.9375"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3093-5-2-7-0-9"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2-8-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:0"
+         offset="0"
+         id="stop4286" />
+      <stop
+         id="stop4288"
+         offset="0.49999967"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:0"
+         offset="1"
+         id="stop4290" />
+    </linearGradient>
+    <linearGradient
+       y2="519.39288"
+       x2="323.26462"
+       y1="528.64294"
+       x1="323.26462"
+       gradientTransform="matrix(0.197686,0,0,0.32432277,-38.574335,887.91126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10770-6"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         id="stop10450-3-5-6-7"
+         offset="0"
+         style="stop-color:#fbdf89;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdf89;stop-opacity:1"
+         offset="0.29561663"
+         id="stop5110" />
+      <stop
+         id="stop5114"
+         offset="0.33333409"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#f3f4f0;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-5-3" />
+      <stop
+         id="stop5112"
+         offset="0.66666681"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop5108"
+         offset="0.69352579"
+         style="stop-color:#fceaaf;stop-opacity:1" />
+      <stop
+         id="stop10452-22-7-8-4"
+         offset="1"
+         style="stop-color:#fceaaf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         id="stop10442-43-2-0-9"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-5-3" />
+      <stop
+         id="stop10444-3-4-0-4"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10750-5" />
+      <stop
+         id="stop10752-8"
+         offset="0.25"
+         style="stop-color:#f1ce66;stop-opacity:1" />
+      <stop
+         id="stop10754-8"
+         offset="0.5"
+         style="stop-color:#f6e5a6;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1cf6c;stop-opacity:1"
+         offset="0.75"
+         id="stop10756-4" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10758-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         id="stop10450-0"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-2" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-96" />
+      <stop
+         id="stop10460-3"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-1"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         id="stop10416-3"
+         offset="0"
+         style="stop-color:#5078b9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6d8cbd;stop-opacity:1"
+         offset="0.5"
+         id="stop10422-8" />
+      <stop
+         id="stop10418-4"
+         offset="1"
+         style="stop-color:#5f88c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10434-4" />
+      <stop
+         id="stop10436-2"
+         offset="0.5"
+         style="stop-color:#4e6da1;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10438-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         id="stop10159-5"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-9" />
+      <stop
+         id="stop10161-55"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-5">
+      <stop
+         id="stop10398-7"
+         offset="0"
+         style="stop-color:#1b3e79;stop-opacity:1;" />
+      <stop
+         style="stop-color:#728fbf;stop-opacity:1"
+         offset="0.5"
+         id="stop10404-9" />
+      <stop
+         id="stop10400-9"
+         offset="1"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         id="stop10159-8-3"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999985"
+         id="stop10165-3-9" />
+      <stop
+         id="stop10161-5-0"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         id="stop10151-5-7-2"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b9c7df;stop-opacity:1"
+         offset="0.5"
+         id="stop10394-3" />
+      <stop
+         id="stop10153-8-1-2"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient5123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.197686,0,0,0.32432277,-50.581951,870.91846)"
+       x1="323.26462"
+       y1="528.64294"
+       x2="323.26462"
+       y2="519.39288" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient5173"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.197686,0,0,0.32432277,-50.574335,877.91787)"
+       x1="323.26462"
+       y1="528.64294"
+       x2="323.26462"
+       y2="519.39288" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       id="linearGradient3929-5-9-8"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539"
+       gradientTransform="matrix(0.37647059,0,0,0.37647062,-135.61764,871.58461)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.2"
+     inkscape:cx="16.911188"
+     inkscape:cy="6.4513204"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#linearGradient5123);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2-7-6"
+       width="4"
+       height="3.0210745"
+       x="11.992384"
+       y="1039.3628"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 14.992384,1039.3694 v 1 h 1 v -1 z"
+       id="path4313-8-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 15.989463,1041.3602 -0.997079,0.031 0.0029,1 0.9971,-0.031 z"
+       id="path4313-5-1-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 15.009737,1042.37 -3.017353,0.031 0.0088,1 3.017353,-0.031 z"
+       id="path4313-5-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 15,1038.3622 -3.007616,0.031 0.0088,1 3.007615,-0.031 z"
+       id="path4313-8"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:url(#linearGradient5173);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2-7-6-8"
+       width="4"
+       height="3.0210745"
+       x="12"
+       y="1046.3622"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 15,1046.3688 v 1 h 1 v -1 z"
+       id="path4313-8-8-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 15.997079,1048.3596 15,1048.3906 l 0.0029,1 0.9971,-0.031 z"
+       id="path4313-5-1-8-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 15.017353,1049.3694 12,1049.4004 l 0.0088,1 3.017353,-0.031 z"
+       id="path4313-5-1-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 15.007616,1045.3616 12,1045.3926 l 0.0088,1 3.007615,-0.031 z"
+       id="path4313-8-3"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image838"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAnpJREFU
+OI2Fk0tIlFEYhp8z86t/4yVTNPGClogohlBhhZdIqVRUMhEKMlxFEQVKLbqhLbTUCEwwa1lQuyJG
+jbRC8gLZhS6iKcbUDNbIoKMmTaPOOS2qURdjZ3kO3/O9nIdXKKVY69yo61NzTjdKSoQQhITpnL6Q
+Jf69i7UAZ4+1q5AQnaBgfzTNwNKSZP7HAnNzv2i6XSQANF/DLXW9Sg/wQ9f9qKrJ8d7fufmW8REH
+3W3Jau/xUWHwBZiwzuJ2LzLlmKelvu8PtL6P4XffcbkWyC1roLstWflMYP82i5QePFKiBUgAJu1O
+bNYpDAaBy3SAXRWD+EywPsyEAqRSyL//JJVCSomUEt1xiyfN6b4BcfGhGI0aiUmR1LeUAFDfUkJ2
+XhL+/gE8utdK2fkvYpUFc2e/uv7CRnVOHMWFmeLk4QcqMMiPiKggBKCACdsMygPNd0sFsDpBY4+V
+7QmhNPVYAXDnv0SmWNBiHRijnYiYSQxbrMzkDnhntJXbF6XCIAQLUmHu7FcJEeEczN9NSmQa0z+n
+CA+MYMwxzMWH17wavYCaLguX922itsvC/rQoarssNJ/KJHVjOuYPHTwbfkpyVDKBuonokFBy81Zo
+NHf2K7dHUlyYKc49/qyMRoHbo3COAonQMdTH8/ev6DUNE6QHohkNuEx7ljVWm8e5WpAIwJWCRO4P
+2ijPiKXKPA7AoYwS4iNjOJJdTmtlA2HBG5Y1rtwOUFyYKdwehWY0srAkMXf2szN+K22VjRzdUcqY
+/RN2p2NZI+Wta9cRMF/azIBlkOl5JyM2CynRqbRV1An4TxsBBsZeq/ahZ7z5+pF1fjpZCds4U3TC
+W+ffrxsXz3nBD/wAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       id="g844"
+       transform="translate(-6.9937282,-1.024912)">
+      <path
+         transform="translate(0,1036.3622)"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4005"
+         d="M 7.9991455,15.524912 11.490485,8.4869904 15.026019,15.524912 H 13.015184 L 10.518213,10.497825"
+         style="fill:url(#linearGradient4823);fill-opacity:1;stroke:#095799;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         y="1051.3789"
+         x="6.9937282"
+         height="0.99436891"
+         width="3.0273011"
+         id="rect4009"
+         style="fill:#095799;fill-opacity:1;stroke:none" />
+      <rect
+         y="1051.3789"
+         x="10.993729"
+         height="0.99436891"
+         width="5.0160389"
+         id="rect4009-1"
+         style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       transform="matrix(0.13972603,0,0,0.16234201,-43.593216,972.25873)"
+       style="display:inline;stroke-width:1.85268462"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.85268462;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.85268462"
+       transform="matrix(0.50075087,0,0,0.58180212,14.299623,445.12442)" />
+    <g
+       id="g6438"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.6219058"
+       transform="matrix(0.57167787,0,0,0.66496285,26.311225,358.34392)">
+      <g
+         id="text3782"
+         style="font-size:15.56941891px;font-family:Sans;fill:#ffffff;stroke-width:1.6219058"
+         transform="scale(0.94400511,1.0593163)" />
+    </g>
+    <g
+       transform="matrix(0.1604285,0,0,0.16135966,-52.09452,964.70814)"
+       style="display:inline;stroke-width:1.73427248"
+       id="g11331-3-1-1-4">
+      <g
+         id="g13408-8-1"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.73427248;stroke-opacity:1" />
+    </g>
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient3929-5-9);fill-opacity:1;stroke:#55429f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.5,1043.3622 c -0.690867,1.1985 -1.517266,1.5 -3,1.5 -2.2091388,0 -3.9999997,-1.7909 -4,-4 3e-7,-2.2091 1.7908612,-4 4,-4 1.492204,0 2.312494,0.2888 3,1.5 z"
+       id="path10796-2-6-2-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9.0078124,1038.8622 H 12 Z m 1.4960936,0.5 v 2.9902 z m -1.4999998,3.5 h 2.9902348 z"
+       id="path1108"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient3929-5-9-8);fill-opacity:1;stroke:#14733c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.5,1050.3622 c -0.690867,1.1985 -1.517266,1.5 -3,1.5 -2.2091388,0 -3.9999997,-1.7909 -4,-4 3e-7,-2.2091 1.7908612,-4 4,-4 1.492204,0 2.312494,0.2888 3,1.5 z"
+       id="path10796-2-6-2-3-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       d="m 11.334615,1047.2497 c -0.03726,-0.2692 -0.122425,-0.4719 -0.255489,-0.6082 -0.130409,-0.1362 -0.300734,-0.2043 -0.510979,-0.2043 -0.279443,0 -0.502995,0.1185 -0.6706584,0.3553 -0.165005,0.2333 -0.247507,0.3859 -0.247505,0.9372 -2e-6,0.6131 0.08383,0.8859 0.251498,1.139 0.1703234,0.253 0.3978684,0.3794 0.6826344,0.3794 0.212905,0 0.387223,-0.072 0.522954,-0.2189 0.135725,-0.1493 0.231534,-0.4038 0.287425,-0.7639 l 1.101796,-0.011 c -0.114442,0.6162 -0.334002,1.3216 -0.658682,1.6362 -0.324688,0.3146 -0.759817,0.4719 -1.305389,0.4719 -0.6200954,0 -1.1151044,-0.2384 -1.4850304,-0.7151 -0.367266,-0.4767 -0.550899,-0.9768 -0.550899,-1.8201 0,-0.8529 0.184963,-1.2763 0.554891,-1.7496 0.369925,-0.4769 0.870258,-0.7152 1.5009984,-0.7152 0.516298,0 0.926144,0.1361 1.229541,0.4087 0.30605,0.269 0.559493,0.9009 0.692564,1.4554 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.56941891px;line-height:125%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+       id="path3817"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscscccsscscsccc" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/configure_problem_severity.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/configure_problem_severity.svg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg3156"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="New document 3">
+  <defs
+     id="defs3158">
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="0.98171616"
+       x2="3.3833356"
+       y1="7.0159616"
+       x1="3.3833356"
+       id="linearGradient5087"
+       xlink:href="#linearGradient5081"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         id="stop5083"
+         offset="0"
+         style="stop-color:#ffe296;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8d880;stop-opacity:1"
+         offset="0.5"
+         id="stop5089" />
+      <stop
+         id="stop5085"
+         offset="1"
+         style="stop-color:#fffcd3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="0.39338252"
+       x2="6.3885393"
+       y1="7.2369323"
+       x1="6.3885393"
+       id="linearGradient5097"
+       xlink:href="#linearGradient5091"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5091"
+       inkscape:collect="always">
+      <stop
+         id="stop5093"
+         offset="0"
+         style="stop-color:#c6852e;stop-opacity:1" />
+      <stop
+         id="stop5095"
+         offset="1"
+         style="stop-color:#e1a555;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask25144">
+      <g
+         id="g25146">
+        <g
+           inkscape:label="Layer 1"
+           id="g25148"
+           style="fill:#ffffff;stroke:none;display:inline"
+           transform="translate(8.9848537,-0.99390417)">
+          <g
+             style="fill:#ffffff;stroke:none;display:inline"
+             id="g25150"
+             transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+            <rect
+               style="fill:#ffffff;fill-opacity:1;stroke:none"
+               id="rect25152"
+               width="7.4892092"
+               height="8.5590963"
+               x="15.590192"
+               y="1043.4797" />
+            <path
+               inkscape:connector-curvature="0"
+               style="font-size:7.68999243px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:125%;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.27519909;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+               d="m 1.25,1.78125 0,0.125 0,0.5 0,0.125 0.125,0 0.375,0 1.1875,1.40625 -1.21875,1.53125 -0.34375,0 -0.125,0 0,0.125 0,0.5 0,0.125 0.125,0 1.5,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 L 3.5,4.625 l 0.625,0.84375 -0.125,0 0,0.125 0,0.5 0,0.125 0.125,0 1.5,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -0.3125,0 -1.25,-1.5625 1.15625,-1.375 0.40625,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -1.5,0 -0.125,0 0,0.125 0,0.5 0,0.125 0.0625,0 L 3.5,3.25 2.9375,2.53125 l 0.0625,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -1.5,0 -0.125,0 z"
+               transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)"
+               id="path25154" />
+          </g>
+        </g>
+        <g
+           inkscape:label="Layer 1"
+           id="g25156"
+           style="fill:#ffffff;stroke:#ffffff;display:inline"
+           transform="translate(4.9852807,-7.9432158)">
+          <g
+             style="fill:#ffffff;stroke:#ffffff;display:inline"
+             id="g25158"
+             transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+            <path
+               style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               d="M 2.8125,0.90625 0.78125,5 C 0.17522066,6.0251238 0.58843406,7.4816983 1.71875,7.5 L 3,7.5 l 1,0 1.28125,0 C 6.4115665,7.4817738 6.8247794,6.0250615 6.21875,5 L 4.1875,0.90625 c -0.2942923,-0.55673837 -1.1188077,-0.46727236 -1.375,0 z"
+               id="path25160"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccccccc"
+               transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)" />
+            <path
+               sodipodi:type="arc"
+               style="fill:#ffffff;fill-opacity:1;stroke:#ffffff"
+               id="path25162"
+               sodipodi:cx="3.484375"
+               sodipodi:cy="5.484375"
+               sodipodi:rx="0.625"
+               sodipodi:ry="0.625"
+               d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+               transform="matrix(1.125929,0,0,1.125929,15.411638,1043.3738)" />
+            <path
+               style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline"
+               d="m 19.350026,1045.5028 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+               id="path25164"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="sccsccs" />
+          </g>
+        </g>
+      </g>
+    </mask>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter25166"
+       x="-0.23445988"
+       width="1.4689198"
+       y="-0.24580829"
+       height="1.4916166">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.0667455"
+         id="feGaussianBlur25168" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="8.0256044"
+     inkscape:cy="1.3124776"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="668"
+     inkscape:window-height="604"
+     inkscape:window-x="1652"
+     inkscape:window-y="473"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3164"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3161">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="translate(8.9848532,-0.99391581)"
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1">
+      <g
+         transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)"
+         id="g8472-2"
+         style="display:inline">
+        <rect
+           y="1043.4797"
+           x="15.590192"
+           height="8.5590963"
+           width="7.4892092"
+           id="rect4244"
+           style="fill:#d8424f;fill-opacity:1;stroke:none" />
+        <path
+           id="path4187"
+           transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)"
+           d="m 1.25,1.78125 0,0.125 0,0.5 0,0.125 0.125,0 0.375,0 1.1875,1.40625 -1.21875,1.53125 -0.34375,0 -0.125,0 0,0.125 0,0.5 0,0.125 0.125,0 1.5,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 L 3.5,4.625 l 0.625,0.84375 -0.125,0 0,0.125 0,0.5 0,0.125 0.125,0 1.5,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -0.3125,0 -1.25,-1.5625 1.15625,-1.375 0.40625,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -1.5,0 -0.125,0 0,0.125 0,0.5 0,0.125 0.0625,0 L 3.5,3.25 2.9375,2.53125 l 0.0625,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -1.5,0 -0.125,0 z"
+           style="font-size:7.68999243px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:125%;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.27519909;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       transform="translate(4.9852807,-7.9432158)"
+       style="display:inline"
+       id="layer1-8"
+       inkscape:label="Layer 1">
+      <g
+         transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)"
+         id="g8472"
+         style="display:inline">
+        <path
+           transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)"
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292"
+           d="M 2.8125,0.90625 0.78125,5 C 0.17522066,6.0251238 0.58843406,7.4816983 1.71875,7.5 L 3,7.5 l 1,0 1.28125,0 C 6.4115665,7.4817738 6.8247794,6.0250615 6.21875,5 L 4.1875,0.90625 c -0.2942923,-0.55673837 -1.1188077,-0.46727236 -1.375,0 z"
+           style="fill:url(#linearGradient5087);fill-opacity:1;stroke:url(#linearGradient5097);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           transform="matrix(1.125929,0,0,1.125929,15.411638,1043.3738)"
+           d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+           sodipodi:ry="0.625"
+           sodipodi:rx="0.625"
+           sodipodi:cy="5.484375"
+           sodipodi:cx="3.484375"
+           id="path4253"
+           style="fill:#502800;fill-opacity:1;stroke:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="sccsccs"
+           inkscape:connector-curvature="0"
+           id="path4253-7"
+           d="m 19.350026,1045.5028 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+           style="fill:#502800;fill-opacity:1;stroke:none;display:inline" />
+      </g>
+    </g>
+    <g
+       transform="translate(-2.0539105e-8,-1.5806884e-5)"
+       style="display:inline"
+       id="g25137"
+       mask="url(#mask25144)">
+      <g
+         transform="matrix(0.8261236,0,0,0.8261236,-0.70848,186.15135)"
+         inkscape:label="Layer 1"
+         id="layer1-4-9"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2.42094517;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter25166)">
+        <g
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:2.00652146;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g17594-4"
+           transform="matrix(1.2065384,0,0,1.2065384,1.2248827,-221.37405)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.00652146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-9"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="translate(12.005651,1037.2461)" />
+          <path
+             sodipodi:nodetypes="scccccscccccccccccccccsccccccccccscccccccccccccccccsccc"
+             inkscape:connector-curvature="0"
+             id="path6139-5-5"
+             d="m 5.2901155,1042.6691 c -0.4193865,0 -0.827937,0.074 -1.2109584,0.1863 l 0.4968033,0.6521 0.8073063,1.0246 0.7762559,-1.0246 0.4968036,-0.59 c -0.429042,-0.1444 -0.8885091,-0.2484 -1.3662107,-0.2484 z m -2.1114149,0.59 c -0.7184889,0.4103 -1.2964352,1.0016 -1.6767124,1.7388 l 0.6520553,0.093 1.2730592,0.1553 -0.1552509,-1.2731 -0.093148,-0.7141 z m 4.2228311,0 -0.093148,0.7141 -0.155251,1.2731 1.3041096,-0.1553 0.6210049,-0.061 c -0.3798299,-0.7481 -0.9503317,-1.3549 -1.6767123,-1.7698 z m -6.2100454,2.484 c -0.112404,0.383 -0.1863014,0.7916 -0.1863014,1.2109 0,0.433 0.09783,0.8481 0.2173518,1.2421 l 0.5278537,-0.4348 1.0246571,-0.7761 -1.0246571,-0.8074 z m 8.1972597,0.031 -0.5278537,0.4037 -1.024658,0.8074 1.024658,0.7762 0.4968033,0.4036 c 0.1140598,-0.3856 0.2173518,-0.7884 0.2173518,-1.211 0,-0.409 -0.079196,-0.8053 -0.1863014,-1.1799 z m -5.9616433,2.9499 -1.2730592,0.1552 -0.6210049,0.062 c 0.3807416,0.7204 0.9395255,1.3044 1.645662,1.7079 l 0.093148,-0.6522 0.155251,-1.273 z m 3.7260268,0 0.155251,1.2729 0.093148,0.6522 c 0.7061365,-0.4034 1.2649204,-0.9875 1.645662,-1.7079 l -0.5899545,-0.062 c -0.4345689,-0.052 -0.8703802,-0.1039 -1.3041096,-0.1557 z m -1.7698628,0.7141 -0.8073063,0.9936 -0.4657529,0.6209 c 0.3746086,0.1072 0.7709056,0.1864 1.179908,0.1864 0.4641221,0 0.9166457,-0.081 1.3351603,-0.2173 l -0.4657532,-0.59 z"
+             style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.00652146;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="ccccccscccs"
+             inkscape:connector-curvature="0"
+             id="rect9436-2"
+             d="m 0.524759,1042.9675 3.79253,5.2259 c 0,0 1.216807,0.4672 1.684108,-1e-4 l 0.19297,-0.193 c 0.467299,-0.4673 -8e-6,-1.6841 -8e-6,-1.6841 z m 4.055643,3.5242 c 0.376798,-0.3768 0.991528,-0.3769 1.368362,0 0.376788,0.3767 0.376773,0.9914 -2.5e-5,1.3682 -0.376798,0.3769 -0.991507,0.3769 -1.368294,0 -0.376855,-0.3768 -0.376841,-0.9915 -4.3e-5,-1.3682 z"
+             style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.00652146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        </g>
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,-0.70848002,186.15128)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,1.2248827,-221.37405)"
+         id="g17594">
+        <path
+           transform="translate(12.005651,1037.2461)"
+           d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+           sodipodi:ry="4.3089318"
+           sodipodi:rx="4.3089318"
+           sodipodi:cy="9.7465248"
+           sodipodi:cx="-6.7838054"
+           id="path6139"
+           style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#4d607b;stroke-width:0.82881737;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           sodipodi:type="arc" />
+        <path
+           style="color:#000000;fill:#4e8fbd;fill-opacity:1;fill-rule:nonzero;stroke:#4d607b;stroke-width:0.59773082;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           d="m 5.2901155,1042.6691 c -0.4193865,0 -0.827937,0.074 -1.2109584,0.1863 l 0.4968033,0.6521 0.8073063,1.0246 0.7762559,-1.0246 0.4968036,-0.59 c -0.429042,-0.1444 -0.8885091,-0.2484 -1.3662107,-0.2484 z m -2.1114149,0.59 c -0.7184889,0.4103 -1.2964352,1.0016 -1.6767124,1.7388 l 0.6520553,0.093 1.2730592,0.1553 -0.1552509,-1.2731 -0.093148,-0.7141 z m 4.2228311,0 -0.093148,0.7141 -0.155251,1.2731 1.3041096,-0.1553 0.6210049,-0.061 c -0.3798299,-0.7481 -0.9503317,-1.3549 -1.6767123,-1.7698 z m -6.2100454,2.484 c -0.112404,0.383 -0.1863014,0.7916 -0.1863014,1.2109 0,0.433 0.09783,0.8481 0.2173518,1.2421 l 0.5278537,-0.4348 1.0246571,-0.7761 -1.0246571,-0.8074 z m 8.1972597,0.031 -0.5278537,0.4037 -1.024658,0.8074 1.024658,0.7762 0.4968033,0.4036 c 0.1140598,-0.3856 0.2173518,-0.7884 0.2173518,-1.211 0,-0.409 -0.079196,-0.8053 -0.1863014,-1.1799 z m -5.9616433,2.9499 -1.2730592,0.1552 -0.6210049,0.062 c 0.3807416,0.7204 0.9395255,1.3044 1.645662,1.7079 l 0.093148,-0.6522 0.155251,-1.273 z m 3.7260268,0 0.155251,1.2729 0.093148,0.6522 c 0.7061365,-0.4034 1.2649204,-0.9875 1.645662,-1.7079 l -0.5899545,-0.062 c -0.4345689,-0.052 -0.8703802,-0.1039 -1.3041096,-0.1557 z m -1.7698628,0.7141 -0.8073063,0.9936 -0.4657529,0.6209 c 0.3746086,0.1072 0.7709056,0.1864 1.179908,0.1864 0.4641221,0 0.9166457,-0.081 1.3351603,-0.2173 l -0.4657532,-0.59 z"
+           id="path6139-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccccscccccccccccccccsccccccccccscccccccccccccccccsccc" />
+        <path
+           style="color:#000000;fill:#4d607b;fill-opacity:1;fill-rule:nonzero;stroke:#384e6e;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           d="m 0.524759,1042.9675 3.79253,5.2259 c 0,0 1.216807,0.4672 1.684108,-1e-4 l 0.19297,-0.193 c 0.467299,-0.4673 -8e-6,-1.6841 -8e-6,-1.6841 z m 4.055643,3.5242 c 0.376798,-0.3768 0.991528,-0.3769 1.368362,0 0.376788,0.3767 0.376773,0.9914 -2.5e-5,1.3682 -0.376798,0.3769 -0.991507,0.3769 -1.368294,0 -0.376855,-0.3768 -0.376841,-0.9915 -4.3e-5,-1.3682 z"
+           id="rect9436"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccscccs" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/expandall.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/expandall.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5080-7-5">
+      <stop
+         style="stop-color:#9acbce;stop-opacity:1;"
+         offset="0"
+         id="stop5082-1-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5084-3-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5080-79"
+       id="linearGradient5113-12"
+       gradientUnits="userSpaceOnUse"
+       x1="16.774115"
+       y1="1040.2089"
+       x2="26.536173"
+       y2="1046.4403"
+       gradientTransform="translate(0.97227179,0.97227179)" />
+    <linearGradient
+       id="linearGradient5080-79">
+      <stop
+         style="stop-color:#9acbce;stop-opacity:1;"
+         offset="0"
+         id="stop5082-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5084-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1046.4403"
+       x2="26.536173"
+       y1="1040.2089"
+       x1="16.774115"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5178"
+       xlink:href="#linearGradient5080-7-5"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="1.6268851"
+     inkscape:cy="7.7733305"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4827"
+     showgrid="true"
+     inkscape:window-width="1842"
+     inkscape:window-height="1058"
+     inkscape:window-x="74"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4827"
+       transform="translate(0.53033009,-0.70710678)">
+      <g
+         style="display:inline"
+         id="g5108-3"
+         transform="translate(-16.071514,-1.3236045)">
+        <rect
+           y="1040.9159"
+           x="18.031223"
+           height="9.9620361"
+           width="10.029854"
+           id="rect5076-6"
+           style="color:#000000;fill:url(#linearGradient5178);fill-opacity:1;fill-rule:nonzero;stroke:#8b96ab;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      </g>
+      <g
+         style="display:inline"
+         id="g5108"
+         transform="translate(-15.055048,-0.35127627)">
+        <rect
+           y="1041.8882"
+           x="19.003494"
+           height="9.9932861"
+           width="9.9986038"
+           id="rect5076"
+           style="color:#000000;fill:url(#linearGradient5113-12);fill-opacity:1;fill-rule:nonzero;stroke:#8b96ab;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        <rect
+           y="1047.3531"
+           x="20.48687"
+           height="1.1048543"
+           width="6.9826794"
+           id="rect5088-0"
+           style="color:#000000;fill:#d5f3ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        <rect
+           y="24.524717"
+           x="-1050.4033"
+           height="1"
+           width="6.9826794"
+           id="rect5088-0-1"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#d5f3ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;enable-background:accumulate"
+           transform="rotate(-90)" />
+        <rect
+           y="23.419863"
+           x="-1050.4033"
+           height="1.1048543"
+           width="6.9826794"
+           id="rect5088-3"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#01467a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;enable-background:accumulate"
+           transform="rotate(-90)" />
+        <rect
+           y="1046.3518"
+           x="20.550289"
+           height="1.1048543"
+           width="6.9826794"
+           id="rect5088"
+           style="color:#000000;fill:#01467a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/export.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/export.svg
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="export_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4483">
+      <stop
+         style="stop-color:#4077a7;stop-opacity:1"
+         offset="0"
+         id="stop4485" />
+      <stop
+         style="stop-color:#0d5c9a;stop-opacity:1"
+         offset="1"
+         id="stop4487" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4460">
+      <stop
+         style="stop-color:#a8a286;stop-opacity:1"
+         offset="0"
+         id="stop4462" />
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="1"
+         id="stop4464" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         id="stop7089"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093" />
+      <stop
+         id="stop7095"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter7378"
+       x="-0.11264625"
+       width="1.2252925"
+       y="-0.44767511"
+       height="1.8953502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3754875"
+         id="feGaussianBlur7380" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient7541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       id="linearGradient7087-7">
+      <stop
+         id="stop7089-4"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9" />
+      <stop
+         id="stop7095-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7117"
+       xlink:href="#linearGradient7087-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4">
+      <stop
+         id="stop7089-4-5"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1" />
+      <stop
+         id="stop7095-4-7"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7160"
+       xlink:href="#linearGradient7087-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2">
+      <stop
+         id="stop7089-4-5-7"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1" />
+      <stop
+         id="stop7095-4-7-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7203"
+       xlink:href="#linearGradient7087-7-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2-2">
+      <stop
+         id="stop7089-4-5-7-1"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1-8" />
+      <stop
+         id="stop7095-4-7-4-5"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2-7"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7246"
+       xlink:href="#linearGradient7087-7-4-2-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.03086799,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,1.00246,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-0.75106699,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.030868,-2089.7194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871-8"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460"
+       id="linearGradient4466"
+       x1="-1046.3622"
+       y1="12.5"
+       x2="-1037.3622"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.1667483e-7,3)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4483"
+       id="linearGradient4489"
+       x1="13"
+       y1="1050.3622"
+       x2="15"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1047.2885,1063.3622)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="43.583483"
+     inkscape:cx="17.092315"
+     inkscape:cy="4.0148715"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2348"
+     inkscape:window-height="1311"
+     inkscape:window-x="57"
+     inkscape:window-y="54"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9"
+       d="m 6,1037.3622 9.226335,0 0.0058,9.4978 -2.568358,3.0564 -5.7180776,0.018 c -0.4153006,-0.022 -0.9041922,-0.5519 -0.9041922,-1.0385 z"
+       style="display:inline;fill:#e6f8ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="display:inline;opacity:0.99715307;fill:#989891;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367-3"
+       width="6"
+       height="1"
+       x="6"
+       y="1049.3622" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4-5"
+       d="M 12.720747,1050.3622 16,1047.0482 l 0,-0.686 -3.99982,4 z"
+       style="display:inline;fill:#d4b268;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       id="g7358"
+       mask="url(#mask7366)"
+       transform="matrix(0,-1,1,0,-1034.7801,1032.6792)">
+      <g
+         id="g7205-6"
+         style="display:inline;opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7378)">
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -15.584151,1041.8789 0,-2.013"
+           id="path7045-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -13.584151,1041.8789 0,-2.013"
+           id="path7045-0-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -11.584151,1041.8789 0,-2.013"
+           id="path7045-3-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -9.584151,1041.8789 0,-2.013"
+           id="path7045-3-4-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -7.584151,1041.8789 0,-2.013"
+           id="path7045-3-4-7-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+    <g
+       id="g7205"
+       transform="matrix(0,-1,-1,0,1047.386,1032.2781)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045"
+         d="m -15.584151,1041.8789 0,-2.013"
+         style="fill:none;stroke:url(#linearGradient7541);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8"
+         d="m -13.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7117);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1"
+         d="m -11.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7160);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1-3"
+         d="m -9.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7203);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1-3-6"
+         d="m -7.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7246);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       transform="translate(-11.117495,16.574943)"
+       style="display:inline"
+       id="g7590-7" />
+    <g
+       transform="matrix(0.40514455,0,0,0.40514455,49.493535,621.6127)"
+       style="display:inline"
+       id="g7827-7" />
+    <rect
+       style="opacity:0.99715307;fill:#c7b571;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367"
+       width="9"
+       height="1"
+       x="6"
+       y="1037.3622" />
+    <rect
+       style="display:inline;opacity:0.99715307;fill:url(#linearGradient4466);fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367-3-6"
+       width="8.9999828"
+       height="1"
+       x="-1046.3622"
+       y="15"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <g
+       id="g4361"
+       transform="translate(3.9652262,-0.99483804)">
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         id="rect4001-1"
+         width="3.2970483"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1048.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         id="rect4001-1-7"
+         width="4.0242004"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1046.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1044.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871-8);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4-6"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1042.3674" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4"
+       d="m 12.002413,1046.3622 3.997407,0 -3.99982,4 z"
+       style="display:inline;fill:#e6c8ad;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4-1"
+       d="m 5.0737,1048.3647 0,3.9974 L 1,1048.3622 Z"
+       style="display:inline;fill:url(#linearGradient4489);fill-opacity:1;stroke:none" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4633"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAWdJREFU
+OI2lk8ErRFEUxr87KStrZWdtZzErkT9ANhYW2Cm2o0QzshHKYspGUxZCzWOkTCELYSFTbEiUlUQj
+BuW9O+67b2Y+i6eZN817Rjn1dU6dztevzjmCJP4TDUGNzF7kT84iiOCriLoGlwcRhPwaXWMGT26e
+0Boe+tWgVAoFE+SLIAhAAMsbGShbQ0oFUyrYSmMh1ofz3XGAZI06I0nuXz2yuX2QpkOaBdZkyyEP
+tycZSPDpgBBuvbKZgVIallSQ8gvKdjAX7cPZTqw+wYdmrRxXaWM6mODdqWxhPfVDkHcJopFegMBx
+aqY+wavNsl489atNJldngwledIXA2HK3YFkKo2ELGg/Q8g1a5uoTPCsy69F9Js67wxiv0yMk6d5B
+94RB0y7iLpd3N7A2LLK2/yVap1PQMoe2niUBeE7Za/K5NiwSiUVfg46W2/JwlUHFpICL+IDwG/aL
+ql84mu8XTY2BD+ob3xcTczsCvhyeAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/filter_ps.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/filter_ps.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="filter_ps.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1047">
+      <stop
+         style="stop-color:#96a0b9;stop-opacity:1"
+         offset="0"
+         id="stop1043" />
+      <stop
+         style="stop-color:#77849d;stop-opacity:1"
+         offset="1"
+         id="stop1045" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1039">
+      <stop
+         style="stop-color:#fbffff;stop-opacity:1"
+         offset="0"
+         id="stop1035" />
+      <stop
+         style="stop-color:#b9e7ff;stop-opacity:1"
+         offset="1"
+         id="stop1037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         id="stop4991"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1;"
+         offset="0.5"
+         id="stop4995" />
+      <stop
+         id="stop4993"
+         offset="1"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1039"
+       id="linearGradient1041"
+       x1="2.1048543"
+       y1="1039.3379"
+       x2="12.850951"
+       y2="1039.2937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1047"
+       id="linearGradient1049"
+       x1="1"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#444248"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.7020062"
+     inkscape:cy="8.7735937"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="path859"
+       style="fill:url(#linearGradient1041);stroke:url(#linearGradient1049);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
+       d="m 7.504725,1043.8623 h 1.99055 M 1.5,1037.8622 h 12 v 2 l -4,4 v 6 l -3.0000002,2 H 5.5 v -8 l -4,-4 z" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/help.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/help.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2"
+   height="16"
+   width="16">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4877">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#f7fdff;stop-opacity:1" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#e8f0f5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="17.832731"
+       x2="12.108335"
+       y1="2.7923172"
+       x1="12.108335"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4118"
+       xlink:href="#linearGradient4877" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1036.3622)"
+     style="display:inline"
+     id="layer1">
+    <g
+       transform="translate(-8.2201163,-12.904699)"
+       id="g8159"
+       style="display:inline">
+      <g
+         transform="matrix(0.70002175,0,0,0.70002175,22.066022,320.64029)"
+         id="g4113">
+        <path
+           style="fill:url(#linearGradient4118);fill-opacity:1;stroke:#286296;stroke-width:1.48209679;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="path4110"
+           d="m 21.8125,11.6875 a 9.875,9.875 0 0 1 -9.875,9.875 9.875,9.875 0 0 1 -9.875,-9.875 9.875,9.875 0 0 1 9.875,-9.875 9.875,9.875 0 0 1 9.875,9.875 z"
+           transform="matrix(0.94006782,0,0,0.94006782,-19.572484,1041.2798)" />
+        <path
+           style="font-size:20.03678703px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#286296;fill-opacity:1;stroke:none;font-family:Reznor;"
+           d="m -8.2362428,1045.9247 c -1.273895,10e-5 -2.2909442,0.3542 -3.0669772,1.0668 -0.776035,0.7126 -1.180487,1.6995 -1.22679,2.9336 l 2.106879,0.2667 c 0.06927,-1.5258 0.7676282,-2.2669 2.0535412,-2.2669 0.544332,0 0.986005,0.1392 1.333468,0.4534 0.347451,0.3142 0.50671,0.7177 0.506718,1.2001 -8e-6,0.4489 -0.155573,0.8368 -0.480048,1.1734 -0.173559,0.1795 -0.518749,0.4482 -1.040106,0.7735 -0.47471,0.2917 -0.782855,0.6247 -0.933427,1.04 -0.13927,0.348 -0.21336,0.8822 -0.213355,1.6002 l 0,0.9601 1.946863,0 0,-0.6134 c -6e-6,-0.7067 0.304445,-1.2494 0.906758,-1.6534 0.787868,-0.5387 1.32567,-1.0168 1.626831,-1.3868 0.416727,-0.5387 0.640055,-1.1881 0.640064,-1.9736 -9e-6,-1.0772 -0.431305,-1.9671 -1.253459,-2.6403 -0.787883,-0.6283 -1.760322,-0.9333 -2.90696,-0.9334 z"
+           id="text4882" />
+        <path
+           style="fill:#286296;fill-opacity:1;stroke:none;display:inline"
+           id="path4908-1"
+           d="m 12.575997,16.531185 a 0.64356911,0.39774758 0 0 1 -0.64357,0.397748 0.64356911,0.39774758 0 0 1 -0.643569,-0.397748 0.64356911,0.39774758 0 0 1 0.643569,-0.397747 0.64356911,0.39774758 0 0 1 0.64357,0.397747 z"
+           transform="matrix(2.2887845,0,0,3.1572419,-35.660077,1005.1852)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/next_nav.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/next_nav.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="next_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-7.4627612"
+     inkscape:cy="10.319471"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1044.8626 3,0 0,-5.7812 c 0,-0.6679 0.5509,-1.2188 1.2188,-1.2188 l 2.5625,0 c 0.6678,0 1.2187,0.5508 1.2187,1.2188 l 0,5.7812 3,0 0,1 -5.5,5.5 -5.5,-5.5 0,-1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/open_page.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/open_page.svg
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="open_page.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6042">
+      <stop
+         style="stop-color:#9c956f;stop-opacity:1"
+         offset="0"
+         id="stop6038" />
+      <stop
+         style="stop-color:#918f77;stop-opacity:1"
+         offset="1"
+         id="stop6040" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6034">
+      <stop
+         style="stop-color:#928f76;stop-opacity:1"
+         offset="0"
+         id="stop6030" />
+      <stop
+         style="stop-color:#86887e;stop-opacity:1"
+         offset="1"
+         id="stop6032" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6020"
+       inkscape:collect="always">
+      <stop
+         id="stop6016"
+         offset="0"
+         style="stop-color:#a79c68;stop-opacity:1" />
+      <stop
+         id="stop6018"
+         offset="1"
+         style="stop-color:#7a8086;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6004">
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="0"
+         id="stop6000" />
+      <stop
+         style="stop-color:#717b8c;stop-opacity:1"
+         offset="1"
+         id="stop6002" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-3">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-5" />
+      <stop
+         id="stop7550-07"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548-6"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8287-7-5-4">
+      <stop
+         style="stop-color:#6eb6e2;stop-opacity:1;"
+         offset="0"
+         id="stop8289-4-1-2" />
+      <stop
+         style="stop-color:#d3e5f4;stop-opacity:1"
+         offset="1"
+         id="stop8291-0-7-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3-4-1-2">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084-8-8-5-1" />
+      <stop
+         id="stop4864-7-8-2-6"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086-2-2-7-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8287-7-5-4"
+       id="linearGradient8293"
+       x1="-16.963362"
+       y1="1038.8951"
+       x2="-4.9919548"
+       y2="1038.8951"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72365309,0,0,1.0027501,17.960733,1.3811984)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6004"
+       id="linearGradient8887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72586718,0,0,0.67000765,2.8175868,346.31722)"
+       x1="8.5172787"
+       y1="1041.8463"
+       x2="8.5172787"
+       y2="1049.3088" />
+    <linearGradient
+       id="linearGradient4810-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4812-0"
+         offset="0"
+         style="stop-color:#a79c68;stop-opacity:1" />
+      <stop
+         id="stop4814-4"
+         offset="1"
+         style="stop-color:#615941;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6">
+      <stop
+         id="stop6283-0-2-2-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810-5"
+       id="linearGradient5941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1795341,0,0,1.4939907,-1.2339218,-515.68053)"
+       x1="8.0137892"
+       y1="1042.3622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8287-7-5-4"
+       id="linearGradient5947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1759362,0,0,1.0027368,23.37369,-2.6049903)"
+       x1="-16.963362"
+       y1="1038.8951"
+       x2="-4.9919548"
+       y2="1038.8951" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6020"
+       id="linearGradient6014"
+       gradientUnits="userSpaceOnUse"
+       x1="8"
+       y1="1044.3622"
+       x2="8"
+       y2="1049.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6004"
+       id="linearGradient6028"
+       x1="8"
+       y1="1044.3622"
+       x2="8"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6034"
+       id="linearGradient6036"
+       x1="6"
+       y1="1046.3622"
+       x2="6"
+       y2="1047.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6042"
+       id="linearGradient6044"
+       x1="9"
+       y1="1045.3622"
+       x2="9"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.7381087"
+     inkscape:cy="6.3635628"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-1"
+       d="M 1.5286379,1037.8622 H 14.5 v 13 H 1.5286379 Z"
+       style="display:inline;fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient5941);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-9-2"
+       d="m 1.5,1037.8622 h 13 v 2 h -13 z"
+       style="display:inline;fill:url(#linearGradient5947);fill-opacity:1;stroke:#315b91;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image5867"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAcpJREFU
+OI2lkz1rFUEUhp9zzsxs9mYtTCTgDxALtQ4ptFGsUthtIaS3SWFAiQYMoojBXIWgaQSxEAlC/oBY
+CYaAnaVgq6WmuV9771rM5N69ZcjAcnbYmfd9zrszUtc1pxkO4HLZrkUUVcEsVTXMFGeKqaWqOFXU
+xfn+81IcwOj8IheunMWrkAcld0rujSIorRnjTKbMOqPwSh6M3Am77z9PCPT3Ib/+gKphGgmcRQJT
+nXo3U8wiwVhg7dInFu8enKj3w/YSUEaBahjV5jzcWGljZgTvCN6RBU8WPN4Zzow3j0sAqlGDoBoJ
+AJryuHb9IvOzxkLhWSg88y1HkRlbr/ZQgbqGwVAmAr2hRQGJeXz7+J3gHCHEJ/Me713MAqiBftrj
+ALpVnBiwcfMnV2/vAnCwd4+lcmvc99cPdxApUYHuoCHQq3RM0OkHvEabLz/O0as2oE6ug4Alsf6w
+kcExgQJH3Zz9t0/TMs/yypMxwbud9diCQKdqEPQbGfztFNxffQjA652XzGh0B/jXaaGSCKqpFlIG
+AkednAebLxDiyvVH24jU1IAwEeg1Qzz+JSrwbHMNYeIqCTkpjD8MhlPnQNlevcXJRjSV017n/8dN
+e99qIay7AAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9"
+       d="m 4.5176236,1043.0321 h 7.9823774 v 5.8301 H 4.5176236 Z"
+       style="display:inline;fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-9"
+       d="M 4.5000002,1041.8622 H 12.5 v 2 H 4.5000002 Z"
+       style="display:inline;fill:url(#linearGradient8293);fill-opacity:1;stroke:#315b91;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4299"
+       d="m 7.5,1044.3622 v 4"
+       style="fill:url(#linearGradient6014);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6028);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4301"
+       d="m 8,1045.8622 h 4"
+       style="fill:#a79d79;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6044);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4303"
+       d="M 7,1046.8622 H 5"
+       style="fill:#a79d79;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6036);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/prev_nav.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/prev_nav.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="prev_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-4.5683281"
+     inkscape:cy="9.6786205"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1043.8618 3,0 0,5.7812 c 0,0.6679 0.5509,1.2188 1.2188,1.2188 l 2.5625,0 c 0.6678,0 1.2187,-0.5508 1.2187,-1.2188 l 0,-5.7812 3,0 0,-1 -5.5,-5.5 -5.5,5.5 0,1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/remove_exc.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/remove_exc.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="remove_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#414141;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#535353;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="5.5301136"
+     inkscape:cy="7.9227098"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="963"
+     inkscape:window-y="622"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 13.267004,1038.2068 c -0.463993,-0.4858 -1.211033,-0.4858 -1.675002,-10e-5 l -3.0849275,3.2304 -3.0849031,-3.2303 c -0.4639226,-0.4858 -1.2110333,-0.4858 -1.6750018,0 l -0.8523552,0.8927 c -0.4639479,0.4856 -0.463936,1.2678 3.62e-5,1.7537 l 3.0848535,3.2303 -3.084858,3.2302 c -0.4640179,0.4858 -0.4640062,1.268 -1.34e-5,1.7538 l 0.852401,0.8927 c 0.4639431,0.4858 1.2109842,0.4858 1.6750016,0 l 3.084908,-3.2302 3.1063417,3.2526 c 0.463945,0.4859 1.210985,0.4859 1.675003,0 l 0.852355,-0.8925 c 0.463969,-0.4859 0.459308,-1.2632 -3.6e-5,-1.7539 l -3.106344,-3.2527 3.084908,-3.2302 c 0.46399,-0.4859 0.463978,-1.2681 3.4e-5,-1.7538 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/text_edit.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/elcl16/text_edit.svg
@@ -1,0 +1,620 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="text_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135-7"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5135-7"
+       inkscape:collect="always">
+      <stop
+         id="stop5137-4"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139-0"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141-4"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5141-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5143-8"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145-8"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147-4"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5147-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5149-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151-5"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#7b703e;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.022097,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302" />
+      <stop
+         id="stop5308"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7" />
+      <stop
+         id="stop5087-6"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.6704"
+       x2="-8.7005796"
+       y1="1042.1598"
+       x1="-11.21119"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5173-0"
+       xlink:href="#linearGradient4908-52-3-2-9"
+       inkscape:collect="always"
+       gradientTransform="translate(20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4908-52-3-2-9">
+      <stop
+         style="stop-color:#986443;stop-opacity:1"
+         offset="0"
+         id="stop4910-7-2-7-0" />
+      <stop
+         style="stop-color:#994f1b;stop-opacity:1"
+         offset="1"
+         id="stop4912-6-2-9-4" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter5428-9">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.22207033"
+         id="feGaussianBlur5430-2" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5077-5-8"
+       id="linearGradient5196-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-1036.3622)"
+       x1="-0.9810437"
+       y1="1047.4242"
+       x2="1.9838035"
+       y2="1050.3188" />
+    <linearGradient
+       id="linearGradient5077-5-8">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7-9" />
+      <stop
+         id="stop5087-6-0"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1-4"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6"
+       id="linearGradient5306-8"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5300-6">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302-7" />
+      <stop
+         id="stop5308-2"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3208"
+       xlink:href="#linearGradient5300-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3-3"
+       id="linearGradient4908-2-4"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3-3">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2-7" />
+      <stop
+         style="stop-color:#7b703e;stop-opacity:1"
+         offset="1"
+         id="stop4906-2-6" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter5428-9-1">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.22207033"
+         id="feGaussianBlur5430-2-9" />
+    </filter>
+    <linearGradient
+       id="linearGradient5077-5-8-7">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7-9-4" />
+      <stop
+         id="stop5087-6-0-2"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1-4-6"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8-7-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3208-6"
+       xlink:href="#linearGradient5300-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5300-6-8">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302-7-1" />
+      <stop
+         id="stop5308-2-6"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304-3-8" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4177"
+       x="-0.11984986"
+       width="1.2396997"
+       y="-0.12015051"
+       height="1.240301">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.40384366"
+         id="feGaussianBlur4179" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4181">
+      <path
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         id="path4183"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8.0000004"
+     inkscape:cx="10.666768"
+     inkscape:cy="4.4401945"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="779"
+     inkscape:window-x="98"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4101);fill-opacity:1;stroke:none;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 9.998718,1037.397 0,3.9112 3.977478,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1040.3074" />
+    <rect
+       style="fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1042.3074" />
+    <rect
+       style="fill:url(#linearGradient4871-2);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1044.3074" />
+    <rect
+       style="fill:url(#linearGradient4875-9);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1046.3074" />
+    <rect
+       style="fill:url(#linearGradient4873-1);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="5.0291462"
+       y="1048.3074" />
+    <g
+       id="g3395"
+       style="stroke:#ffffff;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4177)"
+       mask="url(#mask4181)">
+      <g
+         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:2.11441896;stroke-miterlimit:4;stroke-dasharray:none"
+         id="layer1-5-0"
+         inkscape:label="Layer 1"
+         transform="matrix(-0.70941475,0,0,0.70941475,9.6234575,302.66333)">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path5226-6-14-1-5-6"
+           d="m 12.866728,1043.3715 -5.928369,5.8862 -5.461084,2.5938 2.59375,-5.4564 5.8445857,-5.9039 c 1.2698873,0.6025 2.2104673,1.6169 2.9511173,2.8807 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;stroke:#ffffff;stroke-width:2.11441896;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path5424-4"
+           d="M 9.9307747,1040.4939 4.0625,1046.3935 5,1047.2997 l 6.118275,-6.0558 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875003,-0.75 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.11441896;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path5226-6-14-1-5-2-0"
+           d="m 12.493275,1042.7752 -5.962025,6.087 0.40625,0.4063 5.930775,-5.8996 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.11441896;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path5226-6-14-1-5-2-7-6"
+           d="m 6.536718,1048.8567 -1.548139,-1.5456 6.120492,-6.0629 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.11441896;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path5426-2"
+           d="m 4.984376,1047.2528 6.118276,-6.0089"
+           style="opacity:0.50000000000000000;fill:#ffffff;stroke:#ffffff;stroke-width:2.11441896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428-9-1)" />
+        <path
+           transform="translate(0,1036.3622)"
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           id="path5006-9"
+           d="M 5.40625,8.6875 4.09375,10 2.6875,12.9375 l 1.375,1.28125 -0.03125,0.0625 2.9375,-1.40625 0.75,-0.75 0.1875,-2 L 5.1875,9.96875 c 0,0 0.127199,-0.74275 0.21875,-1.28125 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.11441896;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path5006-1-9"
+           d="m 3.25,1049.1435 c -0.211528,0.024 -0.41079,0.089 -0.5625,0.1562 l -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c 0.121601,-0.3002 0.273127,-0.8318 -0.09375,-1.2188 -0.132606,-0.1402 -0.331591,-0.1963 -0.5,-0.2187 -0.08057,-0.011 -0.138928,-0.01 -0.21875,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.11441896;stroke-miterlimit:4;stroke-dasharray:none" />
+      </g>
+    </g>
+    <g
+       transform="matrix(-0.70941475,0,0,0.70941475,9.6234575,302.66333)"
+       inkscape:label="Layer 1"
+       id="layer1-5"
+       style="display:inline">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient5173-0);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 12.866728,1043.3715 -5.928369,5.8862 -5.461084,2.5938 2.59375,-5.4564 5.8445857,-5.9039 c 1.2698873,0.6025 2.2104673,1.6169 2.9511173,2.8807 z"
+         id="path5226-6-14-1-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffcb72;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="M 9.9307747,1040.4939 4.0625,1046.3935 5,1047.2997 l 6.118275,-6.0558 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875003,-0.75 z"
+         id="path5424"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#e5a856;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 12.493275,1042.7752 -5.962025,6.087 0.40625,0.4063 5.930775,-5.8996 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+         id="path5226-6-14-1-5-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#fbbc67;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 6.536718,1048.8567 -1.548139,-1.5456 6.120492,-6.0629 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+         id="path5226-6-14-1-5-2-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="opacity:0.5;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428-9)"
+         d="m 4.984376,1047.2528 6.118276,-6.0089"
+         id="path5426"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:url(#linearGradient5196-0);fill-opacity:1;stroke:none;display:inline"
+         d="M 5.40625,8.6875 4.09375,10 2.6875,12.9375 l 1.375,1.28125 -0.03125,0.0625 2.9375,-1.40625 0.75,-0.75 0.1875,-2 L 5.1875,9.96875 c 0,0 0.127199,-0.74275 0.21875,-1.28125 z"
+         id="path5006"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         transform="translate(0,1036.3622)" />
+      <path
+         style="fill:url(#linearGradient3208);fill-opacity:1;stroke:none;display:inline"
+         d="m 3.25,1049.1435 c -0.211528,0.024 -0.41079,0.089 -0.5625,0.1562 l -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c 0.121601,-0.3002 0.273127,-0.8318 -0.09375,-1.2188 -0.132606,-0.1402 -0.331591,-0.1963 -0.5,-0.2187 -0.08057,-0.011 -0.138928,-0.01 -0.21875,0 z"
+         id="path5006-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/annotation_obj.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/annotation_obj.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg4061"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="annotation_obj.svg">
+  <defs
+     id="defs4063" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="33.3125"
+     inkscape:cx="4.4577862"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1132"
+     inkscape:window-height="873"
+     inkscape:window-x="834"
+     inkscape:window-y="441"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4066">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11.458315,1046.4119 0,-2.7842 0.0042,-0.8839 c 0,0 -0.0617,-1.9004 -0.105904,-2.1213 -0.04419,-0.221 -0.88388,-2.2915 -0.88388,-2.2915 l -1.137373,-0.9547 -1.1932427,-0.442 -1.0589922,-0.1941 -1.8228007,0.3344 -1.3458363,0.8147 -1.5501319,1.5559 -1.065664,2.3265 0.088388,1.812 0.7071068,1.6352 1.016466,1.5468 c 0,0 1.0681638,1.2741 1.3333289,1.2299 0.265165,-0.044 2.1972011,0.6346 2.1972011,0.6346 l 2.0079171,-0.1293 2.2347239,-1.5143 z"
+       id="path3840"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#236298;fill-opacity:1;stroke:#236298;stroke-width:0.28257138;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+       d="m 11.309169,1039.7124 c -0.09375,-0.4062 -0.177236,-0.9956 -0.552237,-1.4332 -0.374998,-0.4374 -0.614324,-0.6075 -1.022557,-0.8389 -0.4082332,-0.2314 -1.6921375,-0.7905 -2.890625,-0.8594 -0.3994958,-0.023 -0.8168984,0.026 -1.1875,0.125 -1.8098211,0.485 -2.6365843,1.3182 -3.59375,2.8125 -0.991819,1.5427 -1.18883707,3.5664 -0.65625,5.3438 0.5272319,1.7597 1.555815,2.9531 3.09375,3.5937 1.4108866,0.5774 2.6810837,0.7061 4.5,0.2188 1.67339,-0.4485 2.016965,-0.7867 3.21875,-1.8438 l -0.4375,-0.3437 c -1.553801,1.2177 -1.622762,1.2331 -2.96875,1.5937 -1.5005895,0.4027 -3.1035995,0.1737 -4.25,-0.4062 -1.1463954,-0.5798 -1.9388113,-1.5074 -2.4375,-3.0938 -0.4986887,-1.5864 -0.022863,-3.5209 0.5625,-4.5312 0.5853631,-1.0103 1.2965074,-2.1937 2.90625,-2.625 1.282323,-0.3436 2.8157521,0.1597 3.788182,0.7279 0.97243,0.5683 1.292239,1.6525 1.258042,2.5824 -0.0342,0.9298 -0.664674,1.9656 -1.133042,2.368 -0.4683686,0.4027 -1.475682,0.4154 -1.475682,0.4154 0,0 0.1240658,-0.6578 0.125,-1.4687 0.030258,-0.6627 -0.1295408,-1.6952 -0.59375,-2.125 -0.4642092,-0.431 -1.2172197,-0.4323 -1.6875,-0.4063 -0.5523523,0.031 -0.932751,0.349 -1.34375,1.125 -0.4594324,0.8674 -0.5953852,2.7605 -0.4375,3.4688 0.1578852,0.7083 0.2457352,0.8707 0.65625,1.2812 0.4105148,0.4103 1.4233638,0.4191 1.96875,0.094 0.8226727,-0.5067 0.5968097,-1.091 1.21875,-1.125 0,0 1.2730873,-0.2595 2.067862,-0.8125 0.815373,-0.5226 1.093629,-1.2093 1.265854,-1.9429 0.172226,-0.7335 0.131703,-1.4881 0.03795,-1.8944 z M 6,1040.2997 c 0.1214058,0 0.264899,0.01 0.40625,0.031 0.5654037,0.1018 0.65625,1.125 0.65625,1.125 0,0 0.075363,0.6862 0.03125,1.5938 -0.044113,0.9079 -0.00335,1.2628 -0.34375,1.5312 -0.3403969,0.2684 -1.2509038,0.4278 -1.6875,-0.2812 -0.4365972,-0.7089 -0.3169368,-2.8026 0.0625,-3.4375 0.238137,-0.4 0.5107825,-0.5487 0.875,-0.5625 z"
+       id="path4719-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cczscccccccccssczzccccccscccczcssccsccs" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/api_tools.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/api_tools.svg
@@ -1,0 +1,727 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="api_tools.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4805">
+      <stop
+         style="stop-color:#4b82b6;stop-opacity:1"
+         offset="0"
+         id="stop4807" />
+      <stop
+         id="stop4815"
+         offset="0.79358917"
+         style="stop-color:#9ab7d5;stop-opacity:1" />
+      <stop
+         style="stop-color:#a2bcd8;stop-opacity:1"
+         offset="1"
+         id="stop4809" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#91c168;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1-7"
+       id="linearGradient3929-5-9"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539"
+       gradientTransform="matrix(0.37647059,0,0,0.37647062,-139.62155,864.58459)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-7">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-5"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-6" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-1"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient6323-7-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,1046.6356)"
+       x1="10"
+       y1="5"
+       x2="10.007812"
+       y2="6.9843998" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5068-6-9-4-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5070-8-0-4-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5072-3-6-1-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5084-3-3-2-6"
+       x1="12"
+       y1="1043.3622"
+       x2="12"
+       y2="1045.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5086-8-0-8-5"
+       x1="13"
+       y1="1043.3622"
+       x2="15.007812"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5082-1-0-8-1"
+       x1="12"
+       y1="1042.3622"
+       x2="10.007812"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5078-8-2-1-4"
+       x1="10"
+       y1="1041.3622"
+       x2="8.0078125"
+       y2="1041.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5076-5-2-9-8"
+       x1="10"
+       y1="1040.3622"
+       x2="10.007812"
+       y2="1038.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <linearGradient
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1038.3622"
+       x1="12"
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3500-5"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068-6-9-4-9"
+       id="linearGradient5088-1-4-8-6"
+       x1="14"
+       y1="1041.3622"
+       x2="14"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.015625,10.2734)" />
+    <radialGradient
+       r="3.4803574"
+       fy="-738.83777"
+       fx="-757.20496"
+       cy="-738.83777"
+       cx="-757.20496"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3091-1-9-6-4-6"
+       xlink:href="#linearGradient4528-9-5-7-9-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="7.549418"
+       x2="0.9375"
+       y1="4.8437853"
+       x1="0.9375"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3093-5-2-7-0-9"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2-8-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:0"
+         offset="0"
+         id="stop4286" />
+      <stop
+         id="stop4288"
+         offset="0.49999967"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:0"
+         offset="1"
+         id="stop4290" />
+    </linearGradient>
+    <linearGradient
+       y2="519.39288"
+       x2="323.26462"
+       y1="528.64294"
+       x1="323.26462"
+       gradientTransform="matrix(0.197686,0,0,0.32432277,-38.574335,887.91126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10770-6"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         id="stop10450-3-5-6-7"
+         offset="0"
+         style="stop-color:#fbdf89;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdf89;stop-opacity:1"
+         offset="0.29561663"
+         id="stop5110" />
+      <stop
+         id="stop5114"
+         offset="0.33333409"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#f3f4f0;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-5-3" />
+      <stop
+         id="stop5112"
+         offset="0.66666681"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop5108"
+         offset="0.69352579"
+         style="stop-color:#fceaaf;stop-opacity:1" />
+      <stop
+         id="stop10452-22-7-8-4"
+         offset="1"
+         style="stop-color:#fceaaf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         id="stop10442-43-2-0-9"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-5-3" />
+      <stop
+         id="stop10444-3-4-0-4"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10750-5" />
+      <stop
+         id="stop10752-8"
+         offset="0.25"
+         style="stop-color:#f1ce66;stop-opacity:1" />
+      <stop
+         id="stop10754-8"
+         offset="0.5"
+         style="stop-color:#f6e5a6;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1cf6c;stop-opacity:1"
+         offset="0.75"
+         id="stop10756-4" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10758-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         id="stop10450-0"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-2" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-96" />
+      <stop
+         id="stop10460-3"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-1"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         id="stop10416-3"
+         offset="0"
+         style="stop-color:#5078b9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6d8cbd;stop-opacity:1"
+         offset="0.5"
+         id="stop10422-8" />
+      <stop
+         id="stop10418-4"
+         offset="1"
+         style="stop-color:#5f88c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10434-4" />
+      <stop
+         id="stop10436-2"
+         offset="0.5"
+         style="stop-color:#4e6da1;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10438-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         id="stop10159-5"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-9" />
+      <stop
+         id="stop10161-55"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-5">
+      <stop
+         id="stop10398-7"
+         offset="0"
+         style="stop-color:#1b3e79;stop-opacity:1;" />
+      <stop
+         style="stop-color:#728fbf;stop-opacity:1"
+         offset="0.5"
+         id="stop10404-9" />
+      <stop
+         id="stop10400-9"
+         offset="1"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         id="stop10159-8-3"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999985"
+         id="stop10165-3-9" />
+      <stop
+         id="stop10161-5-0"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         id="stop10151-5-7-2"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b9c7df;stop-opacity:1"
+         offset="0.5"
+         id="stop10394-3" />
+      <stop
+         id="stop10153-8-1-2"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient5123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24767695,0,0,0.32432277,-70.409692,870.91846)"
+       x1="323.26462"
+       y1="528.64294"
+       x2="323.26462"
+       y2="519.39288" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient5173"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24730056,0,0,0.32432277,-70.282934,877.91787)"
+       x1="323.26462"
+       y1="528.64294"
+       x2="323.26462"
+       y2="519.39288" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       id="linearGradient3929-5-9-8"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539"
+       gradientTransform="matrix(0.37647059,0,0,0.37647062,-139.62155,871.58461)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.2"
+     inkscape:cx="16.911188"
+     inkscape:cy="4.5154977"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#linearGradient5123);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2-7-6"
+       width="5.0115223"
+       height="3.0210745"
+       x="7.9884777"
+       y="1039.3628"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 10.988478,1039.3694 v 1 H 13 v -1 z"
+       id="path4313-8-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 12.994125,1041.3602 -2.005647,0.031 0.0058,1 L 13,1042.3602 Z"
+       id="path4313-5-1-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 11.005831,1042.37 -3.0173532,0.031 0.0088,1 3.0173532,-0.031 z"
+       id="path4313-5-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 10.996094,1038.3622 -3.0076162,0.031 0.0088,1 3.0076152,-0.031 z"
+       id="path4313-8"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:url(#linearGradient5173);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2-7-6-8"
+       width="5.0039062"
+       height="3.0210745"
+       x="7.9960942"
+       y="1046.3622"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 10.996094,1046.3688 v 1 H 13 v -1 z"
+       id="path4313-8-8-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 12.994146,1048.3596 -1.998052,0.031 0.0058,1 L 13,1049.3596 Z"
+       id="path4313-5-1-8-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ac851f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 11.013447,1049.3694 -3.0173532,0.031 0.0088,1 3.0173532,-0.031 z"
+       id="path4313-5-1-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba9726;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 11.00371,1045.3616 -3.0076162,0.031 0.0088,1 3.0076152,-0.031 z"
+       id="path4313-8-3"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="matrix(0.13972603,0,0,0.16234201,-43.593216,972.25873)"
+       style="display:inline;stroke-width:1.85268462"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.85268462;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.85268462"
+       transform="matrix(0.50075087,0,0,0.58180212,14.299623,445.12442)" />
+    <g
+       id="g6438"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.6219058"
+       transform="matrix(0.57167787,0,0,0.66496285,26.311225,358.34392)">
+      <g
+         id="text3782"
+         style="font-size:15.56941891px;font-family:Sans;fill:#ffffff;stroke-width:1.6219058"
+         transform="scale(0.94400511,1.0593163)" />
+    </g>
+    <g
+       transform="matrix(0.1604285,0,0,0.16135966,-52.09452,964.70814)"
+       style="display:inline;stroke-width:1.73427248"
+       id="g11331-3-1-1-4">
+      <g
+         id="g13408-8-1"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.73427248;stroke-opacity:1" />
+    </g>
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient3929-5-9-8);fill-opacity:1;stroke:#14733c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.4960938,1050.3622 c -0.690867,1.1985 -1.517266,1.5 -3,1.5 -2.2091388,0 -3.9999997,-1.7909 -4,-4 3e-7,-2.2091 1.7908612,-4 4,-4 1.492204,0 2.312494,0.2888 3,1.5 z"
+       id="path10796-2-6-2-3-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient3929-5-9);fill-opacity:1;stroke:#55429f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.4960938,1043.3622 c -0.690867,1.1985 -1.517266,1.5 -3,1.5 -2.2091388,0 -3.9999997,-1.7909 -4,-4 3e-7,-2.2091 1.7908612,-4 4,-4 1.492204,0 2.312494,0.2888 3,1.5 z"
+       id="path10796-2-6-2-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.0039062,1038.8622 h 2.9921876 z m 1.4960936,0.5 v 2.9902 z M 5,1042.8622 h 2.9902348 z"
+       id="path1108"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.3307088,1047.2497 c -0.03726,-0.2692 -0.122425,-0.4719 -0.255489,-0.6082 -0.130409,-0.1362 -0.300734,-0.2043 -0.510979,-0.2043 -0.279443,0 -0.502995,0.1185 -0.6706584,0.3553 -0.165005,0.2333 -0.247507,0.3859 -0.247505,0.9372 -2e-6,0.6131 0.08383,0.8859 0.251498,1.139 0.1703234,0.253 0.3978684,0.3794 0.6826344,0.3794 0.212905,0 0.387223,-0.072 0.522954,-0.2189 0.135725,-0.1493 0.231534,-0.4038 0.287425,-0.7639 l 1.101796,-0.011 c -0.114442,0.6162 -0.334002,1.3216 -0.658682,1.6362 -0.324688,0.3146 -0.759817,0.4719 -1.305389,0.4719 -0.6200954,0 -1.1151044,-0.2384 -1.4850304,-0.7151 -0.367266,-0.4767 -0.550899,-0.9768 -0.550899,-1.8201 0,-0.8529 0.184963,-1.2763 0.554891,-1.7496 0.369925,-0.4769 0.870258,-0.7152 1.5009984,-0.7152 0.516298,0 0.926144,0.1361 1.229541,0.4087 0.30605,0.269 0.559493,0.9009 0.692564,1.4554 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.56941891px;line-height:125%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+       id="path3817"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscscccsscscsccc" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image6344"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAk5JREFU
+OI19k1FI01EUh7//mvl3W8tWkRhRCLU0QsqHqKTIMCKsFCkokCQiiiIIjCCJelEwfaiknNKLhT5V
+JOlLppAOIYPQMkUwDZc5m3M5B8vp7ulBnRupBy6ch3M/7u9+92oiQnQ9LnGK3zeNKIWmaVhtOjeK
+MzWWKS0acOtyo1itOpY1qzEaDczOKgJTIfz+v5TX5CwJMS40lSXtosfHoetx3Lx3KDLwvOozA30e
+mh12yb7S/x/EsNCMDE8yPT2D1xOgstQ5By110ts1SjAYIiu/jGaHXZod9pjMkRO4f02iVJiwUhjj
+FQBjbh+uYS8Gg0bQlMv+gk4AGipSBOB00aAWAay1mZgYn0KJoObvRYmglAI0dE81DfVPAci/82Mx
+ioggIpTfbZULJ+uk+HqjRNeTsjYpPFUnL0u2ysJs9IqxcO3cazFb4tiYZEEDBBhx/UHC8OhF3soW
+AKaPfyTBuxmjOQmUkbAWwpA4htf2E8hbav9ihIeN1XL+2UX55u4SpWZlPDAmIkr6f/fImepCeVe1
+Y8kIkRO0DHVwYHsqaZvSefuliZbe99iT7Jh1E8nWRLKOzmkEiH4PEcCoz4trwg9AU4+T1u5PtJt6
+sehmjKsMBE1HVta4wWpj3D8OQFbaQb6PDnJiTzbHdh3m/psHy2qMALJS9vGqu4kaZy1n9+aSsWU3
+ibqFtoEO3D4PDfXNsf7nK0bjpdrb0uP6SnrKTtZb1jER8NHnGiI1OQ1HQcmSGmMAABWNVfJhsJNQ
+eIaEOJ3MbRkU5Vxd9jv/A+DLPt69H4LZAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b08b21;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 13,1040.3622 v 1 h 2.011522 v -1 z"
+       id="path4313-8-8-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b08b21;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 12.988478,1047.3622 v 1 H 15 v -1 z"
+       id="path4313-8-8-6-3"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/bundleversion.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/bundleversion.svg
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="bundleversion.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7870">
+      <stop
+         style="stop-color:#fcd9b5;stop-opacity:1"
+         offset="0"
+         id="stop7866" />
+      <stop
+         style="stop-color:#fb9575;stop-opacity:1"
+         offset="1"
+         id="stop7868" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7842">
+      <stop
+         style="stop-color:#c4eeff;stop-opacity:1"
+         offset="0"
+         id="stop7838" />
+      <stop
+         id="stop7846"
+         offset="0.1191492"
+         style="stop-color:#c4eeff;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6feff;stop-opacity:1"
+         offset="1"
+         id="stop7840" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7832">
+      <stop
+         style="stop-color:#5aa5d7;stop-opacity:1"
+         offset="0"
+         id="stop7828" />
+      <stop
+         style="stop-color:#1547ae;stop-opacity:1"
+         offset="1"
+         id="stop7830" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7818">
+      <stop
+         style="stop-color:#6791de;stop-opacity:1"
+         offset="0"
+         id="stop7814" />
+      <stop
+         style="stop-color:#94d5fc;stop-opacity:1"
+         offset="1"
+         id="stop7816" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7806">
+      <stop
+         style="stop-color:#686163;stop-opacity:1"
+         offset="0"
+         id="stop7802" />
+      <stop
+         id="stop7810"
+         offset="0.49584505"
+         style="stop-color:#686163;stop-opacity:1" />
+      <stop
+         style="stop-color:#83625d;stop-opacity:1"
+         offset="1"
+         id="stop7804" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7806"
+       id="linearGradient7808"
+       x1="1"
+       y1="1039.3622"
+       x2="1"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7818"
+       id="linearGradient7820"
+       x1="7"
+       y1="1047.3622"
+       x2="7"
+       y2="1041.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7832"
+       id="linearGradient7834"
+       x1="3"
+       y1="1038.8622"
+       x2="9"
+       y2="1038.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7842"
+       id="linearGradient7844"
+       x1="4"
+       y1="1043.3622"
+       x2="12"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.99999997,1.735301e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7870"
+       id="linearGradient7872"
+       x1="3.6254385"
+       y1="1037.9174"
+       x2="8.3681504"
+       y2="1037.9174"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#dadada"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="27.0625"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:object-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient7820);stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 1.5981907,1047.8089 11.8205803,-0.03 0.09046,-6.8451 0.904636,-1.2363 0.03015,-1.2062 H 0.30154542 l 0.27139088,1.0856 1.055409,1.2966 z"
+       id="path7812"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1036.3622"
+       x="-18"
+       id="image7782"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAc1JREFU
+OI2Vkz9oU1EUxn/3JSZ1EdeIUKmTBXVxeoNTDajgoIsFLZiGVkcbRZSiQzpJG12kHeIbqmBAcRBC
+7eCkhuqgqx2sIg4Opqml+fP+Hoe+3L4kpdoPPu693zn3O9zDuUpEiGJqdKRDmHw8r9gJIqKZz1wW
+b7ks3nJZgs9lcR/dlNtnTYnmdFNdvTKqK64P3aBWTfL7u/CntZ9W9QfNtW9cOFDetvisVVTxxS8p
+jp9PM3TG3CblaMhzHepb6xUfK58AMFYqeVV//xTP8XFDeraP6wiuLeE+ZKivfn3NSiWvAOIAtTUX
+u+EDwqnDSRTRPsaiHUNQHBq+ppU4gNs6hl33OH0kydz9hzs2vY2FD29EGwA06y6emwBgZDL3Xybz
+UzMYAOuqir3h4Hu+DpYKFulBk/4+NJeevyA9aFIqWPT3beYZABu1FE7Tx/e23n7rTqan4t17BZ6V
+HmAVi509AHCbDr4X6IBhRNZg66wvGhGDgRP7eDm7wMDekzohoSJrjB6043GApSeX9LyP5xYFIBFW
+SMQgddDk188KmWyW4YvXyWSz7Gmbds/22MS0vFsVaQSbbEUY1RqByNjEtKju3ziem+kU/oEeg93i
+L6jeDD0dxAiLAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#123596;stroke-width:1.02499998;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0.5,1039.3622 1,1.5124 v 6.9751 h 12 v -6.9751 l 1,-1.5124"
+       id="path4168"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient7872);stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 3.6254385,1038.9093 4.7427119,-0.046 -0.7524495,-1.8697 -3.0325994,-0.068 z"
+       id="path7864"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient7834);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3,1038.8622 H 9"
+       id="path7826"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4224-0"
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient7808);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0,1038.8622 h 3.5 l 1,-2 h 3 l 1,2 H 15"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="opacity:0.58;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7836-8"
+       width="11"
+       height="7.0000176"
+       x="3"
+       y="1041.3622" />
+    <rect
+       style="fill:url(#linearGradient7844);fill-opacity:1;stroke:#66728c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7836"
+       width="11"
+       height="8.0000172"
+       x="4.5"
+       y="1042.8622" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7854"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       d="M 7.9938082,1049.3622 H 7 v -4 H 6 v -1 h 1.9938082 z"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7856"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 8.9999999,1049.3622 v -1 h 1 v 1 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7858"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 12.5,1044.3622 q 0.671219,0 1.04937,0.5077 0.45063,0.6011 0.45063,1.994 0,1.3894 -0.453781,1.9973 -0.375,0.501 -1.046219,0.501 -0.67437,0 -1.087184,-0.5478 Q 11,1048.2633 11,1046.8538 q 0,-1.3828 0.453782,-1.9906 0.375,-0.501 1.046218,-0.501 z m 0,0.7782 q -0.160713,0 -0.286764,0.1102 -0.126051,0.1069 -0.195379,0.3875 -0.09138,0.364 -0.09138,1.2258 0,0.8617 0.08194,1.1856 0.08194,0.3208 0.204831,0.4276 0.126051,0.1069 0.286765,0.1069 0.160714,0 0.286764,-0.1069 0.126051,-0.1103 0.195379,-0.3908 0.09138,-0.3607 0.09138,-1.2224 0,-0.8618 -0.08194,-1.1824 -0.08194,-0.324 -0.207984,-0.4309 -0.122898,-0.1102 -0.283612,-0.1102 z" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/category_menu.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/category_menu.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="category_menu.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4814">
+      <stop
+         id="stop4816"
+         offset="0"
+         style="stop-color:#f4d323;stop-opacity:1;" />
+      <stop
+         id="stop4818"
+         offset="1"
+         style="stop-color:#fff6ac;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4808">
+      <stop
+         id="stop4810"
+         offset="0"
+         style="stop-color:#bed345;stop-opacity:1;" />
+      <stop
+         id="stop4812"
+         offset="1"
+         style="stop-color:#f5f6a1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4732">
+      <stop
+         style="stop-color:#b3ced8;stop-opacity:1;"
+         offset="0"
+         id="stop4734" />
+      <stop
+         style="stop-color:#e1e6e8;stop-opacity:1;"
+         offset="1"
+         id="stop4736" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4732"
+       id="linearGradient4738"
+       x1="378.39279"
+       y1="513.99323"
+       x2="378.39279"
+       y2="508.60779"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18.403558,-19.476484)" />
+    <linearGradient
+       y2="510.98355"
+       x2="378.39279"
+       y1="515.10492"
+       x1="378.39279"
+       gradientTransform="translate(18.403556,-37.37381)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4755"
+       xlink:href="#linearGradient4814"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="509.39972"
+       x2="378.39279"
+       y1="513.05664"
+       x1="378.39279"
+       gradientTransform="translate(18.403556,-55.112769)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4789"
+       xlink:href="#linearGradient4808"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="9.7384675"
+     inkscape:cy="8.2245465"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4803"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="1036"
+     inkscape:window-x="1329"
+     inkscape:window-y="365"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3962" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.28101705,0,0,0.28101705,-101.25516,911.18848)"
+       style="display:inline"
+       id="g4803">
+      <rect
+         style="color:#000000;fill:url(#linearGradient4738);fill-opacity:1;fill-rule:nonzero;stroke:#5d7bae;stroke-width:3.58380508;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4722"
+         width="28.350628"
+         height="10.61167"
+         x="380.11639"
+         y="486.28043"
+         ry="1.5838363" />
+      <rect
+         style="color:#000000;fill:url(#linearGradient4755);fill-opacity:1;fill-rule:nonzero;stroke:#bb9826;stroke-width:3.58380508;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4722-7"
+         width="28.350628"
+         height="10.61167"
+         x="380.11639"
+         y="468.38312"
+         ry="1.5838363" />
+      <rect
+         style="color:#000000;fill:url(#linearGradient4789);fill-opacity:1;fill-rule:nonzero;stroke:#7eb89d;stroke-width:3.58380508;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4722-7-2"
+         width="28.350628"
+         height="10.61167"
+         x="380.11639"
+         y="450.6442"
+         ry="1.5838363" />
+      <g
+         id="g3004"
+         transform="translate(-2.8912837,0)">
+        <path
+           sodipodi:nodetypes="cccccccccscccc"
+           inkscape:connector-curvature="0"
+           id="path4917"
+           d="m 385.41478,456.68297 -9.22426,3.05897 -7.3916,6.49565 -2.68785,9.63148 0.44797,5.15172 3.13583,5.59969 6.27166,3.35982 6.94362,-1.11994 5.5997,-1.34393 c 0,0 12.02949,-11.19686 11.8896,-14.40082 -0.19915,-4.56128 0,-7.78755 0,-7.78755 l -2.72861,-5.60203 -5.49566,-2.83265 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+        <g
+           id="text4820"
+           style="font-size:39.59736252px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#3a78ad;fill-opacity:1;stroke:none;display:inline;font-family:Sans">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4920"
+             style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;fill:#3a78ad;font-family:Nimbus Sans L;-inkscape-font-specification:Nimbus Sans L Bold Italic"
+             d="m 391.25933,463.92131 -1.06913,2.33625 c -0.79194,-1.97987 -1.86108,-2.73222 -3.84094,-2.73222 -3.08859,0 -6.57317,1.90068 -9.30538,5.06846 -2.21745,2.61343 -3.56376,5.58323 -3.56376,7.95907 0,3.16779 2.21745,5.38524 5.42483,5.38524 2.17786,0 4.35572,-0.98993 6.29599,-2.8906 0.59396,1.82147 2.05906,2.77181 4.27651,2.77181 3.24698,0 6.65236,-1.97987 9.46377,-5.42484 2.29664,-2.81141 3.48457,-6.17719 3.48457,-9.74095 0,-2.57382 -0.87115,-4.94967 -2.65303,-7.08793 -2.73221,-3.36577 -6.61276,-5.02886 -11.68122,-5.02886 -6.49396,0 -12.71076,2.69262 -17.22485,7.4443 -4.03893,4.23692 -6.41477,9.74096 -6.41477,14.88861 0,3.36577 1.34631,6.57317 3.76175,8.83021 2.69261,2.57383 6.29598,3.76175 11.28525,3.76175 3.76174,0 6.77115,-0.55436 9.78054,-1.78188 l -0.47516,-3.12819 c -3.72215,1.18792 -5.90001,1.62349 -8.39465,1.62349 -7.04832,0 -11.998,-4.11813 -11.998,-9.89934 0,-3.56376 1.46511,-7.64229 3.92014,-11.04766 3.48457,-4.79128 8.63223,-7.40471 14.61143,-7.40471 4.15772,0 6.96914,1.10873 9.30538,3.60336 1.66309,1.78188 2.49463,3.76175 2.49463,5.78121 0,2.45504 -1.02953,5.22686 -2.73221,7.44431 -1.78188,2.29664 -4.11813,3.88054 -5.78122,3.88054 -0.91074,0 -1.5443,-0.55436 -1.5443,-1.38591 0,-0.55436 0.0792,-0.83154 0.75235,-2.13825 l 5.38524,-11.08727 -3.56376,0 m -5.70202,2.45504 c 1.5443,0.0792 2.57383,1.18792 2.57383,2.77182 0,1.62349 -0.98994,3.92014 -2.49463,5.9 -1.70269,2.29665 -3.76175,3.60336 -5.54363,3.60336 -1.5839,0 -2.65303,-1.26712 -2.65303,-3.12819 0,-4.03893 4.71209,-9.34498 8.11746,-9.14699" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/correction_change.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/correction_change.svg
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg4223"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="correction_change.svg">
+  <defs
+     id="defs4225">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3837">
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1;"
+         offset="0"
+         id="stop3839" />
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1"
+         offset="1"
+         id="stop3841" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3829">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop3831" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop3833" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3047"
+       inkscape:collect="always">
+      <stop
+         id="stop3049"
+         offset="0"
+         style="stop-color:#146d39;stop-opacity:1" />
+      <stop
+         id="stop3051"
+         offset="1"
+         style="stop-color:#359b58;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23102">
+      <stop
+         style="stop-color:#c9473e;stop-opacity:1"
+         offset="0"
+         id="stop23104" />
+      <stop
+         id="stop23118"
+         offset="0.25388375"
+         style="stop-color:#f35863;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6928e;stop-opacity:1"
+         offset="1"
+         id="stop23106" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5103-3-7"
+       id="linearGradient9563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(19.911612,-20)"
+       x1="12.339488"
+       y1="1043.0511"
+       x2="12.339488"
+       y2="1048.0511" />
+    <linearGradient
+       id="linearGradient5103-3-7">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop5105-5-4" />
+      <stop
+         id="stop7550-07-0"
+         offset="0.26694915"
+         style="stop-color:#c6d560;stop-opacity:1" />
+      <stop
+         id="stop7548-6-9"
+         offset="0.51694918"
+         style="stop-color:#cfdc63;stop-opacity:1" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop5107-7-48" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8562"
+       id="linearGradient9565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(19.911612,-40)"
+       x1="11.339488"
+       y1="1064.0511"
+       x2="11.339488"
+       y2="1067.0511" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8562">
+      <stop
+         style="stop-color:#6994ad;stop-opacity:1"
+         offset="0"
+         id="stop8564" />
+      <stop
+         style="stop-color:#005596;stop-opacity:1"
+         offset="1"
+         id="stop8566" />
+    </linearGradient>
+    <linearGradient
+       y2="1067.0511"
+       x2="11.339488"
+       y1="1064.0511"
+       x1="11.339488"
+       gradientTransform="translate(19.911612,-40)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6482"
+       xlink:href="#linearGradient3047"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3829"
+       id="linearGradient3835"
+       x1="52.177807"
+       y1="-1019.7672"
+       x2="56.177807"
+       y2="-1019.7672"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3837"
+       id="linearGradient3843"
+       x1="53.177807"
+       y1="-1022.2672"
+       x2="53.177807"
+       y2="-1017.2672"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3837"
+       id="linearGradient3851"
+       gradientUnits="userSpaceOnUse"
+       x1="53.177807"
+       y1="-1022.2672"
+       x2="53.177807"
+       y2="-1017.2672" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3829"
+       id="linearGradient3853"
+       gradientUnits="userSpaceOnUse"
+       x1="52.177807"
+       y1="-1019.7672"
+       x2="56.177807"
+       y2="-1019.7672" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3047"
+       id="linearGradient3861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-6.266193,2108.6294)"
+       x1="11.339488"
+       y1="1064.0511"
+       x2="11.339488"
+       y2="1067.0511" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5103-3-7"
+       id="linearGradient3864"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-6.266193,2088.6294)"
+       x1="12.339488"
+       y1="1043.0511"
+       x2="12.339488"
+       y2="1048.0511" />
+    <linearGradient
+       id="linearGradient5103-3-7-7">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop5105-5-4-4" />
+      <stop
+         id="stop7550-07-0-0"
+         offset="0.26694915"
+         style="stop-color:#c6d560;stop-opacity:1" />
+      <stop
+         id="stop7548-6-9-9"
+         offset="0.51694918"
+         style="stop-color:#cfdc63;stop-opacity:1" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop5107-7-48-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3047-8"
+       id="linearGradient3861-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-6.266193,2108.6294)"
+       x1="11.339488"
+       y1="1064.0511"
+       x2="11.339488"
+       y2="1067.0511" />
+    <linearGradient
+       id="linearGradient3047-8"
+       inkscape:collect="always">
+      <stop
+         id="stop3049-2"
+         offset="0"
+         style="stop-color:#146d39;stop-opacity:1" />
+      <stop
+         id="stop3051-4"
+         offset="1"
+         style="stop-color:#359b58;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3829-7"
+       id="linearGradient3853-2"
+       gradientUnits="userSpaceOnUse"
+       x1="52.177807"
+       y1="-1019.7672"
+       x2="56.177807"
+       y2="-1019.7672" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3829-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop3831-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop3833-1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask3991">
+      <g
+         transform="matrix(1,0,0,-1,-46.177805,2068.6294)"
+         id="g3993"
+         style="fill:#ffffff">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           id="rect3995"
+           width="10"
+           height="5"
+           x="48.177807"
+           y="-1022.2672"
+           transform="scale(1,-1)" />
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           id="rect3997"
+           width="8"
+           height="3"
+           x="49.177807"
+           y="-1021.2672"
+           transform="scale(1,-1)" />
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           id="rect3999"
+           width="1"
+           height="1"
+           x="50.177807"
+           y="-1020.2672"
+           transform="scale(1,-1)" />
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           id="rect4001"
+           width="4"
+           height="1"
+           x="52.177807"
+           y="-1020.2672"
+           transform="scale(1,-1)" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4003"
+       x="-0.16799654"
+       width="1.3359931"
+       y="-0.19385077"
+       height="1.3877015">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.65774696"
+         id="feGaussianBlur4005" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3047"
+       id="linearGradient3081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-2.266193,2109.6406)"
+       x1="11.339488"
+       y1="1064.0511"
+       x2="11.339488"
+       y2="1067.0511" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5103-3-7"
+       id="linearGradient3083"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-2.266193,2089.6406)"
+       x1="12.339488"
+       y1="1043.0511"
+       x2="12.339488"
+       y2="1048.0511" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="4.01953"
+     inkscape:cy="10.558477"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3866"
+     showgrid="true"
+     inkscape:window-width="1574"
+     inkscape:window-height="1098"
+     inkscape:window-x="115"
+     inkscape:window-y="119"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4228">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3866">
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4108-1"
+         d="m 5.519236,1047.6671 -0.816057,-1.9944 0.88243,-2.3985 3.398198,0.051 0,-1.5313 3.781143,2.432 -3.781143,3.0027 0,-1.5156 -2.544844,0 z"
+         style="fill:url(#linearGradient3083);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4108-1-6"
+         d="m 7.983807,1047.8309 0,-1.5156 -0.07965,0 c -1.711191,0 -1.9036885,1.2987 -1.9036885,2.075 l -1,0 c -1.937334,-3.08 -0.6777005,-6.0631 1.8476505,-6.0884 l 1.135685,0.023 0,-1.5313 c 0,-0.6519 0.740915,-0.6375 1.5,0 l 3.923255,3.4983 -3.923255,3.5386 c -0.760225,0.7602 -1.5,0.5203 -1.5,0 z m 1,-1 2.985755,-2.5386 -2.985755,-2.4983 0,1.5313 -2.12809,0.07 c -1.65655,0 -2.276462,2.3386 -1.391431,3.4245 0.477391,-0.9138 0.93524,-1.5048 2.407536,-1.5048 l 1.111985,0 z"
+         style="fill:url(#linearGradient3081);fill-opacity:1;stroke:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/eclipse16.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/eclipse16.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 1.3617021 1.3617021"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse16.svg"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.3906251"
+     inkscape:cy="5.2343751"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1682"
+     inkscape:window-height="1033"
+     inkscape:window-x="220"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 0.40346119,0.84984676 H 0.21424145 c 0.0250542,0.0911041 0.0715448,0.17275664 0.13960955,0.24492124 0.10850978,0.1150391 0.23898823,0.1724809 0.39157083,0.1724809 0.0305008,0 0.0600526,-0.00242 0.0887563,-0.00699 C 0.94910676,1.2418648 1.0497284,1.186783 1.1359419,1.0947681 1.2044471,1.022627 1.2512661,0.94095104 1.2765119,0.84984685 H 1.1997235 1.0874392 Z"
+       id="path2" />
+    <path
+       d="m 0.29912249,0.57740797 h -0.0988478 c -0.003616,0.0230246 -0.00608,0.0465284 -0.007199,0.0706312 h 0.1174827 0.0589335 0.85066471 0.077648 c -0.00113,-0.0241028 -0.00359,-0.0476066 -0.00724,-0.0706312"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133164" />
+    <path
+       d="m 0.19307616,0.71362698 c 0.001119,0.0241148 0.003571,0.0476186 0.007199,0.0706312 h 0.10276911 0.0778961 0.83227843 0.077365 c 0.00364,-0.0230126 0.00612,-0.0465164 0.00726,-0.0706312"
+       id="path6"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133164" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 1.2765345,0.51180881 C 1.2513112,0.42045308 1.2044808,0.33841738 1.1359418,0.26574966 1.0499544,0.17459763 0.94961507,0.11991109 0.83505943,0.1015106 0.80608483,0.0968525 0.77623933,0.0944056 0.74542233,0.0944056 c -0.1525826,0 -0.28307238,0.05712998 -0.39157084,0.17134289 -0.0680866,0.0726676 -0.11460096,0.1547034 -0.13964335,0.24605915"
+       id="path10" />
+    <path
+       d="m 0.16022485,0.68085105 c 0,-0.30935886 0.21917824,-0.56640322 0.50430771,-0.61161389 -0.007074,-2.7553e-4 -0.0141825,-5.7502e-4 -0.0213245,-5.7502e-4 -0.31996972,0 -0.57937867,0.2740912 -0.57937867,0.61218891 0,0.33810975 0.25939765,0.61218895 0.57937867,0.61218895 0.007165,0 0.0142729,-2.875e-4 0.0213697,-5.63e-4 C 0.37940309,1.2472663 0.16022485,0.9902219 0.16022485,0.68085105 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       style="fill:#f7941e;stroke-width:0.133164" />
+    <path
+       d="M 1.1213884,0.6480272 C 1.1195384,0.6238166 1.1156884,0.60020499 1.1099524,0.577396 H 0.38093999 c -0.005741,0.022797 -0.009594,0.0464086 -0.0114477,0.0706312 z"
+       id="path37"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_1_);stroke-width:0.133164" />
+    <path
+       d="M 1.1213884,0.71362698 H 0.36950362 c 0.001853,0.0242106 0.005684,0.0478222 0.0114364,0.0706312 H 1.1099633 c 0.00574,-0.022809 0.00957,-0.0464206 0.011425,-0.0706312 z"
+       id="path44"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_2_);stroke-width:0.133164" />
+    <path
+       d="m 0.745446,1.080823 c 0.15139629,0 0.2818975,-0.0945544 0.3419949,-0.23097701 H 0.4034511 C 0.46354855,0.98626865 0.59404972,1.080823 0.745446,1.080823 Z"
+       id="path51"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_3_);stroke-width:0.133164" />
+    <path
+       d="M 0.31377957,0.71362698 H 0.36897247 1.122801 1.22183 1.297059 c 5.198e-4,-0.0104342 8.137e-4,-0.0209402 8.137e-4,-0.0315181 0,-0.0114404 -3.956e-4,-0.022785 -0.00101,-0.0340817 H 1.2218182 1.1227897 0.36896118 0.30986951 0.19307616 c -6.1025e-4,0.0112847 -0.001006,0.0226413 -0.001006,0.0340817 0,0.0105779 2.9382e-4,0.0210839 8.1365e-4,0.0315181 z"
+       id="path55"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+    <path
+       d="M 0.40124746,0.51180818 H 0.21419728 c -0.006148,0.0213595 -0.0101142,0.04327 -0.0139225,0.0655998 h 0.096339 0.0820322 0.73092182 0.103515 0.073986 c -0.00382,-0.0223178 -0.00874,-0.0442283 -0.014872,-0.0655998"
+       id="path57"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+    <path
+       d="M 1.2160096,0.7842462 H 1.1124947 0.38158413 0.30347328 0.20026344 c 0.003707,0.0223178 0.007922,0.0442164 0.0139677,0.0655998 h 0.18993187 0.68575279 0.1125781 0.073319 c 0.00603,-0.0213714 0.010905,-0.04327 0.014623,-0.0655998 z"
+       id="path59"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/frgmt_obj.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/frgmt_obj.svg
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="frgmt_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#964ecd;stop-opacity:1" />
+      <stop
+         style="stop-color:#a471c5;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#763db7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28984397,0,0,0.32432277,-81.608152,874.91954)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0-9" />
+      <stop
+         id="stop10521-1-2-5-3"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29647957,0,0,0.24303159,-83.809127,918.00795)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-3-4">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0-5" />
+      <stop
+         id="stop10521-1-4-7"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(0.30039597,0,0,0.29264682,-87.12885,891.60319)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-18">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-8" />
+      <stop
+         id="stop10521-7"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-6"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(0.28995536,0,0,0.10976219,-83.833594,987.82732)" />
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         style="stop-color:#b88bd6;stop-opacity:1"
+         offset="0"
+         id="stop10159-5" />
+      <stop
+         id="stop10165-9"
+         offset="0.5"
+         style="stop-color:#c39ddb;stop-opacity:1" />
+      <stop
+         style="stop-color:#ccace1;stop-opacity:1"
+         offset="1"
+         id="stop10161-55" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-5">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398-7" />
+      <stop
+         id="stop10404-9"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27929794,0,0,0.27455303,-80.466752,901.06458)"
+       x1="305"
+       y1="519.01025"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#d8bde7;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#c49fdc;stop-opacity:1" />
+      <stop
+         style="stop-color:#b382d3;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27929794,0,0,0.27455303,-80.466752,901.06458)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#6936ae;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#964ecd;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7-2" />
+      <stop
+         id="stop10394-3"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09367554,0,0,0.16487513,-23.823728,957.45703)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.0832705"
+     inkscape:cy="12.606498"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1349"
+     inkscape:window-height="978"
+     inkscape:window-x="979"
+     inkscape:window-y="516"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4228"
+       transform="translate(0.0078125,-0.98828125)">
+      <rect
+         ry="0"
+         rx="0"
+         y="1043.3639"
+         x="10.137314"
+         height="3.0210745"
+         width="5.8647346"
+         id="rect10007-0-74-2-7-6"
+         style="fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4313-8-8"
+         d="m 12.648438,1043.3652 0,1 3.351562,0 0,-1 -3.351562,0 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4313-8-8-7"
+         d="m 12.981809,1043.3594 0,3.0195 1.01551,0 0,-3.0195 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4313-5-1-8"
+         d="m 15.992188,1045.3613 -3.359376,0.031 0.0098,1 3.359375,-0.031 -0.0098,-1 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1043.3788"
+         x="9.8042965"
+         height="3.9701591"
+         width="3.1863005"
+         id="rect10007-0-74-2-7"
+         style="fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4313-5-1"
+         d="m 13.005859,1046.3711 -3.3593746,0.031 0.00977,1 3.3593746,-0.031 -0.0098,-1 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4313-8"
+         d="m 11.991204,1043.3634 -2.3544852,0.028 0.00685,0.9091 2.3544842,-0.028 -0.0069,-0.909 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1043.3693"
+         x="7.7211761"
+         height="4.979126"
+         width="3.2956753"
+         id="rect10007-0-74-2"
+         style="fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1044.2872"
+         x="4.0091462"
+         height="3.0751004"
+         width="3.7469046"
+         id="rect10007-0"
+         style="fill:#763db7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1043.8904"
+         x="1.4800291"
+         height="1.9523926"
+         width="3.0032339"
+         id="rect10007-0-7"
+         style="fill:#9f67c2;fill-opacity:1;stroke:#8f4ac8;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1044.3788"
+         x="4.030694"
+         height="1.9366455"
+         width="3.7253628"
+         id="rect10007-0-74"
+         style="fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4313"
+         d="m 11.042833,1043.3647 -3.4061142,0.029 0.00991,0.9204 3.4061132,-0.028 -0.0099,-0.9205 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4313-5"
+         d="m 11.001953,1047.3613 -3.3593749,0.031 0.00977,1 3.3593749,-0.031 -0.0098,-1 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0"
+         id="rect10007-6"
+         d="m 6.4755132,1043.9833 c 1.0259795,0 2.0241511,-0.1891 2.0241511,0.834 l 0,3.5451 c 0,0.8271 -0.6658339,1.4929 -1.4929011,1.4929 -0.8270672,0 -1.4929011,-0.6658 -1.4929011,-1.4929 l 0,-3.5537"
+         style="fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1044.3527"
+         x="4.9943314"
+         height="3.2686768"
+         width="1.0209608"
+         id="rect10007-6-6"
+         style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4313-8-8-7-8"
+         d="m 11.003629,1043.3647 0,3.01 1.000277,0 0,-3.01 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4313-8-8-7-5"
+         d="m 11.992245,1042.3524 0,1.0351 1.01551,0 0,-1.0351 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/library_obj.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/library_obj.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="library_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4918-5"
+       id="linearGradient4975-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0039184,0,0,1.0592719,0.03121502,-66.110757)"
+       x1="6.6639614"
+       y1="1051.8521"
+       x2="6.6639614"
+       y2="1053.6217" />
+    <linearGradient
+       id="linearGradient4918-5">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-9" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4907-9"
+       id="linearGradient4977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0039184,0,0,1.0592719,0.03121502,-66.110757)"
+       x1="6.6639614"
+       y1="1051.8521"
+       x2="6.6639614"
+       y2="1053.6217" />
+    <linearGradient
+       id="linearGradient4907-9">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-5" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928-4"
+       id="linearGradient4979-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9970424,0,0,1.0005798,0.0734075,-8.3185454)"
+       x1="5.9250002"
+       y1="1051.6095"
+       x2="5.9250002"
+       y2="1054.2059" />
+    <linearGradient
+       id="linearGradient4928-4">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-9" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4938-8"
+       id="linearGradient4981-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.07142294,3.4940206)"
+       x1="4.8973203"
+       y1="1038.0688"
+       x2="4.8973203"
+       y2="1038.833" />
+    <linearGradient
+       id="linearGradient4938-8">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-4" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-6">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-0" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.2014"
+       x2="18.744612"
+       y1="1040.0764"
+       x1="15.073242"
+       gradientTransform="translate(-4.5808058,0.68500969)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5020"
+       xlink:href="#linearGradient4961-6"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="0.52179164"
+     inkscape:cy="14.434565"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4969"
+     showgrid="true"
+     inkscape:window-width="1395"
+     inkscape:window-height="1016"
+     inkscape:window-x="454"
+     inkscape:window-y="446"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3948" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4969"
+       transform="translate(-0.18750003,0)">
+      <rect
+         y="1046.8949"
+         x="1.6949905"
+         height="2.9961412"
+         width="8.9843884"
+         id="rect4897"
+         style="fill:url(#linearGradient4975-9);fill-opacity:1;stroke:url(#linearGradient4977-3);stroke-width:1.03122377;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1043.8386"
+         x="2.6730409"
+         height="2.0545635"
+         width="7.0478754"
+         id="rect4926"
+         style="fill:#78b87c;fill-opacity:1;stroke:url(#linearGradient4979-8);stroke-width:0.99880952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1041.4269"
+         x="1.6845102"
+         height="1.4362251"
+         width="5.9883103"
+         id="rect4936"
+         style="fill:#0595d3;fill-opacity:1;stroke:url(#linearGradient4981-3);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4949"
+         d="m 9.6799362,1040.2751 c 0.08839,-0.044 1.5696578,-0.9063 1.5696578,-0.9063 l 3.976711,10.3859 -1.956435,0.5243 z"
+         style="fill:#f0c028;fill-opacity:1;stroke:url(#linearGradient5020);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/plugin_obj.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/plugin_obj.svg
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="plugins.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28984397,0,0,0.32432277,-81.608152,874.91954)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0-9" />
+      <stop
+         id="stop10521-1-2-5-3"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29647957,0,0,0.30390146,-83.81694,885.61311)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-3-4">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0-5" />
+      <stop
+         id="stop10521-1-4-7"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(0.30039597,0,0,0.29632024,-87.12885,889.63566)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-18">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-8" />
+      <stop
+         id="stop10521-7"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.27903303,0,0,0.27903303,-80.383503,898.62929)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.27903303,0,0,0.27903303,-80.383503,898.62929)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-6"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(0.28995536,0,0,0.16531775,-83.833594,958.22386)" />
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-5" />
+      <stop
+         id="stop10165-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-55" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-5">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398-7" />
+      <stop
+         id="stop10404-9"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27929794,0,0,0.27455303,-80.466752,901.06458)"
+       x1="305"
+       y1="498.24542"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.49999985"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27929794,0,0,0.27455303,-80.466752,901.06458)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7-2" />
+      <stop
+         id="stop10394-3"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09367554,0,0,0.16487513,-23.823728,957.45703)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="47.607658"
+     inkscape:cy="-9.9169213"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1609"
+     inkscape:window-height="978"
+     inkscape:window-x="719"
+     inkscape:window-y="519"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2-7-6"
+       width="5.8647346"
+       height="3.0210745"
+       x="10.137314"
+       y="1043.3639"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 12.648438,1043.3652 0,1 3.351562,0 0,-1 -3.351562,0 z"
+       id="path4313-8-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 12.981809,1043.3594 0,3.0195 1.01551,0 0,-3.0195 z"
+       id="path4313-8-8-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 15.992188,1045.3613 -3.359376,0.031 0.0098,1 3.359375,-0.031 -0.0098,-1 z"
+       id="path4313-5-1-8"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2-7"
+       width="3.1863005"
+       height="4.9645281"
+       x="9.796484"
+       y="1042.3844"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 13.005859,1046.3711 -3.3593746,0.031 0.00977,1 3.359375,-0.031 -0.0098,-1 z"
+       id="path4313-5-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 12.996094,1042.3633 -3.3593752,0.031 0.00977,1 3.3593746,-0.031 -0.0098,-1 z"
+       id="path4313-8"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74-2"
+       width="3.2956753"
+       height="6.9635262"
+       x="7.7211761"
+       y="1041.3849"
+       rx="0"
+       ry="0" />
+    <rect
+       style="fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0"
+       width="3.7469046"
+       height="4.9969754"
+       x="4.0091462"
+       y="1042.3654"
+       rx="0"
+       ry="0" />
+    <rect
+       style="fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:0.41854954;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-7"
+       width="3.0344839"
+       height="2.6086426"
+       x="1.1987791"
+       y="1043.531"
+       rx="0"
+       ry="0" />
+    <rect
+       style="fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-0-74"
+       width="3.7331753"
+       height="2.9757195"
+       x="4.0228815"
+       y="1043.3397"
+       rx="0"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 10.996094,1041.3613 -3.3593752,0.031 0.00977,1 3.3593746,-0.031 -0.0098,-1 z"
+       id="path4313"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 11.001953,1047.3613 -3.3593749,0.031 0.00977,1 3.3593752,-0.031 -0.0098,-1 z"
+       id="path4313-5"
+       inkscape:connector-curvature="0" />
+    <rect
+       ry="1.0288811"
+       style="fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-6"
+       width="2.9858022"
+       height="9.9848661"
+       x="5.5138621"
+       y="1039.8705"
+       rx="1.0288811" />
+    <rect
+       style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect10007-6-6"
+       width="1.0014296"
+       height="5.5773177"
+       x="5.0138626"
+       y="1042.0441" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 11.003629,1043.3647 0,3.01 1.000277,0 0,-3.01 z"
+       id="path4313-8-8-7-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/ovr16/error_ovr.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/ovr16/error_ovr.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_ovr.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="256"
+     inkscape:cx="3.8095711"
+     inkscape:cy="2.2892427"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4171"
+     showgrid="true"
+     inkscape:window-width="1236"
+     inkscape:window-height="1004"
+     inkscape:window-x="828"
+     inkscape:window-y="425"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <rect
+       style="fill:#d8424f;fill-opacity:1;stroke:none;display:inline"
+       id="rect4244"
+       width="7"
+       height="8"
+       x="-1.1130133e-007"
+       y="1044.3622" />
+    <g
+       id="g4171">
+      <path
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 2,1 0.96143694,0.98353403 1,2 1,3 2,3 3,3 3,2 3,1 Z"
+         transform="translate(0,1044.3622)"
+         id="rect4137"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.0022321,1045.3622 1.0385631,-0.016 -0.038563,1.0165 0,1 -1,0 -1,0 0,-1 0,-1 z"
+         id="rect4137-2"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2,1051.3667 -1.00084097,0 L 1,1050.3667 l 0,-1 1,0 1,0 0,1 0,1 z"
+         id="rect4137-0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.0022321,1051.3667 1.000841,4e-4 -8.41e-4,-1.0009 0,-1 -1,0 -1,0 0,1 0,1 z"
+         id="rect4137-2-5"
+         sodipodi:nodetypes="ccccccccc" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4141"
+         width="1"
+         height="2"
+         x="3"
+         y="1047.3622" />
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/ovr16/success_ovr.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/ovr16/success_ovr.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="success_ovr.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4156"
+       id="linearGradient4162"
+       x1="3.7713745"
+       y1="1061.4009"
+       x2="3.9301004"
+       y2="1067.0873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99979136,0,0,1.0107427,-1.0170045,-1063.6918)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4156">
+      <stop
+         style="stop-color:#81c6a2;stop-opacity:1"
+         offset="0"
+         id="stop4158" />
+      <stop
+         style="stop-color:#479a6f;stop-opacity:1"
+         offset="1"
+         id="stop4160" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="70.375"
+     inkscape:cx="3.5044489"
+     inkscape:cy="4"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     transform="translate(0,-8)">
+    <path
+       style="display:inline;opacity:1;fill:url(#linearGradient4162);fill-opacity:1;stroke:#029e4b;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 0.5,8.5 6.0088978,0 0,6.999965 -6.0088978,0 z"
+       id="rect7768"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path4065"
+       inkscape:connector-curvature="0"
+       d="m 1.761221,12.442778 c 0.4074842,0.627763 1.2262681,2.278541 1.5690748,1.64183 0.4243273,-0.788032 1.9178196,-4.349962 1.9178196,-4.349962"
+       sodipodi:nodetypes="csc" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/ovr16/warning_ovr.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/ovr16/warning_ovr.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="New document 1">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient5087"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient5097"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(3.8209032e-8,1044.3622)"
+       y2="0.98171616"
+       x2="3.3833356"
+       y1="7.0159616"
+       x1="3.3833356"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4230"
+       xlink:href="#linearGradient5081"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8209032e-8,1044.3622)"
+       y2="0.39338252"
+       x2="6.3885393"
+       y1="7.2369323"
+       x1="6.3885393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4232"
+       xlink:href="#linearGradient5091"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="-0.70863259"
+     inkscape:cy="2.3717404"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="945"
+     inkscape:window-height="1125"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3024"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <path
+       style="fill:url(#linearGradient4230);fill-opacity:1;stroke:url(#linearGradient4232);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+       d="m 2.8125,1045.2684 -2.03124996,4.0938 c -0.60602934,1.0251 -0.19281594,2.4817 0.93749996,2.5 l 1.28125,0 1,0 1.28125,0 c 1.1303165,-0.018 1.5435294,-1.475 0.9375,-2.5 l -2.03125,-4.0938 c -0.2942923,-0.5567 -1.1188077,-0.4672 -1.375,0 z"
+       id="path4292"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+       id="path4253"
+       sodipodi:cx="3.484375"
+       sodipodi:cy="5.484375"
+       sodipodi:rx="0.625"
+       sodipodi:ry="0.625"
+       d="m 4.109375,5.484375 a 0.625,0.625 0 1 1 -1.25,0 0.625,0.625 0 1 1 1.25,0 z"
+       transform="matrix(1.0523812,0,0,1.0523812,-0.16689048,1044.2631)" />
+    <path
+       style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.5142345,1046.253 c -0.3537485,0 -0.6547532,0.3148 -0.6547532,0.7235 l 0.085402,1.3916 c 0,0.3633 0.2549073,0.6577 0.5693508,0.6577 0.3144435,0 0.5693489,-0.2944 0.5693489,-0.6577 l 0.056931,-1.3916 c 0,-0.4087 -0.2725362,-0.7235 -0.6262867,-0.7235 z"
+       id="path4253-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccsccs" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/wizban/compare_wiz.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/wizban/compare_wiz.svg
@@ -1,0 +1,1180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="applypatch_wizban.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,22.503359,158.27907)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#dbe2eb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7798932,0,0,2.8715894,22.273474,-1974.3527)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,22.503359,158.27905)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6411">
+      <stop
+         style="stop-color:#4f605c;stop-opacity:1"
+         offset="0"
+         id="stop6413" />
+      <stop
+         style="stop-color:#dbe2eb;stop-opacity:0"
+         offset="1"
+         id="stop6415" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4264"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4456935,0,0,1.5152448,-25.667265,-537.6685)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#f4ae5f;stop-opacity:1;"
+         offset="0"
+         id="stop4260" />
+      <stop
+         id="stop4266"
+         offset="0.41542953"
+         style="stop-color:#eec290;stop-opacity:1" />
+      <stop
+         style="stop-color:#c7700e;stop-opacity:1"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4527"
+       id="linearGradient4533"
+       x1="29.521629"
+       y1="29.827848"
+       x2="31.546745"
+       y2="39.175972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-0.41994314,1068.4388)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4527">
+      <stop
+         style="stop-color:#68b367;stop-opacity:1"
+         offset="0"
+         id="stop4529" />
+      <stop
+         style="stop-color:#5eaa6e;stop-opacity:1"
+         offset="1"
+         id="stop4531" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4578"
+       id="linearGradient4584"
+       x1="42.780308"
+       y1="1025.5621"
+       x2="40.143147"
+       y2="1039.7532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-8.6400594,2067.7057)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4578">
+      <stop
+         style="stop-color:#c5f0b4;stop-opacity:1"
+         offset="0"
+         id="stop4580" />
+      <stop
+         style="stop-color:#80c171;stop-opacity:1"
+         offset="1"
+         id="stop4582" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient4314-5"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient4499"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,-9.5473378,158.33322)"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4501"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7798932,0,0,2.8715894,-9.7772236,-1974.2986)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,-9.5473378,158.3332)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4505"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4456935,0,0,1.5152448,-57.717962,-537.61435)"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient4314-5-4"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344-1"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346-7" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bcbcbc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.293333"
+     inkscape:cx="74.924774"
+     inkscape:cy="33.000009"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       transform="translate(0,-986.3622)"
+       y="986.36218"
+       x="86"
+       id="image4401"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAS9ElEQVR42uybaXAlV3XHf+fe7n6rnp40+3hW
+ezAGGy8BHC8sXhJjh8IOpCpJhaUwVVSFpCqYJR9SldRkUlRBYRxC+JAUMbFDQoJZYkOI2UwMGGeA
+YHtsYw8eLzPSaKTRSKOR9KS3dt+TD/329zSj0YwcF86tkt573be7T//vWf7n3HuF/2992ye/dMSq
+klTVQVUGgJT3/7B0AOQDKVVyzmlGlVT7+Zc9WJ/+6rhVJeOUpHOaUqcZpwT9+r5swfrsvRMp50ir
+aqBgUR1ANXGya15WYP39N44apyRUdUAVKwKqpFHNAnKq6182YH3um5MDTjUtYFSBWJtyAoEs8x6/
+8mB9/v7JlFNiTQI0VqGUwoCA6GncS1ZLyDf81a4T1vPy1Urp1r17Ru5+sUG6+zvHAlVyquo7B05B
+VVFlQFXTzoFzitP4M6p/qsZ9X1Swrr/91/Tmm97Pvd/4DJUlALty9/b3Am8GdrQd3gf8cO+ekftW
+8tx/+d6Udao5VZINgOpgCWhelcC5+rGXCljX3f5a/eP3fIzJ6cN8+eufplIpNgG7cvf224Ddu3Zd
+kt92zg7WDQ1jxWFwjI6PcOD5Zzg6PXkI2HM6WvnFB6YyqmRV1ThtaZNTPGBQnXoNcF5SYF37ydfp
+R279OE6V8elRvnTfHVQqxQ8Bt2zbcdE1V151M8O5QTyJWFiYwZcIK450IiCdCBg9cogHf/JDRsfH
+fgC8fe+ekdmlnnXPg9N+XZsC1TYQYrA8YFgVaQfnJaZZr9O/eN/t7H3uKS7Ydi5HZ8b58tfv4LLX
+38yuV12Bqy1y5MhBZmenUFfFisbaZRzZpM/2DRvZvmEj9z3wTfbtf3IfcG0/wL7yg+mMU7KqGKf1
+l62DoLFGDauqOO0EZyVgrVo0NCJkrKVUWuThXzzCr1/4Wt79zo8RegFHjh1hdPRZNKqirkqlXABC
+rFE8cVSrAZVqmSPHxvmNq68lCIJLf/b4I/cC1zbu/+8PHTfOMaRoIBpHuQ4tEDwjDDtFVM/OO60a
+WFYEBySsYaZQ5Of7H+U1F1zK2NExDhw8AC5kbm6aUmkOKw5rWn9zC46EZxnK5XAHarzp9VdzdGry
+GnZz2949I39z34+PJ50yKNLkTF1AiSfCsDqkF8aXIFhGhFAdgTWkPEu1XOSxp37OfLGIBcYmJ4jC
+ElKbJQrnCSuF5rVBIkk6M0AYVimVF3DOccMbr+POe76w+4P/+OdfQyQU1b4wCHhiYh+lZ/udVg8s
+iJQ6WIaEZ9GwRmANVpRd552PHx0nXDwyG1YKe4Cde/eMyN49I1KtlC+bnZm6e3J8jPlCgbGpcabn
+TnDxBRfm909+99aTkEbPGhmWVfLFZjU1y6kSGEPCWhLWkLCGwBo25tdw3SVXcv0N7yYIUnng0N49
+I4ca1+7dM7Jv756RW51zl01OTMzOFwqMTBxm8/pNlKon3tIXKMFaK8PI6gWtVQPLIiiK3wDJGHwj
++GIolhZ55OnHWLdmKze97Y9IJFJ31QlqR9u7Z2RfPrX5xmNHJzkxP8tscZ5Iw4v6qJRYQ15WMbqv
+umZFGnL46AGOHDvI6NGDHD46wtHpcY5OjXPg4AEefPgBJPB5+83vI5FI9gD23Z/P5m67/v5R36Tu
+mZ2bI5lIoupyPY7XyrCIrHqea1bv1o6xsScgrOIZwZr4WKVaplIpU66UGDsyyn3/+S0eO/Ac1117
+C9b6d125e/sOgAcemc0DGYD1A7u+UiqWWFhcQMTMdwBlJCcvUkFg1R4yMTOx73P3fvbS5fR95vHH
+eeZxAGaTftZ8/9HZtar4jfO3XvVP//3x713O2PgRApv6VtPUjaRFNOXci5OcrxpYe/eMXHa61/xg
+35xRZVhV/e6w72nqH07MLOSuOf+DuwGMITDCgNNVxUdU8eopk3Q4xKmH7nhvVwXgbLRDwH3r3viR
+2ZN1+tETc74qwxtLD2/PhYd+t3UmRqOdfCrGOPFTqi2Hrm1f2vGLr1MO1c7/xnPlV44vme44JHTq
+O6eeKn49VZIlc8Oph+54cG79TddIHUOp/+v4RJoQSz1mL3We4jThk3eTWLtt1vipW9e/6SN9yy4/
+fnLeV2XYqZodi/9xleZ2fDUK1vTK0Bze5csgQG3f5/GTAbXUli9+e/6WTzXAiSL1w0h959SPHF4j
+t9Tl5IahU8LkptaDuoRogigg7QLVf2sbsIggmc14A5upjD2ZN0Pb7x3/4adu3fzmj3aUXB7+RQxU
+I9hETnH+MFFy4zJkaAHVDqJAXZb4h91xHbV9d0Ju4Z2/NVy+/Efz1902Fa6pNhLn5eaOphsskbog
+Il3fpeccJ+tbfwH7yt8mk8tiFicI54/dNfpftzfpwd6nC75ICyiAqC2NOdVgtQMlbUB1y2S2vIH0
+uq0E4Qxuav8rrsh+/2/z3kz2jKhDLdK6gO0Pbheo+7d0vVDXdSLo4C68/DaGL72FoDZPVJi66/kH
+PnnNT/cXfKETqMaAcZLn9A5OHcQlBqshk9lwGYO7riabX4d3/JnzXpt56ANnBFbo9BRm12ckl9Su
++j2MUAs2YIwhu+VCEqVxXHnh3vTMg5f043mRq08qyNLAyKlkaoLdurY2+GokqpDddhmphCVT2H/D
+FdnvveMMNes0zW4ZAqs3QHhsPxKVSQ4MERRG8lJ45jP9BGpq1nIHi5MMVpuMYXIjbm6MaG6MZG6Y
+ZHWKIXfwAzsTT523Ip5Vc0qyTcBSqUItjHqjToffaDl13/MIfItnDdYzmMZJdbi5I+AHWONImhrl
+wthVibF//r3SOe+6pxsspW2AlvBdjd8uckSRa4uUfSwDqDkPijNEYQWMECSTpAqH2JrLf+D50qs/
+evpgRa0XV1UOjh5jsVQmlfTw4nylOVsSOSWKHGHkCEMlco78YIa1QxnWDGZJpwJsEGuWC0NMZR4X
+eoixBImA7OIxFheHPgx0gRVzpVNFu4aPLBSKLBRLOOdQbfk72vwmda3cXCujURWMxbNC0oRkFw9e
+8prkgzc8Xrr2u6epWa5uaoIR4YJd5+Cc6zAHukasczQFYyTWLGswxhBFIV7hMD5x5dQZwfpJajUl
+WZzYWh751xvZ+gff7tGsPtSENrNrgDiUzzI4mOkBt9uUq0cejVmmKk4U4/loUsgUpkl7R68CThOs
+ZjSMBfJ9r8MvdI6snPxc/XitViNfeAGXHOJ45hWM1tYyOR9SK81BcZL1mcULLXy75eC1RSr7mF0P
+iGIw/fq19VVVvOnHMQ7KmU0c9bYxVkyzWCyileNkvcWrT9sMw0hbL68wOj5NqVTB901zhOLkoU7m
+nOJUm7MimXTAYDZNLpskmfDwfY+B2hThRe9iccPl1IpFkjPHGUgcZ35untnIY41bxPb4LF3S7LoH
+ZGGxRKlcaZogPUw/lnutpDl00Z+hqWFqlRKJ2RkWpqYomPXgDq7MwTd5C1ov3zVIYlcipg2gXBOs
+KHI454ici1mxgua3U8vvICEQBD6+7+F58V9YmaXmFjoWQ0XNaNjGnbq0tSOw0J0dSjMnFIkHVASm
+z7mJVNInmfBJpxL4ngV1eL5HZfrQCsBqN0Mj7Ni6vhl+YXlm12uiLX9nxJLNZlEXoRpRXshRm5/o
+5FkkEtphhr2+q913DubSDObSfc/1RNC2fNGzEIVVrDEcmZaVgtUaOdoSy4Zpan3piUh8LhZQ68fr
+IKkiRhBj2nxILLxnDAPZAaIoYv5EhskZ19AL65wO4A+uB6VYKTEyMdETWATYuXkzmVQMUBhGTfna
+zZU+5tu4h2eEZDJFbnAQpw4xHriVmGHDKTrliV8eZqFYIp30sEaayh5FMW2InBJGjiiKP4dyaTas
+HWQ4nyabTpBM+BjTm8P5vk82myGTyVCphtRXtWStkYxDrCqMTEyw586/6yv0n77r/Vx18auohRFf
++ubPmJ6ZxxptAlKfjUZV6jPMgudZtm0cYufWNWzfPMy64SyZdBoXhRi7ErCitkTaCDu3raNWC1tm
+1+E8489GbQiUwPdIJjySCZ/AtxiRThbeZhrJRIJEMklEkFJlQARrjaQipyjC+qFh3vbG6ylXwp6K
+kmdjrfI9y5svP59SqdpBRmlzDWEUNYgIqaRPLpskl03iexbPM6TTGdSYMzRDA0O5dP/Mv29I7w7d
+/clk47f1PIIgwImx9UmHDCBRvVi3fniYd77lRsLI9alZSZ3Twblb1i7pI3v8aZ8SUyIRoKwUrIYZ
+ohybLlAsVTC2rbrQCIZ18jg4kCI/kCKZ8E8eubp8B4C1Hg4wRnwjEjhVGpoVa44h8E0X2G2DBRRL
+VUqVap9iZQxoMuGRTgX4ntfXh1lruwvGp0sdQB0cOz5PYbFEMrCIkQ4+FoYR1Zpj7VCWhG9JBh6C
+6SKM/clk01KMIXTgWRlo0KSGZvVEsD6OGmChWKawWEa1Xq6o50qCIEZIJxMEvsX3bB3ozllYEcGx
+ArCqbdTBWuHiV21taQe6NEkUMGJOSTO6m6qiYn0E06BJUVcifSpqsnFdnk3r6etPO2mLWVKBwmVW
+SpfwWf1CrunJy07X7HpmFhUiNR0yxJq1hNn18ZG1WtiqjPSbO2hLqK2N81ZjDNa0gk/kWKEZ9jjF
+PsJ3m8UpcrilmsbgSCdYiqouSTI7NVWZmikwO1/EuahzPl86qw7GCNl0HAkz6YCE72GtdNTQVsTg
+zzjayfJWZ6j2ChrTkM7S9ts++iEAvvaJO0glvLbBMmxan2fj2sHOigRLm74xcUXFtPvglYPVGslK
+pUa5WuuT6Us9ksQPbh9J3xp832KMwZiTg+ZUCSPtKitrW1m58/qpEyW2bxzoGCzfM8v2kUu10Omy
+lpQsAZYQRY7Hnh5loVgmk/JpDITSIKLxi4ZRFBf/IiU/mGbT2gHWDQ+QSSdIp3zsSQifNop9XWYI
+cHB8nDu/fm/Hub/+t8+TDCx/+I7f4bxz4lrbY/vHmCsUm2AZY2jGI1oB0hhDPpdiKJdmcCBFNh1H
+ySZY9rR9lms6aN8zXHzBFqrVsHdis53Rt323RvD9mBn7nq1r3anM0PXVrGK5xJPPP9dx7sBoXEp5
++oVj7NpyDmGk7H/+KMdPzGNM25SxNgsjzZTHGMP64SzbzxlmuwyTCLw6nahXOuyKqEPL5+SyyTOK
+dsvxWbUufxHVX/TiXbv4wu5PMD1b5sOf+UsAPn3bno4Il0p4vOeWyzs5w7KXRLUuCR1n4ODrwzM5
+XaBcCeMkWrSVHbaKEi2+pBD4HqmUTzoREATxxIWc5CUcShjRo1kNMNYNpVg/1NofmUl57NyU6xis
+dke90nbGDj6K4ODhaQqLZZIJj4braVQb4spDPFERRQ6nkM+l2bw+x9p8lozWfdZJwOoXDSNHW8kl
+1tzf/823MFuodlEVqQ/oAvMLpZjBt41kY+oskwrID6bjDGMJWcJI8S2mVa04TZ7le8IVl53bnGnp
+njhYzso/Maf2WdZ66YStrVOJNS2VCPLdvOq9b30r5WqEZ6XDTTRWyFgrqJoOLUd681g5iWbtWscW
+1VZAOG2e5bUX787QPy1FHXzfH7JaOU+JfWw6GWzStpkjQbAWsmmvRwYRYcPa3FkxwzWZ6Hw9yQoR
+VaL+Dh5B1fHC6DSL5Urd97QicoM6RJGSyybZsDZHJp1oFgiX7eABz3hDhNWdjXv71mxabiJ+tlro
+IGVr5/ezP0WcIlWnsrikg1eF+cUy84USgW86TCqeXI3BEiPkqyHpVMDpLhZWBSt2natWLgRURKpW
+JaPd6Y3Iqi5DDp1iXe3czoVroipSVmQxQubBlvrUs6ivvre87qJtq7oGMSbOMuRqNSPGLGLsvKpK
+v5IMqwyWiWr1NQ/i1JgyyAJiqg5TjdSeKIXmsAF47tCR4NnnD68V46U6FoKscqvPPwaAQaQo1h6r
+KMe6Z6RfDLBQzcYby9UHKTqxEzX8g8XQf2Jywf+fZybso97+Xx58a2Wh9AoXRq8czA7slBdLwgYp
+VQpeIjFiPG8KY0rGyNoVcMwzanVupypmTq03Eol3uOy8Fwple2hyTg5PzTPnHOqF1dqNGrotURRt
+DYw38IX773/RhDw+O4fne9M2mRhRlYpGkajT4Ds/+SmPP/vsiybH0eMzOOs/44w3UlXv8ELFvjBV
+MKOTsxyvhjRnTOSpXzz3J6qaVqcJYyQH4hljUoDRPprQOwesPSuEG4clvo+0X1unBRHWLojxZtTY
+Ew4puwiHukBVPXXOtnK7FvfR+hLKjmONpQRt/WnrR1v/BgfruF/9d+SkWqpJYbYoJ04ssFCLiLpf
+qans5WqUUmXIOYad4rV2dTZ3hbZtp9XW0iNt7f5s7iCN6+ppayTtGhu6HTh19R2jvbtI1dWf1fHZ
+3o94qUDXs/r3bV2j6vqfd336n2K1sgGo1pwRJF9fNXzGGwlEEM9Kil+xZur6NaSwBjk7Oy48K4nV
+3qH1fwJWGLkksOlsAQXgW0nzK9gMsPNs7qryjQQiYn4VwfrfAQAc9dDnZ0sguwAAAABJRU5ErkJg
+gg==
+"
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66.000015"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5-7"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient4314-5-4);fill-opacity:1;stroke:none;filter:url(#filter4344-1)"
+       transform="matrix(0.81385308,0,0,0.61823795,-26.010509,404.93119)" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient4314-5);fill-opacity:1;stroke:none;filter:url(#filter4344)"
+       transform="matrix(0.81385308,0,0,0.61823795,8.9894909,404.93119)" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 37.506494,1008.8603 19.753919,-0.2323 7.608429,8.7088 0.07385,27.9289 -27.288467,0.2323 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 37.555332,1008.952 19.486128,0 c 0,0 5.85893,1.2059 4.373085,3.9843 -0.04608,0.087 4.030127,4.7374 4.030127,4.7374 l 0,28.1389 -27.88934,0 z"
+       style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0"
+       d="m 57.260413,1008.9265 7.577969,8.4882 0,8.8212 -11.121134,-7.7162 c 1.458578,-3.0944 2.515266,-6.3264 3.543105,-9.5932 z"
+       style="display:inline;fill:url(#linearGradient4240);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4"
+       d="m 57.057798,1008.3236 c 1.63519,2.2276 3.607055,5.0773 2.145555,9.9462 3.363056,-1.9023 6.847609,-0.8933 6.847609,-0.8933 0,-4.5455 -5.518386,-9.2672 -8.993164,-9.0529 z"
+       style="display:inline;fill:url(#linearGradient4264);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1038.3622 9.700639,0"
+       id="path4696"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#879ab6;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1034.3622 14,0"
+       id="path4696-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1016.3622 12,0"
+       id="path4696-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1020.3622 12,0"
+       id="path4696-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#7b8fae;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47.000001,1024.3622 14,0"
+       id="path4696-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1030.3622 12,0"
+       id="path4696-2"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g8662"
+       transform="matrix(-1.0520896,0,0,-1.0534376,64.741831,2090.0588)">
+      <path
+         style="fill:url(#linearGradient4533);fill-opacity:1;fill-rule:evenodd;stroke:#398a43;stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.244943,1041.4693 c -0.24182,0.7378 -4.276215,-4.6418 -4.276215,-4.6418 -11.44876,7.9356 -17.573348,-1.4122 -16.632852,-8.3285 0.287455,-2.114 2.873263,9.5491 13.24418,4.9398 0,0 -6.161054,-4.0913 -5.456972,-5.1523 0.390532,-0.5886 13.008987,-0.7195 13.731155,0.03 0.722169,0.75 -0.343071,12.3401 -0.609296,13.1524 z"
+         id="path4522"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scscszs" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4584);stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.029866,1028.5266 c 0.335464,3.4409 -0.540551,10.8513 -0.558812,11.097 -0.130143,-0.1351 -3.305251,-4.1177 -3.305251,-4.1177 -13.489832,9.4517 -15.979945,-3.8837 -15.944315,-4.5632 0,0 4.159907,8.1407 14.425918,2.5964 -3.722931,-2.2 -6.36447,-4.7334 -6.416153,-4.8694"
+         id="path4522-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscc" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-3"
+       d="m 5.4557968,1008.9145 19.7539192,-0.2324 7.608429,8.7088 0.07385,27.9289 -27.2884668,0.2324 z"
+       style="display:inline;fill:url(#linearGradient4499);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1-8"
+       d="m 5.5046347,1009.0062 19.4861283,0 c 0,0 5.85893,1.2058 4.373085,3.9843 -0.04608,0.087 4.030127,4.7373 4.030127,4.7373 l 0,28.139 -27.8893403,0 z"
+       style="fill:none;stroke:url(#linearGradient4501);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0-0"
+       d="m 25.209716,1008.9807 7.577969,8.4882 0,8.8212 -11.121134,-7.7163 c 1.458578,-3.0943 2.515266,-6.3264 3.543104,-9.5931 z"
+       style="display:inline;fill:url(#linearGradient4503);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4-7"
+       d="m 25.007101,1008.3777 c 1.63519,2.2277 3.607055,5.0774 2.145555,9.9463 3.363056,-1.9023 6.847609,-0.8933 6.847609,-0.8933 0,-4.5456 -5.518387,-9.2672 -8.993164,-9.053 z"
+       style="display:inline;fill:url(#linearGradient4505);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1041.3622 9.700638,0"
+       id="path4696-88"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1037.3622 13.338378,0"
+       id="path4696-5-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1033.3622 14.550958,0"
+       id="path4696-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1016.3622 13.338378,0"
+       id="path4696-0-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1020.3622 13.338378,0"
+       id="path4696-9-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1024.3622 13.338378,0"
+       id="path4696-8-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1028.3622 10.913218,0"
+       id="path4696-2-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1027.3622 10,0"
+       id="path4696-2-4"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g4574"
+       transform="translate(-55,-20)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4696-09"
+         d="m 94,1054.3622 6,0"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#3b6568;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4696-09-2"
+         d="m 97,1051.3622 0,6"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#3b6568;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#3b6568;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39,1024.3622 6,0"
+       id="path4696-09-1"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/icons/full/wizban/profile_wiz.svg
+++ b/apitools/org.eclipse.pde.api.tools.ui/icons/full/wizban/profile_wiz.svg
@@ -1,0 +1,1167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="profile_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8785">
+      <stop
+         style="stop-color:#bb8d2d;stop-opacity:1"
+         offset="0"
+         id="stop8781" />
+      <stop
+         id="stop8789"
+         offset="0.49535784"
+         style="stop-color:#ac7400;stop-opacity:1" />
+      <stop
+         style="stop-color:#b07905;stop-opacity:1"
+         offset="1"
+         id="stop8783" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8777">
+      <stop
+         style="stop-color:#fbeaab;stop-opacity:1;"
+         offset="0"
+         id="stop8773" />
+      <stop
+         style="stop-color:#deb241;stop-opacity:1"
+         offset="1"
+         id="stop8775" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8767">
+      <stop
+         style="stop-color:#6a8ec1;stop-opacity:1"
+         offset="0"
+         id="stop8763" />
+      <stop
+         style="stop-color:#80a1cf;stop-opacity:1"
+         offset="1"
+         id="stop8765" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8759">
+      <stop
+         style="stop-color:#d3e0eb;stop-opacity:1"
+         offset="0"
+         id="stop8755" />
+      <stop
+         style="stop-color:#5179b5;stop-opacity:1"
+         offset="1"
+         id="stop8757" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8751">
+      <stop
+         style="stop-color:#2e5d8f;stop-opacity:1"
+         offset="0"
+         id="stop8747" />
+      <stop
+         style="stop-color:#6085bb;stop-opacity:1"
+         offset="1"
+         id="stop8749" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8490">
+      <stop
+         style="stop-color:#fdfefd;stop-opacity:1"
+         offset="0"
+         id="stop8486" />
+      <stop
+         style="stop-color:#9abd9a;stop-opacity:1"
+         offset="1"
+         id="stop8488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8458">
+      <stop
+         style="stop-color:#c1cee6;stop-opacity:1"
+         offset="0"
+         id="stop8454" />
+      <stop
+         style="stop-color:#3461ab;stop-opacity:1"
+         offset="1"
+         id="stop8456" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95292719,0,0,0.9400082,-4.3529074,51.703107)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#dbe2eb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2881074,0,0,3.2719678,-4.5756557,-2398.3972)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9145639,0,0,0.92391963,-2.206999,67.629058)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6411">
+      <stop
+         style="stop-color:#4f605c;stop-opacity:1"
+         offset="0"
+         id="stop6413" />
+      <stop
+         style="stop-color:#dbe2eb;stop-opacity:0"
+         offset="1"
+         id="stop6415" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4264"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7683014,0,0,1.8268252,-65.185236,-863.52445)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#f4ae5f;stop-opacity:1;"
+         offset="0"
+         id="stop4260" />
+      <stop
+         id="stop4266"
+         offset="0.41542953"
+         style="stop-color:#eec290;stop-opacity:1" />
+      <stop
+         style="stop-color:#c7700e;stop-opacity:1"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <filter
+       height="1.0954513"
+       y="-0.047725668"
+       width="1.0967932"
+       x="-0.048396592"
+       id="filter4285-9"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4308"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4308">
+      <stop
+         style="stop-color:#d5d2d9;stop-opacity:1"
+         offset="0"
+         id="stop4310" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.328"
+         offset="1"
+         id="stop4312" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344"
+       x="-0.027383926"
+       width="1.0547679"
+       y="-0.085576576"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8458"
+       id="linearGradient8460"
+       x1="44"
+       y1="1014.3622"
+       x2="43"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8490"
+       id="linearGradient8492"
+       x1="89"
+       y1="1054.3622"
+       x2="102"
+       y2="1068.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-52.5,-34.49997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8490"
+       id="linearGradient8492-0"
+       x1="89"
+       y1="1054.3622"
+       x2="102"
+       y2="1068.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41176473,0,0,0.41176481,3.676469,589.53652)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8641"
+       x="-0.096127967"
+       width="1.1922559"
+       y="-0.1596458"
+       height="1.3192916">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.92592472"
+         id="feGaussianBlur8643" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8751"
+       id="linearGradient8753"
+       x1="50"
+       y1="1019.3622"
+       x2="50"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8759"
+       id="linearGradient8761"
+       x1="57"
+       y1="1019.3622"
+       x2="62"
+       y2="1030.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8767"
+       id="linearGradient8769"
+       x1="51.658199"
+       y1="1020.4141"
+       x2="51.933025"
+       y2="1023.234"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8777"
+       id="linearGradient8779"
+       x1="63.98344"
+       y1="1016.2225"
+       x2="68.598152"
+       y2="1026.0538"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8785"
+       id="linearGradient8787"
+       x1="68.47998"
+       y1="1015.6127"
+       x2="67.683601"
+       y2="1028.4165"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8813"
+       x="-0.53770523"
+       width="2.0754105"
+       y="-0.24307477"
+       height="1.4861495">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1269452"
+         id="feGaussianBlur8815" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8835"
+       x="-0.313344"
+       width="1.626688"
+       y="-0.30129232"
+       height="1.6025846">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.49751501"
+         id="feGaussianBlur8837" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8871"
+       x="-0.41554753"
+       width="1.8310951"
+       y="-0.11828489"
+       height="1.2365698">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.53588249"
+         id="feGaussianBlur8873" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8881"
+       x="-0.49425547"
+       width="1.9885109"
+       y="-0.77112415"
+       height="2.5422483">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.61211194"
+         id="feGaussianBlur8883" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8996"
+       x="-0.088669853"
+       width="1.1773397"
+       y="-0.11527081"
+       height="1.2305416">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.5635"
+         id="feGaussianBlur8998" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8767"
+       id="linearGradient9006"
+       gradientUnits="userSpaceOnUse"
+       x1="51.658199"
+       y1="1020.4141"
+       x2="51.933025"
+       y2="1023.234" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8751"
+       id="linearGradient9008"
+       gradientUnits="userSpaceOnUse"
+       x1="50"
+       y1="1019.3622"
+       x2="50"
+       y2="1024.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8777"
+       id="linearGradient9010"
+       gradientUnits="userSpaceOnUse"
+       x1="63.98344"
+       y1="1016.2225"
+       x2="68.598152"
+       y2="1026.0538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8785"
+       id="linearGradient9012"
+       gradientUnits="userSpaceOnUse"
+       x1="68.47998"
+       y1="1015.6127"
+       x2="67.683601"
+       y2="1028.4165" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter8871-1"
+       x="-0.41554753"
+       width="1.8310951"
+       y="-0.11828489"
+       height="1.2365698">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.53588249"
+         id="feGaussianBlur8873-8" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bcbcbc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.2780981"
+     inkscape:cx="36.699332"
+     inkscape:cy="43.435626"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:object-nodes="false"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter4344)"
+       transform="matrix(1.0651476,0,0,0.83720885,-20.627749,171.5995)" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 13.663391,1000.9751 23.221829,0.3871 9.027157,9.726 0.08762,31.1905 -32.37689,0.2595 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none;stroke-width:1" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 13.5,1000.8622 h 23.04854 c 0,0 6.930048,1.3741 5.172564,4.5397 -0.0545,0.099 4.766907,5.3979 4.766907,5.3979 v 32.0624 H 13.5 Z"
+       style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0"
+       d="m 37.370949,1001.3622 8.629053,9.3172 v 9.6828 l -12.663665,-8.4699 c 1.660888,-3.3965 2.864141,-6.9443 4.034543,-10.5301 z"
+       style="display:inline;fill:url(#linearGradient4240);fill-opacity:1;stroke:none;stroke-width:1.00000012" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4"
+       d="m 36,1000.3707 c 2.000085,2.6856 4.411975,6.1214 2.624338,11.9915 4.113526,-2.2935 8.37566,-1.077 8.37566,-1.077 0,-5.4803 -6.749821,-11.1729 -10.999998,-10.9145 z"
+       style="display:inline;fill:url(#linearGradient4264);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9)"
+       id="path4252-6"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(0,0.85573635,-0.89764149,0,975.36983,1001.8184)"
+       inkscape:transform-center-x="-0.020119543"
+       inkscape:transform-center-y="0.26977445" />
+    <g
+       id="g8557"
+       transform="translate(-14,2.5936079e-5)">
+      <ellipse
+         ry="12.500009"
+         rx="12.5"
+         cy="1026.3622"
+         cx="43"
+         id="path8452"
+         style="opacity:1;fill:url(#linearGradient8460);fill-opacity:1;stroke:#154881;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="8.5000124"
+         rx="8.5"
+         cy="1026.3622"
+         cx="43"
+         id="path8452-2"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient8492);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="3.500006"
+         rx="3.5000002"
+         cy="1026.3622"
+         cx="43"
+         id="path8452-2-3"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient8492-0);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="opacity:0.52100004;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter8641)"
+       d="m 17.207763,1028.749 c 7.306631,-6.772 14.405975,-7.9839 22.922194,-6.4311 -4.27551,-7.06 -6.952168,-8.5211 -15.538905,-6.8744 -4.413263,2.3533 -8.532831,6.1883 -7.383289,13.3055 z"
+       id="path8579"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       id="g9048"
+       transform="translate(-43.990779,-20.979869)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8791"
+         d="m 53.577367,1026.9835 -0.152425,-8.8407 0.91455,-1.2194 3.124711,-0.076 0.07621,-0.9908 h 0.91455 l -0.07621,1.9054 -3.048499,1.2194 -0.152425,4.9538 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter8813)" />
+      <path
+         transform="matrix(1.0486083,0,0,1.0499923,-3.0656229,-51.085241)"
+         inkscape:connector-curvature="0"
+         d="m 70.499999,1023.8622 -10e-7,0.7084 c 0,0.7154 -0.630695,1.3084 -1.581494,1.2913 -0.950799,-0.017 -1.418505,0 -1.418505,0 v 0.1348 c 0,1.0333 -0.846416,1.865 -1.897793,1.8652 l -1.204207,2e-4 c -0.993831,2e-4 -0.897896,0.3654 -0.897896,-1.9999 v -8 c 0,-2.3654 -0.149817,-2 0.897896,-2 h 1.204207 c 1.051377,0 1.897793,0.8319 1.897793,1.8652 v 0.1348 h 1.418506 c 0.876148,0 1.581494,0.5759 1.581494,1.2913 v 1.7087 z m 0.01,-3 h 3.99 v 3 h -3.7903 m -8.209702,-2 2e-6,-7.4174 c 0,-1.4308 -0.846416,-2.5826 -1.897793,-2.5826 h -2.204414 c -1.051377,0 -1.897793,1.1518 -1.897793,2.5826 v 1.4174 h -2.418506 c -0.876148,0 -1.581494,0.7039 -1.581494,1.5782 v 1.3017 3.1196 m 9.999998,5e-4 2e-6,7.4174 c 0,1.4308 -0.846416,2.5826 -1.897793,2.5826 h -2.204414 c -1.051377,0 -1.897793,-1.1518 -1.897793,-2.5826 v -1.4174 h -2.418506 c -0.876148,0 -1.581494,-0.7039 -1.581494,-1.5782 v -1.3017 -3.1196 m -4,-5e-4 v 2 h 4 v -4 h -4 v 2"
+         style="display:inline;opacity:1;fill:#fdf6d8;fill-opacity:0.88627451;stroke:#f9f2d9;stroke-width:1.90603244;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.92941176;filter:url(#filter8996)"
+         id="rect8645-2-5-3" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         d="m 48.5,1021.8622 v 2 h 4 v -4 h -4 v 2"
+         style="display:inline;opacity:1;fill:url(#linearGradient9006);fill-opacity:1;stroke:url(#linearGradient9008);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path8722-7" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 62.499998,1021.8622 2e-6,-7.4174 c 0,-1.4308 -0.846416,-2.5826 -1.897793,-2.5826 h -2.204414 c -1.051377,0 -1.897793,1.1518 -1.897793,2.5826 v 1.4174 h -2.418506 c -0.876148,0 -1.581494,0.7039 -1.581494,1.5782 v 1.3017 3.1196 m 9.999998,5e-4 2e-6,7.4174 c 0,1.4308 -0.846416,2.5826 -1.897793,2.5826 h -2.204414 c -1.051377,0 -1.897793,-1.1518 -1.897793,-2.5826 v -1.4174 h -2.418506 c -0.876148,0 -1.581494,-0.7039 -1.581494,-1.5782 v -1.3017 -3.1196"
+         style="display:inline;opacity:1;fill:url(#linearGradient8761);fill-opacity:1;stroke:#4d73ae;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect8645-3" />
+      <path
+         sodipodi:nodetypes="cczccssssssccsccccccc"
+         inkscape:connector-curvature="0"
+         d="m 70.5,1023.8622 -10e-7,0.7084 c 0,0.7154 -0.630695,1.3084 -1.581494,1.2913 -0.950799,-0.017 -1.418505,0 -1.418505,0 v 0.1348 c 0,1.0333 -0.846416,1.865 -1.897793,1.8652 l -1.204207,2e-4 c -0.993831,2e-4 -0.897896,0.3654 -0.897896,-1.9999 v -8 c 0,-2.3654 -0.149817,-2 0.897896,-2 h 1.204207 c 1.051377,0 1.897793,0.8319 1.897793,1.8652 v 0.1348 h 1.418506 c 0.876148,0 1.581494,0.5759 1.581494,1.2913 v 1.7087 z m 0.01,-3 h 3.99 v 3 h -3.7903"
+         style="display:inline;opacity:1;fill:url(#linearGradient9010);fill-opacity:1;stroke:url(#linearGradient9012);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect8645-2-5" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path8861"
+         d="m 64.018476,1016.5423 -0.152427,10.8222 c 2.375507,-3.3036 3.484206,-4.2052 2.972286,-9.2217 0.305009,-1.654 -1.117834,-1.7529 -2.819859,-1.6005 z"
+         style="opacity:0.63899997;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter8871)" />
+      <ellipse
+         ry="1.9815242"
+         rx="1.9053118"
+         cy="1014.637"
+         cx="59.521938"
+         id="path8817"
+         style="opacity:0.70499998;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter8835)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8875"
+         d="m 70.953811,1023.4014 v -1.8291 l 2.972286,-0.076 z"
+         style="opacity:0.86199999;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter8881)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path8861-7"
+         d="m 53.924652,1016.631 -0.152427,10.8222 c 2.375507,-3.3036 3.484206,-4.2052 2.972286,-9.2217 0.305009,-1.654 -1.117834,-1.7529 -2.819859,-1.6005 z"
+         style="display:inline;opacity:0.48500001;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter8871-1)" />
+    </g>
+  </g>
+</svg>

--- a/apitools/org.eclipse.pde.api.tools.ui/plugin.xml
+++ b/apitools/org.eclipse.pde.api.tools.ui/plugin.xml
@@ -34,7 +34,7 @@
          name="%ApiToolsProposalCategory.name"
          point="org.eclipse.jdt.ui.javaCompletionProposalComputer">
       <proposalCategory
-            icon="icons/full/obj16/category_menu.png">
+            icon="icons/full/obj16/category_menu.svg">
       </proposalCategory>
    </extension>
    <extension
@@ -263,7 +263,7 @@
       <view
             category="org.eclipse.pde.api.tools.ui.views.apitooling.view.category"
             class="org.eclipse.pde.api.tools.ui.internal.views.APIToolingView"
-            icon="icons/full/obj16/api_tools.png"
+            icon="icons/full/obj16/api_tools.svg"
             id="org.eclipse.pde.api.tools.ui.views.apitooling.views.apitoolingview"
             name="%Apitoolingview.name">
       </view>
@@ -435,7 +435,7 @@
          point="org.eclipse.debug.ui.launchConfigurationTypeImages">
       <launchConfigurationTypeImage
             configTypeID="org.eclipse.pde.api.tools.usescan"
-            icon="$nl$/icons/full/obj16/category_menu.png"
+            icon="$nl$/icons/full/obj16/category_menu.svg"
             id="org.eclipse.pde.api.tools.usescan.image">
       </launchConfigurationTypeImage>
    </extension>
@@ -585,19 +585,19 @@
          point="org.eclipse.ui.commandImages">
       <image
             commandId="org.eclipse.pde.api.tools.ui.convert.javadocs"
-            icon="$nl$/icons/full/obj16/annotation_obj.png">
+            icon="$nl$/icons/full/obj16/annotation_obj.svg">
       </image>
       <image
             commandId="org.eclipse.pde.api.tools.ui.remove.filters"
-            icon="$nl$/icons/full/elcl16/filter_ps.png">
+            icon="$nl$/icons/full/elcl16/filter_ps.svg">
       </image>
       <image
             commandId="org.eclipse.pde.api.tools.ui.setup.projects"
-            icon="$nl$/icons/full/obj16/category_menu.png">
+            icon="$nl$/icons/full/obj16/category_menu.svg">
       </image>
       <image
             commandId="org.eclipse.pde.api.tools.ui.compare.to.baseline"
-            icon="$nl$/icons/full/obj16/eclipse16.png">
+            icon="$nl$/icons/full/obj16/eclipse16.svg">
       </image>
    </extension>
 </plugin>

--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/ApiUIPlugin.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/ApiUIPlugin.java
@@ -274,35 +274,35 @@ public class ApiUIPlugin extends AbstractUIPlugin {
 	@Override
 	protected void initializeImageRegistry(ImageRegistry reg) {
 		// model objects
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_API_COMPONENT, OBJECT + "api_tools.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_API_SYSTEM_LIBRARY, OBJECT + "library_obj.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_API_SEARCH, OBJECT + "extract_references.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_BUNDLE, OBJECT + "plugin_obj.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_FRAGMENT, OBJECT + "frgmt_obj.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_ECLIPSE_PROFILE, OBJECT + "eclipse16.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_BUNDLE_VERSION, OBJECT + "bundleversion.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_CHANGE_CORRECTION, OBJECT + "correction_change.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_SETUP_APITOOLS, OBJECT + "category_menu.png"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_API_COMPONENT, OBJECT + "api_tools.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_API_SYSTEM_LIBRARY, OBJECT + "library_obj.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_API_SEARCH, OBJECT + "extract_references.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_BUNDLE, OBJECT + "plugin_obj.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_FRAGMENT, OBJECT + "frgmt_obj.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_ECLIPSE_PROFILE, OBJECT + "eclipse16.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_BUNDLE_VERSION, OBJECT + "bundleversion.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OBJ_CHANGE_CORRECTION, OBJECT + "correction_change.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_SETUP_APITOOLS, OBJECT + "category_menu.svg"); //$NON-NLS-1$
 
 		// overlays
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OVR_ERROR, OVR + "error_ovr.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OVR_WARNING, OVR + "warning_ovr.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_OVR_SUCCESS, OVR + "success_ovr.png"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OVR_ERROR, OVR + "error_ovr.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OVR_WARNING, OVR + "warning_ovr.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_OVR_SUCCESS, OVR + "success_ovr.svg"); //$NON-NLS-1$
 		// wizards
-		declareRegistryImage(reg, IApiToolsConstants.IMG_WIZBAN_PROFILE, WIZBAN + "profile_wiz.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_WIZBAN_COMPARE_TO_BASELINE, WIZBAN + "compare_wiz.png"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_WIZBAN_PROFILE, WIZBAN + "profile_wiz.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_WIZBAN_COMPARE_TO_BASELINE, WIZBAN + "compare_wiz.svg"); //$NON-NLS-1$
 		// enabled images
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_FILTER, ELCL + "filter_ps.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_REMOVE, ELCL + "remove_exc.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_OPEN_PAGE, ELCL + "open_page.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_HELP_PAGE, ELCL + "help.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_COMPARE_APIS, ELCL + "compare_apis.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_CONFIG_SEV, ELCL + "configure_problem_severity.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_EXPORT, ELCL + "export.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_NEXT_NAV, ELCL + "next_nav.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_PREV_NAV, ELCL + "prev_nav.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_EXPANDALL, ELCL + "expandall.png"); //$NON-NLS-1$
-		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_TEXT_EDIT, ELCL + "text_edit.png"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_FILTER, ELCL + "filter_ps.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_REMOVE, ELCL + "remove_exc.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_OPEN_PAGE, ELCL + "open_page.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_HELP_PAGE, ELCL + "help.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_COMPARE_APIS, ELCL + "compare_apis.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_CONFIG_SEV, ELCL + "configure_problem_severity.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_EXPORT, ELCL + "export.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_NEXT_NAV, ELCL + "next_nav.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_PREV_NAV, ELCL + "prev_nav.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_EXPANDALL, ELCL + "expandall.svg"); //$NON-NLS-1$
+		declareRegistryImage(reg, IApiToolsConstants.IMG_ELCL_TEXT_EDIT, ELCL + "text_edit.svg"); //$NON-NLS-1$
 	}
 
 	void showAPIToolingView() {


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.pde.api.tools.ui` except for the following as it does not exist as SVG yet:

~~obj16/eclipse16.svg~~

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.