### PR TITLE
Add SVGs to org.eclipse.pde.spy bundles

### DIFF
--- a/ui/org.eclipse.pde.spy.bundle/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.bundle/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)"
 Bundle-Vendor: %provider-name
 Bundle-ActivationPolicy: lazy
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/ui/org.eclipse.pde.spy.bundle/icons/osgi.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/osgi.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="15"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="osgi.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.26"
+     inkscape:cx="16.886402"
+     inkscape:cy="-30.570165"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4074" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1037.3622)">
+    <image
+       y="1037.3622"
+       x="18"
+       id="image4296"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAPCAYAAADtc08vAAAKQWlDQ1BJQ0MgUHJvZmlsZQAASA2d
+lndUU9kWh8+9N73QEiIgJfQaegkg0jtIFQRRiUmAUAKGhCZ2RAVGFBEpVmRUwAFHhyJjRRQLg4Ji
+1wnyEFDGwVFEReXdjGsJ7601896a/cdZ39nnt9fZZ+9917oAUPyCBMJ0WAGANKFYFO7rwVwSE8vE
+9wIYEAEOWAHA4WZmBEf4RALU/L09mZmoSMaz9u4ugGS72yy/UCZz1v9/kSI3QyQGAApF1TY8fiYX
+5QKUU7PFGTL/BMr0lSkyhjEyFqEJoqwi48SvbPan5iu7yZiXJuShGlnOGbw0noy7UN6aJeGjjASh
+XJgl4GejfAdlvVRJmgDl9yjT0/icTAAwFJlfzOcmoWyJMkUUGe6J8gIACJTEObxyDov5OWieAHim
+Z+SKBIlJYqYR15hp5ejIZvrxs1P5YjErlMNN4Yh4TM/0tAyOMBeAr2+WRQElWW2ZaJHtrRzt7VnW
+5mj5v9nfHn5T/T3IevtV8Sbsz55BjJ5Z32zsrC+9FgD2JFqbHbO+lVUAtG0GQOXhrE/vIADyBQC0
+3pzzHoZsXpLE4gwnC4vs7GxzAZ9rLivoN/ufgm/Kv4Y595nL7vtWO6YXP4EjSRUzZUXlpqemS0TM
+zAwOl89k/fcQ/+PAOWnNycMsnJ/AF/GF6FVR6JQJhIlou4U8gViQLmQKhH/V4X8YNicHGX6daxRo
+dV8AfYU5ULhJB8hvPQBDIwMkbj96An3rWxAxCsi+vGitka9zjzJ6/uf6Hwtcim7hTEEiU+b2DI9k
+ciWiLBmj34RswQISkAd0oAo0gS4wAixgDRyAM3AD3iAAhIBIEAOWAy5IAmlABLJBPtgACkEx2AF2
+g2pwANSBetAEToI2cAZcBFfADXALDIBHQAqGwUswAd6BaQiC8BAVokGqkBakD5lC1hAbWgh5Q0FQ
+OBQDxUOJkBCSQPnQJqgYKoOqoUNQPfQjdBq6CF2D+qAH0CA0Bv0BfYQRmALTYQ3YALaA2bA7HAhH
+wsvgRHgVnAcXwNvhSrgWPg63whfhG/AALIVfwpMIQMgIA9FGWAgb8URCkFgkAREha5EipAKpRZqQ
+DqQbuY1IkXHkAwaHoWGYGBbGGeOHWYzhYlZh1mJKMNWYY5hWTBfmNmYQM4H5gqVi1bGmWCesP3YJ
+NhGbjS3EVmCPYFuwl7ED2GHsOxwOx8AZ4hxwfrgYXDJuNa4Etw/XjLuA68MN4SbxeLwq3hTvgg/B
+c/BifCG+Cn8cfx7fjx/GvyeQCVoEa4IPIZYgJGwkVBAaCOcI/YQRwjRRgahPdCKGEHnEXGIpsY7Y
+QbxJHCZOkxRJhiQXUiQpmbSBVElqIl0mPSa9IZPJOmRHchhZQF5PriSfIF8lD5I/UJQoJhRPShxF
+QtlOOUq5QHlAeUOlUg2obtRYqpi6nVpPvUR9Sn0vR5Mzl/OX48mtk6uRa5Xrl3slT5TXl3eXXy6f
+J18hf0r+pvy4AlHBQMFTgaOwVqFG4bTCPYVJRZqilWKIYppiiWKD4jXFUSW8koGStxJPqUDpsNIl
+pSEaQtOledK4tE20Otpl2jAdRzek+9OT6cX0H+i99AllJWVb5SjlHOUa5bPKUgbCMGD4M1IZpYyT
+jLuMj/M05rnP48/bNq9pXv+8KZX5Km4qfJUilWaVAZWPqkxVb9UU1Z2qbapP1DBqJmphatlq+9Uu
+q43Pp893ns+dXzT/5PyH6rC6iXq4+mr1w+o96pMamhq+GhkaVRqXNMY1GZpumsma5ZrnNMe0aFoL
+tQRa5VrntV4wlZnuzFRmJbOLOaGtru2nLdE+pN2rPa1jqLNYZ6NOs84TXZIuWzdBt1y3U3dCT0sv
+WC9fr1HvoT5Rn62fpL9Hv1t/ysDQINpgi0GbwaihiqG/YZ5ho+FjI6qRq9Eqo1qjO8Y4Y7ZxivE+
+41smsImdSZJJjclNU9jU3lRgus+0zwxr5mgmNKs1u8eisNxZWaxG1qA5wzzIfKN5m/krCz2LWIud
+Ft0WXyztLFMt6ywfWSlZBVhttOqw+sPaxJprXWN9x4Zq42Ozzqbd5rWtqS3fdr/tfTuaXbDdFrtO
+u8/2DvYi+yb7MQc9h3iHvQ732HR2KLuEfdUR6+jhuM7xjOMHJ3snsdNJp9+dWc4pzg3OowsMF/AX
+1C0YctFx4bgccpEuZC6MX3hwodRV25XjWuv6zE3Xjed2xG3E3dg92f24+ysPSw+RR4vHlKeT5xrP
+C16Il69XkVevt5L3Yu9q76c+Oj6JPo0+E752vqt9L/hh/QL9dvrd89fw5/rX+08EOASsCegKpARG
+BFYHPgsyCRIFdQTDwQHBu4IfL9JfJFzUFgJC/EN2hTwJNQxdFfpzGC4sNKwm7Hm4VXh+eHcELWJF
+REPEu0iPyNLIR4uNFksWd0bJR8VF1UdNRXtFl0VLl1gsWbPkRoxajCCmPRYfGxV7JHZyqffS3UuH
+4+ziCuPuLjNclrPs2nK15anLz66QX8FZcSoeGx8d3xD/iRPCqeVMrvRfuXflBNeTu4f7kufGK+eN
+8V34ZfyRBJeEsoTRRJfEXYljSa5JFUnjAk9BteB1sl/ygeSplJCUoykzqdGpzWmEtPi000IlYYqw
+K10zPSe9L8M0ozBDuspp1e5VE6JA0ZFMKHNZZruYjv5M9UiMJJslg1kLs2qy3mdHZZ/KUcwR5vTk
+muRuyx3J88n7fjVmNXd1Z752/ob8wTXuaw6thdauXNu5Tnddwbrh9b7rj20gbUjZ8MtGy41lG99u
+it7UUaBRsL5gaLPv5sZCuUJR4b0tzlsObMVsFWzt3WazrWrblyJe0fViy+KK4k8l3JLr31l9V/nd
+zPaE7b2l9qX7d+B2CHfc3em681iZYlle2dCu4F2t5czyovK3u1fsvlZhW3FgD2mPZI+0MqiyvUqv
+akfVp+qk6oEaj5rmvep7t+2d2sfb17/fbX/TAY0DxQc+HhQcvH/I91BrrUFtxWHc4azDz+ui6rq/
+Z39ff0TtSPGRz0eFR6XHwo911TvU1zeoN5Q2wo2SxrHjccdv/eD1Q3sTq+lQM6O5+AQ4ITnx4sf4
+H++eDDzZeYp9qukn/Z/2ttBailqh1tzWibakNml7THvf6YDTnR3OHS0/m/989Iz2mZqzymdLz5HO
+FZybOZ93fvJCxoXxi4kXhzpXdD66tOTSna6wrt7LgZevXvG5cqnbvfv8VZerZ645XTt9nX297Yb9
+jdYeu56WX+x+aem172296XCz/ZbjrY6+BX3n+l37L972un3ljv+dGwOLBvruLr57/17cPel93v3R
+B6kPXj/Mejj9aP1j7OOiJwpPKp6qP6391fjXZqm99Oyg12DPs4hnj4a4Qy//lfmvT8MFz6nPK0a0
+RupHrUfPjPmM3Xqx9MXwy4yX0+OFvyn+tveV0auffnf7vWdiycTwa9HrmT9K3qi+OfrW9m3nZOjk
+03dp76anit6rvj/2gf2h+2P0x5Hp7E/4T5WfjT93fAn88ngmbWbm3/eE8/syOll+AAAACXBIWXMA
+ABYlAAAWJQFJUiTwAAACb2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxu
+czp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJE
+RiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMi
+PgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0
+aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOlhSZXNv
+bHV0aW9uPjE0NDwvdGlmZjpYUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6WVJlc29sdXRpb24+
+MTQ0PC90aWZmOllSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpSZXNvbHV0aW9uVW5pdD4yPC90
+aWZmOlJlc29sdXRpb25Vbml0PgogICAgICAgICA8dGlmZjpDb21wcmVzc2lvbj41PC90aWZmOkNv
+bXByZXNzaW9uPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9u
+PgogICAgICAgICA8dGlmZjpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPjI8L3RpZmY6UGhvdG9t
+ZXRyaWNJbnRlcnByZXRhdGlvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJE
+Rj4KPC94OnhtcG1ldGE+Cka1WbsAAALpSURBVCgVbVJbSFRRFN3nnnvuXHVm1Cl1LPvRyl4ElqiV
+SoYfZmZYWJEKJolFf/1MfgTzFYQfEaS9KJOKYoz6CCqswSgVjakwyyIfI6PZzMjkvGzmzuOe7hmb
+CvHAvey9zlpr77PZAMscajRyS+HlsKWcWE5NtZgFs5ZrifZrhWenrxcZ7MNtSQyL37F42ROvYlHE
+ro6CfnpZRWm7hs515L/ppb08E8U5cQMUDygFhBBQlruuFz/ScX01Ub/yEioD1gLMy4V3dc1DDQqB
+U0RyXPfPwAQYHYbo7IXqk8m8+UpIzH4hJ2aNIox5zmfL5QJfyr3RssYsQ08X/cNlJrG2WNDdzf6K
+NU07ElpveJVSda5CaelvJffjVjP9/OOYQumC0cVOGT/WgVFpS/liZKvVmqJ3P/uEQwE9Bf65QlHw
+yD7gxUmz9tSWynVIYsK4BrGhIKNRHjOc3ixmq+vTi3I/StHQFIFQEx+WDyi2cgTzT35h1U01ITn2
+gdHNv0bmb29sv/HNVFuLUXwo9rYdZpyQI6TsKsmWJX+GpEot1eY1DbBq3g93dwkhx2tI0Dr9g+/n
+I663E/rWd/sVLY5N9PvDQ3kZKx17BDLSQ/JaVgPCTg230O8d6lqxMHonU0PcfQjhGXFrc6YgTD7J
+SPdU2R40bFHeH41tnOiaaYTwpDIZXTWrCDh5DySoQMD+ej7wswEEAkE5rZxdRQMLuyE8DkmeqSaW
+xwyQ5CsOewAEaTzfaTraqMo//jXiXvjOAcqTKd4kuYP25KK6MfuDgyeEsK0g6FPWQ/KXMoPF7cLq
+SaJL2kY80wCOoU5X514ig2ijlLNQxIscJ2+Yu1XRonYOXlVFZgGlasEXVk38NfCu2tQsO4iVE3xl
+JOzTy84vF+023WfP9sp7icRLsOVtnYbYLkkqcSZAtjqjcvJL39qd5wEGAf2/wsyx19opwtOnPH+/
+h5T0eeYZNmysSUfrcsP+0vTgzjVnAgxjh2l/AwuRO/N8h5vlAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="15.000017"
+       width="16" />
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-12.551145,-2.6983344e-7)" />
+    <g
+       id="g4480"
+       transform="matrix(0.16938299,0,0,0.17276709,-2.8505255,863.69032)">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4301-9"
+         d="m 22.732658,1077.7291 c 4.288186,11.2649 34.94152,9.0209 36.881304,7.4317 -16.372848,-4.4414 -26.807883,-20.9667 -22.255315,-37.4308 -9.63195,2.0884 -13.577938,20.691 -14.625989,29.9991 z"
+         style="display:inline;opacity:1;fill:#f18a01;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4301-9-1"
+         d="m 105.38559,1077.9068 c -4.28819,11.2649 -34.94152,9.0209 -36.881304,7.4317 16.372848,-4.4414 26.807883,-20.9667 22.255315,-37.4308 9.631949,2.0884 13.577939,20.691 14.625989,29.9991 z"
+         style="display:inline;opacity:1;fill:#f18a01;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4301-9-0"
+         d="m 65.007174,1011.129 c -9.184577,-1.9509 -23.373859,24.2204 -23.23639,26.6815 12.652709,-11.3007 32.10625,-12.2771 43.422785,0.5185 3.19585,-9.8074 -16.019525,-27.1798 -20.186395,-27.2 z"
+         style="display:inline;opacity:1;fill:#f18a01;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path4429"
+         transform="translate(0,1037.3622)"
+         d="m 39.966797,10.722656 -1.636719,6.833985 a 24.55595,23.801065 0 0 1 15.087891,21.953125 24.55595,23.801065 0 0 1 -0.226563,3.035156 L 59.234375,45.0625 A 24.55595,23.801065 0 0 0 61.900391,34.359375 24.55595,23.801065 0 0 0 39.966797,10.722656 Z"
+         style="opacity:1;fill:#f6c88c;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path4429-3"
+         d="m 88.21238,1047.8032 1.636719,6.834 a 24.55595,23.801065 0 0 0 -15.08789,21.9531 24.55595,23.801065 0 0 0 0.226563,3.0352 l -6.042969,2.5175 a 24.55595,23.801065 0 0 1 -2.666016,-10.7031 24.55595,23.801065 0 0 1 21.933593,-23.6367 z"
+         style="display:inline;opacity:1;fill:#f6c88c;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path4429-8"
+         d="m 83.512769,1041.2655 -4.826643,-5.1075 a 23.801065,24.55595 33.150625 0 1 -26.630615,0.6273 23.801065,24.55595 33.150625 0 1 -2.417284,-1.8495 l -5.41229,3.6828 a 23.801065,24.55595 33.150625 0 0 7.50313,8.0849 23.801065,24.55595 33.150625 0 0 31.783702,-5.438 z"
+         style="display:inline;opacity:1;fill:#f6c88c;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/refresh.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/refresh.svg
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="refresh.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7608-3"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345"
+       gradientTransform="translate(-0.35355341,-0.48613593)" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient7610-5"
+       gradientUnits="userSpaceOnUse"
+       x1="23.107393"
+       y1="1042.9795"
+       x2="23.107393"
+       y2="1046.6238"
+       gradientTransform="translate(-0.35355341,-0.48613593)" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3"
+       id="linearGradient7608-9-7"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-0-5"
+       id="linearGradient7610-7-6"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="12.871772"
+     inkscape:cy="11.737298"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7604"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="150"
+     inkscape:window-y="150"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4074" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-12.551145,-2.6983344e-7)">
+      <path
+         sodipodi:nodetypes="ccssscscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 23.231602,1038.8387 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 1.546796,1.4584 1.546796,0.088 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.694788,0.3552 2.039845,0.6884 0.345482,0.3336 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.174793,-1.2439 -0.71875,-1.9687 -0.293544,-0.3911 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-3);fill-opacity:1;stroke:url(#linearGradient7610-5);stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 22.715806,1038.5073 0,-0.5966 c 0,0 0.110485,-0.3756 -0.220971,-0.2431 -0.331456,0.1326 -0.972272,0.6629 -1.038563,0.7734 -0.06629,0.1105 -0.751301,0.5967 -0.596622,0.8176 0.15468,0.221 1.458408,0.066 1.458408,0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       style="display:inline"
+       id="g7604-6"
+       transform="matrix(-1,0,0,-1,29.009738,2088.8723)">
+      <path
+         sodipodi:nodetypes="ccssscsscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-7"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-9-7);fill-opacity:1;stroke:url(#linearGradient7610-7-6);stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-2"
+         d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/start.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/start.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="start.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientTransform="matrix(0.66159777,0,0,0.66159776,-240.06252,747.98229)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509664"
+     inkscape:cx="8.4134662"
+     inkscape:cy="1.3092525"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <sodipodi:guide
+       position="0.98332041,11.735262"
+       orientation="1,0"
+       id="guide1"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7.0600196,15.01668"
+       orientation="0,-1"
+       id="guide2"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <circle
+         style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#14733c;stroke-width:0.941048;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path10796-2-6-0"
+         cx="16.720118"
+         cy="1057.767"
+         r="7.0294762" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path8117"
+         d="m 14.220116,1052.2669 6,5.567 -5.938144,5.433 z"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.03057" />
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/state_active.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/state_active.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="methpub_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#75ba7a;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       id="linearGradient9837"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="8.1831043"
+     inkscape:cy="7.2601498"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6438"
+     showgrid="true"
+     inkscape:window-width="1287"
+     inkscape:window-height="862"
+     inkscape:window-x="623"
+     inkscape:window-y="113"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3960" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+         id="g6438">
+        <path
+           sodipodi:type="arc"
+           style="fill:url(#linearGradient9837);fill-opacity:1;stroke:#058149;stroke-width:3.17967892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="path10796-2-6-2"
+           sodipodi:cx="388.125"
+           sodipodi:cy="468.23718"
+           sodipodi:rx="10.625"
+           sodipodi:ry="10.625"
+           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+           transform="matrix(0.32984735,0,0,0.32984735,-136.12701,882.92787)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/state_installed.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/state_installed.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="import_wiz.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4921">
+      <stop
+         style="stop-color:#85a2cd;stop-opacity:1;"
+         offset="0"
+         id="stop4923" />
+      <stop
+         style="stop-color:#d3dce9;stop-opacity:1;"
+         offset="1"
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4913">
+      <stop
+         style="stop-color:#4e6b9b;stop-opacity:1"
+         offset="0"
+         id="stop4915" />
+      <stop
+         style="stop-color:#6783b1;stop-opacity:1"
+         offset="1"
+         id="stop4917" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4913"
+       id="linearGradient4919"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,-17.402778,-24.047507)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4921"
+       id="linearGradient4927"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,-17.402778,-24.047507)" />
+    <linearGradient
+       id="linearGradient4789">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#6991ae;stop-opacity:1"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(0.72295781,-0.72295781,0.72295781,0.72295781,-747.11893,286.63871)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#linearGradient4789"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="3.8401431"
+     inkscape:cy="8.4256951"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1652"
+     inkscape:window-height="1174"
+     inkscape:window-x="827"
+     inkscape:window-y="130"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,16"
+       id="guide4039" />
+    <sodipodi:guide
+       position="16,0"
+       orientation="-16,0"
+       id="guide4041" />
+    <sodipodi:guide
+       position="16,16"
+       orientation="0,-16"
+       id="guide4043" />
+    <sodipodi:guide
+       position="0,16"
+       orientation="16,0"
+       id="guide4045" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4047" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(17.6875,0)">
+      <path
+         style="fill:url(#linearGradient4927);fill-opacity:1;stroke:url(#linearGradient4919);stroke-width:0.71569169;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m -17.306927,1043.9175 0,7.0931 7.124966,0 7.1249674,0 0,-7.0931 -3.0033491,0 0,2.013 0.9265651,0 0,3.0672 -5.0481834,0 -5.048182,0 0,-3.0672 0.926565,0 0,-2.013 z"
+         id="path4143"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+    <path
+       style="fill:url(#linearGradient3924);fill-opacity:1;stroke:none;display:inline"
+       d="m 1.7208163,1039.5526 0.6549857,-0.6549 6.2783105,6.2782 1.3099712,-1.3099 0.3354433,3.4985 -3.4985427,-0.3034 1.2300951,-1.2302 z"
+       id="path3986"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/state_resolved.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/state_resolved.svg
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="methpro_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9800">
+      <stop
+         style="stop-color:#be9c28;stop-opacity:1;"
+         offset="0"
+         id="stop9802" />
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:1"
+         offset="1"
+         id="stop9804" />
+    </linearGradient>
+    <filter
+       height="1.24"
+       y="-0.12"
+       width="1.24"
+       x="-0.12"
+       id="filter5785-5"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur5787-1"
+         stdDeviation="0.19985704"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       y2="1033.6897"
+       x2="-14.570764"
+       y1="1030.8125"
+       x1="-17.447985"
+       gradientTransform="matrix(1.1934266,0,0,1.1934266,11.623455,-194.18756)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5742-5"
+       xlink:href="#linearGradient5789-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5789-2">
+      <stop
+         style="stop-color:#fff2b0;stop-opacity:1"
+         offset="0"
+         id="stop5791-4" />
+      <stop
+         id="stop5793-5"
+         offset="0.62907171"
+         style="stop-color:#fecf6c;stop-opacity:1" />
+      <stop
+         style="stop-color:#fede96;stop-opacity:1"
+         offset="1"
+         id="stop5795-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9800"
+       id="linearGradient9806"
+       x1="-10.452695"
+       y1="1034.6195"
+       x2="-4.3119617"
+       y2="1040.7603"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="8.0945725"
+     inkscape:cy="6.4399446"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6438"
+     showgrid="true"
+     inkscape:window-width="1287"
+     inkscape:window-height="862"
+     inkscape:window-x="175"
+     inkscape:window-y="175"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3960" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+         id="g6438">
+        <g
+           transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,725.39235,291.80106)"
+           style="display:inline"
+           id="layer1-8"
+           inkscape:label="Layer 1">
+          <g
+             id="g11331-3-1-1-8"
+             style="display:inline"
+             transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
+            <g
+               style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+               id="g13408-8-1" />
+          </g>
+          <g
+             id="g6124-3-9"
+             style="display:inline"
+             transform="matrix(-1,0,0,1,16.12959,8.0140628)">
+            <g
+               id="text6430-8"
+               style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+               transform="scale(-1,1)" />
+            <g
+               id="g6438-1"
+               style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+               transform="scale(-1,1)">
+              <rect
+                 y="1034.8657"
+                 x="-10.606487"
+                 height="5.9599032"
+                 width="5.9599032"
+                 id="rect6724"
+                 style="fill:url(#linearGradient5742-5);fill-opacity:1;stroke:url(#linearGradient9806);stroke-width:1.01823986;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+                 rx="0.6875"
+                 ry="0.6875" />
+              <rect
+                 y="1035.847"
+                 x="-9.6251059"
+                 height="3.9971409"
+                 width="3.9971409"
+                 id="rect6724-4"
+                 style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;opacity:0.25;fill:none;stroke:#ffffff;stroke-width:0.68290508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter5785-5);font-family:Sans" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/state_starting.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/state_starting.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="prev_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-4.5683281"
+     inkscape:cy="9.6786205"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1043.8618 3,0 0,5.7812 c 0,0.6679 0.5509,1.2188 1.2188,1.2188 l 2.5625,0 c 0.6678,0 1.2187,-0.5508 1.2187,-1.2188 l 0,-5.7812 3,0 0,-1 -5.5,-5.5 -5.5,5.5 0,1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/state_stopping.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/state_stopping.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="next_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-7.4627612"
+     inkscape:cy="10.319471"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1044.8626 3,0 0,-5.7812 c 0,-0.6679 0.5509,-1.2188 1.2188,-1.2188 l 2.5625,0 c 0.6678,0 1.2187,0.5508 1.2187,1.2188 l 0,5.7812 3,0 0,1 -5.5,5.5 -5.5,-5.5 0,-1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/state_uninstalled.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/state_uninstalled.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="export_wiz.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4921">
+      <stop
+         style="stop-color:#85a2cd;stop-opacity:1;"
+         offset="0"
+         id="stop4923" />
+      <stop
+         style="stop-color:#d3dce9;stop-opacity:1;"
+         offset="1"
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4913">
+      <stop
+         style="stop-color:#4e6b9b;stop-opacity:1"
+         offset="0"
+         id="stop4915" />
+      <stop
+         style="stop-color:#6783b1;stop-opacity:1"
+         offset="1"
+         id="stop4917" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#30495a;stop-opacity:1;"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(0.72371262,0.72371262,0.72371262,-0.72371262,-744.90513,1800.3892)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#linearGradient4789"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4921"
+       id="linearGradient4927-4"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,0.28579018,-24.0306)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4913"
+       id="linearGradient4919-2"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,0.28579018,-24.0306)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.915889"
+     inkscape:cy="2.2744826"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="900"
+     inkscape:window-x="168"
+     inkscape:window-y="264"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient3924);fill-opacity:1;stroke:none;display:inline"
+       d="m 4.7164468,1046.6891 0.6556696,0.6556 6.2848656,-6.2848 1.311339,1.3113 0.335794,-3.5021 -3.5021962,0.3037 1.2313792,1.2315 z"
+       id="path3986"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient4927-4);fill-opacity:1;stroke:url(#linearGradient4919-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0.50664118,1043.8719 0,7.0072 13.98682682,-9e-4 0.01105,-6.9992 -3.001291,0.01 0.0078,1.9974 1.00469,0 0,2.9969 -9.9948038,0.01 -0.01563,-3.0125 1.00469,0 0,-2.0052 z"
+       id="path4143-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/icons/stop.svg
+++ b/ui/org.eclipse.pde.spy.bundle/icons/stop.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="stop.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4729">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4731" />
+      <stop
+         id="stop4737"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49579832;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4733" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6642">
+      <stop
+         style="stop-color:#e83038;stop-opacity:1;"
+         offset="0"
+         id="stop6644" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642"
+       id="linearGradient6648"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.005663,0,0,1.0056668,0.58040404,-5.5217527)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4729"
+       id="linearGradient4735"
+       x1="7.5007138"
+       y1="1040.3939"
+       x2="7.5007138"
+       y2="1048.3102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0453671,0,0,1.0453894,0.30030882,-47.005053)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="49.76264"
+     inkscape:cx="10.713081"
+     inkscape:cy="8.588225"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4227" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4288"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAMtJREFU
+OI3Fk6EOwjAQhr8RxORJZB1IHoFHmETiNonkUcAhJ5FIJBKLq6w8eW4IQmjZCgIS/qTicvd//du0
+Rdd1fKPRV+5fAMZxcd3tOj0dPppkUTGt66IH0GPLfNV8BFz2W6jrfgIADLRt87svl0mdAtTwqojl
+d/eqoM+BfgIAe0N4UXoHBjPvMdWsYeI9cbefQC2JONSP2wlAFJDyvnKS8j43BLAQCM4hZR4QnMNC
+GAYAOBFY59+CACGq0yNUFedmkzXHcw8Vf/+NN+VVQ/03dcEqAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <rect
+       style="color:#000000;font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6648);fill-opacity:1;fill-rule:nonzero;stroke:#a81d24;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect6562"
+       width="10"
+       height="10.044527"
+       x="3.5"
+       y="1039.8622"
+       rx="1.1490484"
+       ry="1.1490484" />
+    <rect
+       style="color:#000000;font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4735);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.69158876;marker:none;enable-background:accumulate"
+       id="rect6562-9"
+       width="8.0380869"
+       height="8.0000172"
+       x="4.5"
+       y="1040.8622"
+       rx="0.30935922"
+       ry="0.30935922" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.bundle/plugin.xml
+++ b/ui/org.eclipse.pde.spy.bundle/plugin.xml
@@ -3,7 +3,7 @@
    <extension point="org.eclipse.pde.spy.core.spyPart">
       <spyPart
             description="%description"
-            icon="$nl$/icons/osgi.png"
+            icon="$nl$/icons/osgi.svg"
             name="%name"
             part="org.eclipse.pde.spy.bundle.BundleSpyPart"
             shortcut="M2+M3+F12">

--- a/ui/org.eclipse.pde.spy.bundle/src/org/eclipse/pde/spy/bundle/BundleSpyPart.java
+++ b/ui/org.eclipse.pde.spy.bundle/src/org/eclipse/pde/spy/bundle/BundleSpyPart.java
@@ -59,15 +59,15 @@ import jakarta.inject.Inject;
  */
 public class BundleSpyPart {
 
-	private static final String ICON_REFRESH = "icons/refresh.png"; //$NON-NLS-1$
-	public static final String ICON_STATE_ACTIVE = "icons/state_active.png"; //$NON-NLS-1$
-	public static final String ICON_STATE_STARTING = "icons/state_starting.png"; //$NON-NLS-1$
-	public static final String ICON_STATE_STOPPING = "icons/state_stopping.png"; //$NON-NLS-1$
-	public static final String ICON_STATE_RESOLVED = "icons/state_resolved.png"; //$NON-NLS-1$
-	public static final String ICON_STATE_INSTALLED = "icons/state_installed.png"; //$NON-NLS-1$
-	public static final String ICON_STATE_UNINSTALLED = "icons/state_uninstalled.png"; //$NON-NLS-1$
-	public static final String ICON_START = "icons/start.png"; //$NON-NLS-1$
-	public static final String ICON_STOP = "icons/stop.png"; //$NON-NLS-1$
+	private static final String ICON_REFRESH = "icons/refresh.svg"; //$NON-NLS-1$
+	public static final String ICON_STATE_ACTIVE = "icons/state_active.svg"; //$NON-NLS-1$
+	public static final String ICON_STATE_STARTING = "icons/state_starting.svg"; //$NON-NLS-1$
+	public static final String ICON_STATE_STOPPING = "icons/state_stopping.svg"; //$NON-NLS-1$
+	public static final String ICON_STATE_RESOLVED = "icons/state_resolved.svg"; //$NON-NLS-1$
+	public static final String ICON_STATE_INSTALLED = "icons/state_installed.svg"; //$NON-NLS-1$
+	public static final String ICON_STATE_UNINSTALLED = "icons/state_uninstalled.svg"; //$NON-NLS-1$
+	public static final String ICON_START = "icons/start.svg"; //$NON-NLS-1$
+	public static final String ICON_STOP = "icons/stop.svg"; //$NON-NLS-1$
 
 	private TableViewer bundlesTableViewer;
 

--- a/ui/org.eclipse.pde.spy.context/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.context/META-INF/MANIFEST.MF
@@ -21,4 +21,4 @@ Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)"
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.spy.context
-
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/ui/org.eclipse.pde.spy.context/icons/annotation_obj.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/annotation_obj.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg4061"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="annotation_obj.svg">
+  <defs
+     id="defs4063" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="33.3125"
+     inkscape:cx="4.4577862"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1132"
+     inkscape:window-height="873"
+     inkscape:window-x="834"
+     inkscape:window-y="441"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4066">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11.458315,1046.4119 0,-2.7842 0.0042,-0.8839 c 0,0 -0.0617,-1.9004 -0.105904,-2.1213 -0.04419,-0.221 -0.88388,-2.2915 -0.88388,-2.2915 l -1.137373,-0.9547 -1.1932427,-0.442 -1.0589922,-0.1941 -1.8228007,0.3344 -1.3458363,0.8147 -1.5501319,1.5559 -1.065664,2.3265 0.088388,1.812 0.7071068,1.6352 1.016466,1.5468 c 0,0 1.0681638,1.2741 1.3333289,1.2299 0.265165,-0.044 2.1972011,0.6346 2.1972011,0.6346 l 2.0079171,-0.1293 2.2347239,-1.5143 z"
+       id="path3840"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#236298;fill-opacity:1;stroke:#236298;stroke-width:0.28257138;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+       d="m 11.309169,1039.7124 c -0.09375,-0.4062 -0.177236,-0.9956 -0.552237,-1.4332 -0.374998,-0.4374 -0.614324,-0.6075 -1.022557,-0.8389 -0.4082332,-0.2314 -1.6921375,-0.7905 -2.890625,-0.8594 -0.3994958,-0.023 -0.8168984,0.026 -1.1875,0.125 -1.8098211,0.485 -2.6365843,1.3182 -3.59375,2.8125 -0.991819,1.5427 -1.18883707,3.5664 -0.65625,5.3438 0.5272319,1.7597 1.555815,2.9531 3.09375,3.5937 1.4108866,0.5774 2.6810837,0.7061 4.5,0.2188 1.67339,-0.4485 2.016965,-0.7867 3.21875,-1.8438 l -0.4375,-0.3437 c -1.553801,1.2177 -1.622762,1.2331 -2.96875,1.5937 -1.5005895,0.4027 -3.1035995,0.1737 -4.25,-0.4062 -1.1463954,-0.5798 -1.9388113,-1.5074 -2.4375,-3.0938 -0.4986887,-1.5864 -0.022863,-3.5209 0.5625,-4.5312 0.5853631,-1.0103 1.2965074,-2.1937 2.90625,-2.625 1.282323,-0.3436 2.8157521,0.1597 3.788182,0.7279 0.97243,0.5683 1.292239,1.6525 1.258042,2.5824 -0.0342,0.9298 -0.664674,1.9656 -1.133042,2.368 -0.4683686,0.4027 -1.475682,0.4154 -1.475682,0.4154 0,0 0.1240658,-0.6578 0.125,-1.4687 0.030258,-0.6627 -0.1295408,-1.6952 -0.59375,-2.125 -0.4642092,-0.431 -1.2172197,-0.4323 -1.6875,-0.4063 -0.5523523,0.031 -0.932751,0.349 -1.34375,1.125 -0.4594324,0.8674 -0.5953852,2.7605 -0.4375,3.4688 0.1578852,0.7083 0.2457352,0.8707 0.65625,1.2812 0.4105148,0.4103 1.4233638,0.4191 1.96875,0.094 0.8226727,-0.5067 0.5968097,-1.091 1.21875,-1.125 0,0 1.2730873,-0.2595 2.067862,-0.8125 0.815373,-0.5226 1.093629,-1.2093 1.265854,-1.9429 0.172226,-0.7335 0.131703,-1.4881 0.03795,-1.8944 z M 6,1040.2997 c 0.1214058,0 0.264899,0.01 0.40625,0.031 0.5654037,0.1018 0.65625,1.125 0.65625,1.125 0,0 0.075363,0.6862 0.03125,1.5938 -0.044113,0.9079 -0.00335,1.2628 -0.34375,1.5312 -0.3403969,0.2684 -1.2509038,0.4278 -1.6875,-0.2812 -0.4365972,-0.7089 -0.3169368,-2.8026 0.0625,-3.4375 0.238137,-0.4 0.5107825,-0.5487 0.875,-0.5625 z"
+       id="path4719-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cczscccccccccssczzccccccscccczcssccsccs" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/collapseall.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/collapseall.svg
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="9.8506072"
+     inkscape:cy="9.9346296"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="809"
+     inkscape:window-x="1159"
+     inkscape:window-y="450"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/contextfunction.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/contextfunction.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="variable_tab.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="11.27237"
+     inkscape:cy="7.2292042"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="746"
+     inkscape:window-height="536"
+     inkscape:window-x="1054"
+     inkscape:window-y="913"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g3348"
+         transform="matrix(1,0,0,1.0390149,0,-41.095587)">
+        <path
+           sodipodi:nodetypes="cccscccsssccssscccscccccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="text4105-1-1-4"
+           d="m 17.407616,1053.3294 -1.181219,0.5938 c 0.49154,0.5175 0.887698,1.1305 1.15625,1.8125 0.268557,0.6819 0.406252,1.3776 0.40625,2.0937 2e-6,0.7324 -0.142576,1.4297 -0.40625,2.0938 -0.27669,0.6901 -0.673174,1.2617 -1.1875,1.75 l 1.212469,0.6562 c 0.615237,-0.5762 1.089195,-1.2715 1.4375,-2.0625 0.348309,-0.791 0.531251,-1.5977 0.53125,-2.4375 10e-7,-0.8333 -0.182941,-1.6465 -0.53125,-2.4375 -0.348305,-0.791 -0.822263,-1.4896 -1.4375,-2.0625 z m -7.09375,0.062 c -0.6152366,0.5729 -1.0891944,1.2715 -1.4374997,2.0625 -0.3483086,0.791 -0.5312511,1.6042 -0.53125,2.4375 -1.1e-6,0.8398 0.1829414,1.6465 0.53125,2.4375 0.3483053,0.791 0.8222631,1.4863 1.4374997,2.0625 l 0.991498,-0.7004 c -0.514326,-0.4883 -0.91081,-1.0599 -1.1875,-1.75 -0.2636742,-0.6641 -0.4062522,-1.3614 -0.4062501,-2.0938 -2.1e-6,-0.7161 0.1376931,-1.4118 0.4062501,-2.0937 0.268552,-0.682 0.633461,-1.295 1.125,-1.8125 z m 0.517655,1.875 1.6875,2.4063 -1.84375,2.5625 1.888595,0 1.25,-1.9375 1.21875,1.9375 1.899318,0 -1.84375,-2.5625 1.6875,-2.4063 -1.868068,0 -1.09375,1.75 -1.09375,-1.75 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:125%;font-family:Gautami;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#334c6f;fill-opacity:1;stroke:none" />
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           id="text4105-1-1-4-4"
+           d="m 20.214429,1056.2608 0,1.0224 4.018306,0 0,-1.0224 z m 0,2.0018 0,1.006 4.018306,0 0,-1.006 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:125%;font-family:Gautami;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#334c6f;fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/expandall.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/expandall.svg
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="expandall.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989-1">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991-2" />
+      <stop
+         id="stop4995-3"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="matrix(0,1,-1,0,1053.3622,1058.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5050"
+       xlink:href="#linearGradient4989-1"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.9999998"
+     inkscape:cx="1.5251501"
+     inkscape:cy="27.213599"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5050);fill-opacity:1;stroke:none;display:inline"
+       d="m 10,1044.3622 0,5 c 0,1 1,1 1,0 l 0,-5 c 0,-1 -1,-1 -1,0 z"
+       id="rect4853-82-0-6-8-41"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none"
+       id="rect4167"
+       width="1"
+       height="7"
+       x="9"
+       y="1042.3622" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/field_public_obj.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/field_public_obj.svg
@@ -1,0 +1,460 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="field_public_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="459.24786"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#a17748;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#8e5c24;stop-opacity:1" />
+      <stop
+         style="stop-color:#c7af93;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <mask
+       id="mask17098"
+       maskUnits="userSpaceOnUse">
+      <g
+         transform="translate(-0.696415,-25.515546)"
+         style="fill:#ffffff"
+         id="g17100">
+        <g
+           transform="matrix(0.27903303,0,0,0.27903303,-148.50157,940.95641)"
+           style="fill:#ffffff;stroke:#ffffff;display:inline"
+           id="g17102">
+          <g
+             style="fill:#ffffff;stroke:#ffffff"
+             transform="matrix(1.1835826,0,0,1.1835826,-7.5789257,-74.544918)"
+             id="g17104">
+            <g
+               transform="matrix(3.0279299,0,0,3.0279299,456.02712,-2782.985)"
+               style="fill:#ffffff;stroke:#ffffff;display:inline"
+               id="g17106"
+               inkscape:label="Layer 1">
+              <g
+                 id="g17108"
+                 style="fill:#ffffff;stroke:#ffffff;display:inline"
+                 transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)">
+                <rect
+                   y="363.23068"
+                   x="464.14426"
+                   height="7.1676102"
+                   width="54.014832"
+                   id="rect17110"
+                   style="fill:#ffffff;fill-opacity:1;stroke:#ffffff" />
+                <g
+                   style="fill:#ffffff;stroke:#ffffff"
+                   id="g17112"
+                   transform="matrix(1.1835826,0,0,1.1835826,-75.612218,-74.709882)">
+                  <rect
+                     ry="2.625"
+                     rx="2.625"
+                     y="365.46738"
+                     x="463.93262"
+                     height="16.625"
+                     width="15"
+                     id="rect17114"
+                     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+                  <path
+                     sodipodi:nodetypes="sssssssss"
+                     inkscape:connector-curvature="0"
+                     id="path17116"
+                     d="m 463.24874,371.54269 31.10344,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,14.39926 c 0,1.45425 -1.21199,2.28111 -2.625,2.625 l -31.10344,7.56983 c -1.413,0.34389 -2.625,-1.17075 -2.625,-2.625 l 0,-21.96909 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+                     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+                  <path
+                     sodipodi:nodetypes="sssssssss"
+                     inkscape:connector-curvature="0"
+                     id="path17118"
+                     d="m 463.24874,371.6096 31.10344,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,14.33235 c 0,1.45425 -1.21199,2.28111 -2.625,2.625 l -31.10344,7.56983 c -1.413,0.34389 -2.625,-1.17075 -2.625,-2.625 l 0,-21.90218 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+                     style="fill:#ffffff;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path17120"
+                     d="m 462.26171,371.52622 20.09375,0"
+                     style="fill:#ffffff;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+                  <g
+                     style="fill:#ffffff;stroke:#ffffff"
+                     mask="url(#mask4917-4-0)"
+                     id="g17122">
+                    <rect
+                       style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.38039374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter4929-9)"
+                       id="rect17124"
+                       width="30.899641"
+                       height="22.649353"
+                       x="860.68469"
+                       y="542.8974"
+                       rx="2.625"
+                       ry="3.7184925"
+                       transform="matrix(1,0,-0.70828043,0.70593118,0,0)" />
+                  </g>
+                  <rect
+                     transform="matrix(1,0,-0.70828042,0.70593119,0,0)"
+                     ry="3.7184927"
+                     rx="2.625"
+                     y="543.43286"
+                     x="860.68469"
+                     height="21.542582"
+                     width="30.23728"
+                     id="rect17126"
+                     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.60383272;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+                </g>
+                <path
+                   sodipodi:nodetypes="ccccccc"
+                   inkscape:connector-curvature="0"
+                   id="path17128"
+                   d="m 492.81474,377.56576 -14.33522,0 0,3.5838 2.02645,0 0,-1.47461 11.8608,0 z"
+                   style="fill:#ffffff;fill-opacity:1;stroke:#ffffff" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <path
+           sodipodi:nodetypes="ssscccssscccscss"
+           inkscape:connector-curvature="0"
+           id="path17130"
+           d="m 5.7026894,1044.9373 c -0.185041,-0.018 -0.402396,-0.059 -0.576929,-0.1108 -0.270837,-0.079 -0.243851,0.015 -0.243851,-0.8593 0,-0.4579 0.0077,-0.7598 0.01951,-0.7646 0.01072,0 0.0317,0 0.04665,0.013 0.04847,0.037 0.294579,0.1623 0.376062,0.1926 0.186482,0.069 0.46629,0.1032 0.663393,0.083 0.436936,-0.047 0.733026,-0.2945 0.881951,-0.7389 0.120095,-0.3583 0.114052,-0.2194 0.12641,-2.9086 l 0.01137,-2.4738 0.829393,0 0.829395,0 0.0062,2.3061 c 0.0064,2.384 -5.49e-4,2.6629 -0.0777,3.0973 -0.156267,0.8809 -0.598495,1.5436 -1.254122,1.8796 -0.440731,0.2258 -1.0806,0.337 -1.637678,0.2843 z"
+           style="fill:#ffffff;fill-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917-4-0">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919-6-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4929-9"
+       x="-0.13757156"
+       width="1.2751431"
+       y="-0.37744918"
+       height="1.7548983"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.5620748"
+         id="feGaussianBlur4931-98" />
+    </filter>
+    <mask
+       id="mask17064"
+       maskUnits="userSpaceOnUse">
+      <g
+         transform="matrix(2.4682548,0,0,2.4682548,-151.3224,-1556.3662)"
+         style="fill:#ffffff"
+         id="g17066">
+        <g
+           transform="matrix(0.27903303,0,0,0.27903303,-148.50157,940.95641)"
+           style="fill:#ffffff;stroke:#ffffff;display:inline"
+           id="g17068">
+          <g
+             style="fill:#ffffff;stroke:#ffffff"
+             transform="matrix(1.1835826,0,0,1.1835826,-7.5789257,-74.544918)"
+             id="g17070">
+            <g
+               transform="matrix(3.0279299,0,0,3.0279299,456.02712,-2782.985)"
+               style="fill:#ffffff;stroke:#ffffff;display:inline"
+               id="g17072"
+               inkscape:label="Layer 1">
+              <g
+                 id="g17074"
+                 style="fill:#ffffff;stroke:#ffffff;display:inline"
+                 transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)">
+                <rect
+                   y="363.23068"
+                   x="464.14426"
+                   height="7.1676102"
+                   width="54.014832"
+                   id="rect17076"
+                   style="fill:#ffffff;fill-opacity:1;stroke:#ffffff" />
+                <g
+                   style="fill:#ffffff;stroke:#ffffff"
+                   id="g17078"
+                   transform="matrix(1.1835826,0,0,1.1835826,-75.612218,-74.709882)">
+                  <rect
+                     ry="2.625"
+                     rx="2.625"
+                     y="365.46738"
+                     x="463.93262"
+                     height="16.625"
+                     width="15"
+                     id="rect17080"
+                     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+                  <path
+                     sodipodi:nodetypes="sssssssss"
+                     inkscape:connector-curvature="0"
+                     id="path17082"
+                     d="m 463.24874,371.54269 31.10344,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,14.39926 c 0,1.45425 -1.21199,2.28111 -2.625,2.625 l -31.10344,7.56983 c -1.413,0.34389 -2.625,-1.17075 -2.625,-2.625 l 0,-21.96909 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+                     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+                  <path
+                     sodipodi:nodetypes="sssssssss"
+                     inkscape:connector-curvature="0"
+                     id="path17084"
+                     d="m 463.24874,371.6096 31.10344,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,14.33235 c 0,1.45425 -1.21199,2.28111 -2.625,2.625 l -31.10344,7.56983 c -1.413,0.34389 -2.625,-1.17075 -2.625,-2.625 l 0,-21.90218 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+                     style="fill:#ffffff;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path17086"
+                     d="m 462.26171,371.52622 20.09375,0"
+                     style="fill:#ffffff;stroke:#ffffff;stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+                  <g
+                     style="fill:#ffffff;stroke:#ffffff"
+                     mask="url(#mask4917-4-0)"
+                     id="g17088">
+                    <rect
+                       style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.38039374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter4929-9)"
+                       id="rect17090"
+                       width="30.899641"
+                       height="22.649353"
+                       x="860.68469"
+                       y="542.8974"
+                       rx="2.625"
+                       ry="3.7184925"
+                       transform="matrix(1,0,-0.70828043,0.70593118,0,0)" />
+                  </g>
+                  <rect
+                     transform="matrix(1,0,-0.70828042,0.70593119,0,0)"
+                     ry="3.7184927"
+                     rx="2.625"
+                     y="543.43286"
+                     x="860.68469"
+                     height="21.542582"
+                     width="30.23728"
+                     id="rect17092"
+                     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.60383272;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+                </g>
+                <path
+                   sodipodi:nodetypes="ccccccc"
+                   inkscape:connector-curvature="0"
+                   id="path17094"
+                   d="m 492.81474,377.56576 -14.33522,0 0,3.5838 2.02645,0 0,-1.47461 11.8608,0 z"
+                   style="fill:#ffffff;fill-opacity:1;stroke:#ffffff" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <path
+           sodipodi:nodetypes="ssscccssscccscss"
+           inkscape:connector-curvature="0"
+           id="path17096"
+           d="m 5.7026894,1044.9373 c -0.185041,-0.018 -0.402396,-0.059 -0.576929,-0.1108 -0.270837,-0.079 -0.243851,0.015 -0.243851,-0.8593 0,-0.4579 0.0077,-0.7598 0.01951,-0.7646 0.01072,0 0.0317,0 0.04665,0.013 0.04847,0.037 0.294579,0.1623 0.376062,0.1926 0.186482,0.069 0.46629,0.1032 0.663393,0.083 0.436936,-0.047 0.733026,-0.2945 0.881951,-0.7389 0.120095,-0.3583 0.114052,-0.2194 0.12641,-2.9086 l 0.01137,-2.4738 0.829393,0 0.829395,0 0.0062,2.3061 c 0.0064,2.384 -5.49e-4,2.6629 -0.0777,3.0973 -0.156267,0.8809 -0.598495,1.5436 -1.254122,1.8796 -0.440731,0.2258 -1.0806,0.337 -1.637678,0.2843 z"
+           style="fill:#ffffff;fill-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask18860">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path18862"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       id="linearGradient7540-2-3-8">
+      <stop
+         id="stop7542-8-7-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9" />
+      <stop
+         id="stop7548-98-9-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-6-33-6-3">
+      <stop
+         id="stop7542-4-4-3-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-5-3-8-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-2-9-1-2" />
+      <stop
+         id="stop7548-9-2-0-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6738"
+       id="linearGradient6744"
+       x1="-31.957434"
+       y1="1042.2544"
+       x2="-31.957434"
+       y2="1039.6025"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4617999,0,0,1.4617999,38.859115,-483.60399)" />
+    <linearGradient
+       id="linearGradient6738">
+      <stop
+         style="stop-color:#5481b6;stop-opacity:1"
+         offset="0"
+         id="stop6740" />
+      <stop
+         id="stop5729"
+         offset="0.5"
+         style="stop-color:#1c65a2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5286ba;stop-opacity:1"
+         offset="1"
+         id="stop6742" />
+    </linearGradient>
+    <linearGradient
+       y2="1039.6025"
+       x2="-31.957434"
+       y1="1042.2544"
+       x1="-31.957434"
+       gradientTransform="matrix(1.1876056,0,0,1.1876056,46.681185,-191.60474)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4964"
+       xlink:href="#linearGradient6738"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1-1"
+       id="linearGradient9837"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-1">
+      <stop
+         style="stop-color:#75ba7a;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1-1"
+       id="linearGradient3077"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="11.913935"
+     inkscape:cy="3.0716956"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1107"
+     inkscape:window-height="899"
+     inkscape:window-x="1404"
+     inkscape:window-y="552"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:type="arc"
+       style="font-size:13.58917427000000100px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient3077);fill-opacity:1;stroke:#058149;stroke-width:4.28791809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+       id="path10796-2-6-2"
+       sodipodi:cx="388.125"
+       sodipodi:cy="468.23718"
+       sodipodi:rx="10.625"
+       sodipodi:ry="10.625"
+       d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+       transform="matrix(0.23321341,0,0,0.23321341,-82.513695,935.16275)" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(1.6252372,17.080298)" />
+    <path
+       sodipodi:nodetypes="czczczczc"
+       inkscape:connector-curvature="0"
+       id="rect6501-1-6-1"
+       d="m 7.9973152,1042.521 c 0,0 0.1917576,0.6999 0.6766707,1.1849 0.4849113,0.4848 1.1847983,0.6765 1.1847983,0.6765 0,0 -0.6959167,0.1879 -1.1847967,0.6767 -0.4888799,0.4889 -0.6766706,1.1847 -0.6766706,1.1847 0,0 -0.1719097,-0.6798 -0.6766707,-1.1847 -0.504761,-0.5048 -1.1847934,-0.6767 -1.1847934,-0.6767 0,0 0.7117911,-0.2037 1.1847934,-0.6765 0.4730006,-0.4732 0.676669,-1.1849 0.676669,-1.1849 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/inher_co.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/inher_co.svg
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="inher_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8080">
+      <stop
+         style="stop-color:#5c7aaa;stop-opacity:1"
+         offset="0"
+         id="stop8082" />
+      <stop
+         id="stop8086"
+         offset="0.6250037"
+         style="stop-color:#6f7684;stop-opacity:1" />
+      <stop
+         style="stop-color:#4d5a5d;stop-opacity:1"
+         offset="1"
+         id="stop8084" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#75ba7a;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       y2="13.5"
+       x2="6.9999628"
+       y1="13.5"
+       x1="0"
+       gradientTransform="matrix(0,-1,1,0,-24.12959,1042.3481)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7993"
+       xlink:href="#linearGradient8080"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="26.386098"
+     inkscape:cy="9.1802237"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6438"
+     showgrid="true"
+     inkscape:window-width="1287"
+     inkscape:window-height="862"
+     inkscape:window-x="623"
+     inkscape:window-y="113"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3960" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+         id="g6438">
+        <rect
+           style="fill:#fefdef;fill-opacity:1;stroke:#c4a543;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect6724"
+           width="2.022656"
+           height="2.022656"
+           x="-5.641345"
+           y="1037.8381" />
+        <path
+           sodipodi:type="arc"
+           style="fill:url(#linearGradient3929-5);fill-opacity:1;stroke:#14733c;stroke-width:5.25411463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="path10796-2-6-2"
+           sodipodi:cx="388.125"
+           sodipodi:cy="468.23718"
+           sodipodi:rx="10.625"
+           sodipodi:ry="10.625"
+           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+           transform="matrix(0.18865958,0,0,0.18865958,-83.839865,942.49831)" />
+        <path
+           sodipodi:nodetypes="cccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-9-0"
+           d="m -11.12959,1043.3481 1,0 0,-6 2,0 -2.5,-2.9998 -2.5,2.9998 2,0 z"
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient7993);fill-opacity:1;stroke:none;display:inline;font-family:Sans" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-9-0-2"
+           d="m -10.12959,1038.3481 0,1 4,0 0,-1 z"
+           style="font-size:13.58917427000000100px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#6b778c;fill-opacity:1;stroke:none;display:inline;font-family:Sans" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-9-0-2-2"
+           d="m -10.12959,1042.3481 0,1 4,0 0,-1 z"
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline;font-family:Sans" />
+        <rect
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#fefdef;fill-opacity:1;stroke:#c4a543;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+           id="rect6724-4"
+           width="2.022656"
+           height="2.022656"
+           x="-5.641345"
+           y="1041.8381" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/letter-l-icon.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/letter-l-icon.svg
@@ -1,0 +1,6481 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="letter-l-icon.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient15157">
+      <stop
+         style="stop-color:#eeb9bd;stop-opacity:1"
+         offset="0"
+         id="stop15159" />
+      <stop
+         id="stop15161"
+         offset="1"
+         style="stop-color:#d65b65;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15151">
+      <stop
+         style="stop-color:#ffe3a7;stop-opacity:1"
+         offset="0"
+         id="stop15153" />
+      <stop
+         id="stop15155"
+         offset="1"
+         style="stop-color:#ffbd2c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#2692d1;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-6-1-7">
+      <stop
+         id="stop11150-7-5-9-3-8-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-35-5-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-1-1-4">
+      <stop
+         id="stop11150-9-6-9-5-6-9"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-6-3-3-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-5-6-8">
+      <stop
+         id="stop11150-7-8-3-8-7-0-6"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-3-2-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507-2">
+      <stop
+         style="stop-color:#2692d1;stop-opacity:1"
+         offset="0"
+         id="stop10509-4" />
+      <stop
+         id="stop10511-2"
+         offset="0.18181793"
+         style="stop-color:#4aa3d7;stop-opacity:1" />
+      <stop
+         id="stop10513-9"
+         offset="0.36363617"
+         style="stop-color:#49a4d9;stop-opacity:1" />
+      <stop
+         id="stop10515-0"
+         offset="0.49999985"
+         style="stop-color:#2692d1;stop-opacity:1" />
+      <stop
+         id="stop10517-9"
+         offset="0.63636351"
+         style="stop-color:#49a2d7;stop-opacity:1" />
+      <stop
+         style="stop-color:#4aa3d7;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519-2" />
+      <stop
+         style="stop-color:#2692d1;stop-opacity:1"
+         offset="1"
+         id="stop10522-7" />
+    </linearGradient>
+    <clipPath
+       id="clipPath4256"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4258"
+         d="m 520.90039,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4260"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4262"
+         d="m 520.90039,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4264"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4266"
+         d="m 520.90039,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4268"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4270"
+         d="m 520.90039,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4272"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4274"
+         d="m 520.90039,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4276"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4278"
+         d="m 520.90039,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4280"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4282"
+         d="m 520.90039,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4284"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4286"
+         d="m 520.90039,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4288"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4290"
+         d="m 520.90039,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4292"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4294"
+         d="m 520.90039,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4296"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4298"
+         d="m 520.90039,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4408"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4410"
+         d="m 536.87793,326.68359 15.44141,0 0,159.62207 -15.44141,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4412"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4414"
+         d="m 536.87793,326.68359 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4416"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4418"
+         d="m 536.87793,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4420"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4422"
+         d="m 536.87793,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4424"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4426"
+         d="m 536.87793,374.74414 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4428"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4430"
+         d="m 536.87793,390.76367 15.44141,0 0,15.44092 -15.44141,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4432"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4434"
+         d="m 536.87793,406.78271 15.44141,0 0,15.44239 -15.44141,0 0,-15.44239 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4436"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4438"
+         d="m 536.87793,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4440"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4442"
+         d="m 536.87793,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4444"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4446"
+         d="m 536.87793,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4448"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4450"
+         d="m 536.87793,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4560"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4562"
+         d="m 488.81348,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4564"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4566"
+         d="m 488.81348,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4568"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4570"
+         d="m 488.81348,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4572"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4574"
+         d="m 488.81348,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4576"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4578"
+         d="m 488.81348,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4580"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4582"
+         d="m 488.81348,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4584"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4586"
+         d="m 488.81348,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4588"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4590"
+         d="m 488.81348,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4592"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4594"
+         d="m 488.81348,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4596"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4598"
+         d="m 488.81348,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4600"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4602"
+         d="m 488.81348,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4712"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4714"
+         d="m 504.86816,326.68164 15.44141,0 0,159.62402 -15.44141,0 0,-159.62402 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4716"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4718"
+         d="m 504.86816,326.68164 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4720"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4722"
+         d="m 504.86816,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4724"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4726"
+         d="m 504.86816,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4728"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4730"
+         d="m 504.86816,374.74219 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4732"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4734"
+         d="m 504.86816,390.76367 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4736"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4738"
+         d="m 504.86816,406.78369 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4740"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4742"
+         d="m 504.86816,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4744"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4746"
+         d="m 504.86816,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4748"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4750"
+         d="m 504.86816,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4752"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4754"
+         d="m 504.86816,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4864"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4866"
+         d="m 56.09717,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4868"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4870"
+         d="m 56.09717,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4872"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4874"
+         d="m 56.09717,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4876"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4878"
+         d="m 56.09717,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4880"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4882"
+         d="m 56.09717,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4884"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4886"
+         d="m 56.09717,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4888"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4890"
+         d="m 56.09717,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4892"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4894"
+         d="m 56.09717,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4896"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4898"
+         d="m 56.09717,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4900"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4902"
+         d="m 56.09717,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath4904"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4906"
+         d="m 56.09717,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5016"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5018"
+         d="m 360.56055,326.68359 15.43945,0 0,159.62207 -15.43945,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5020"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5022"
+         d="m 360.56055,326.68359 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5024"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5026"
+         d="m 360.56055,342.70313 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5028"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5030"
+         d="m 360.56055,358.72266 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5032"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5034"
+         d="m 360.56055,374.74414 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5036"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5038"
+         d="m 360.56055,390.76367 15.43945,0 0,15.44092 -15.43945,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5040"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5042"
+         d="m 360.56055,406.78271 15.43945,0 0,15.44239 -15.43945,0 0,-15.44239 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5044"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5046"
+         d="m 360.56055,422.80371 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5048"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5050"
+         d="m 360.56055,438.82373 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5052"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5054"
+         d="m 360.56055,454.84424 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5056"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5058"
+         d="m 360.56055,470.86426 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5168"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5170"
+         d="m 376.57031,326.68164 15.44141,0 0,159.62402 -15.44141,0 0,-159.62402 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5172"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5174"
+         d="m 376.57031,326.68164 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5176"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5178"
+         d="m 376.57031,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5180"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5182"
+         d="m 376.57031,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5184"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5186"
+         d="m 376.57031,374.74219 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5188"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5190"
+         d="m 376.57031,390.76367 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5192"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5194"
+         d="m 376.57031,406.78369 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5196"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5198"
+         d="m 376.57031,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5200"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5202"
+         d="m 376.57031,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5204"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5206"
+         d="m 376.57031,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5208"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5210"
+         d="m 376.57031,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5320"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5322"
+         d="m 568.88672,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5324"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5326"
+         d="m 568.88672,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5328"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5330"
+         d="m 568.88672,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5332"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5334"
+         d="m 568.88672,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5336"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5338"
+         d="m 568.88672,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5340"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5342"
+         d="m 568.88672,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5344"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5346"
+         d="m 568.88672,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5348"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5350"
+         d="m 568.88672,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5352"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5354"
+         d="m 568.88672,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5356"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5358"
+         d="m 568.88672,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5360"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5362"
+         d="m 568.88672,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5472"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5474"
+         d="m 552.90137,326.68359 15.4414,0 0,159.62207 -15.4414,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5476"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5478"
+         d="m 552.90137,326.68359 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5480"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5482"
+         d="m 552.90137,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5484"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5486"
+         d="m 552.90137,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5488"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5490"
+         d="m 552.90137,374.74414 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5492"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5494"
+         d="m 552.90137,390.76367 15.4414,0 0,15.44092 -15.4414,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5496"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5498"
+         d="m 552.90137,406.78271 15.4414,0 0,15.44239 -15.4414,0 0,-15.44239 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5500"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5502"
+         d="m 552.90137,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5504"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5506"
+         d="m 552.90137,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5508"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5510"
+         d="m 552.90137,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5512"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5514"
+         d="m 552.90137,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5624"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5626"
+         d="m 408.64648,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5628"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5630"
+         d="m 408.64648,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5632"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5634"
+         d="m 408.64648,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5636"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5638"
+         d="m 408.64648,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5640"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5642"
+         d="m 408.64648,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5644"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5646"
+         d="m 408.64648,390.76367 15.44336,0 0,15.44092 -15.44336,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5648"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5650"
+         d="m 408.64648,406.78271 15.44336,0 0,15.44239 -15.44336,0 0,-15.44239 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5652"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5654"
+         d="m 408.64648,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5656"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5658"
+         d="m 408.64648,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5660"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5662"
+         d="m 408.64648,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5664"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5666"
+         d="m 408.64648,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5776"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5778"
+         d="m 72.09766,326.68164 15.4414,0 0,159.62402 -15.4414,0 0,-159.62402 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5780"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5782"
+         d="m 72.09766,326.68164 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5784"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5786"
+         d="m 72.09766,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5788"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5790"
+         d="m 72.09766,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5792"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5794"
+         d="m 72.09766,374.74219 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5796"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5798"
+         d="m 72.09766,390.76367 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5800"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5802"
+         d="m 72.09766,406.78369 15.4414,0 0,15.44092 -15.4414,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5804"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5806"
+         d="m 72.09766,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5808"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5810"
+         d="m 72.09766,438.82422 15.4414,0 0,15.44092 -15.4414,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5812"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5814"
+         d="m 72.09766,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5816"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5818"
+         d="m 72.09766,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5930"
+         d="m 88.02344,326.68262 15.44238,0 0,159.62304 -15.44238,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5932"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5934"
+         d="m 88.02344,326.68262 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5936"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5938"
+         d="m 88.02344,342.70313 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5940"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5942"
+         d="m 88.02344,358.72266 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5944"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5946"
+         d="m 88.02344,374.74316 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5948"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5950"
+         d="m 88.02344,390.76367 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5952"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5954"
+         d="m 88.02344,406.7832 15.44238,0 0,15.44239 -15.44238,0 0,-15.44239 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5956"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5958"
+         d="m 88.02344,422.80371 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5960"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5962"
+         d="m 88.02344,438.82324 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5964"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5966"
+         d="m 88.02344,454.84424 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath5968"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5970"
+         d="m 88.02344,470.86426 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6080"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6082"
+         d="m 104.01172,326.68262 15.44189,0 0,159.62304 -15.44189,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6084"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6086"
+         d="m 104.01172,326.68262 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6088"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6090"
+         d="m 104.01172,342.70313 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6092"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6094"
+         d="m 104.01172,358.72266 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6096"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6098"
+         d="m 104.01172,374.74316 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6100"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6102"
+         d="m 104.01172,390.76367 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6104"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6106"
+         d="m 104.01172,406.7832 15.44189,0 0,15.4419 -15.44189,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6108"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6110"
+         d="m 104.01172,422.80371 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6112"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6114"
+         d="m 104.01172,438.82373 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6116"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6118"
+         d="m 104.01172,454.84424 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6120"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6122"
+         d="m 104.01172,470.86426 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6232"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6234"
+         d="m 135.93994,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6236"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6238"
+         d="m 135.93994,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6240"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6242"
+         d="m 135.93994,342.70215 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6244"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6246"
+         d="m 135.93994,358.72168 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6248"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6250"
+         d="m 135.93994,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6252"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6254"
+         d="m 135.93994,390.7627 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6256"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6258"
+         d="m 135.93994,406.78223 15.44141,0 0,15.44287 -15.44141,0 0,-15.44287 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6260"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6262"
+         d="m 135.93994,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6264"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6266"
+         d="m 135.93994,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6268"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6270"
+         d="m 135.93994,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6272"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6274"
+         d="m 135.93994,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6384"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6386"
+         d="m 119.99805,326.68164 15.44091,0 0,159.62402 -15.44091,0 0,-159.62402 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6388"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6390"
+         d="m 119.99805,326.68164 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6392"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6394"
+         d="m 119.99805,342.70117 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6396"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6398"
+         d="m 119.99805,358.7207 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6400"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6402"
+         d="m 119.99805,374.74219 15.44091,0 0,15.4414 -15.44091,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6404"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6406"
+         d="m 119.99805,390.76172 15.44091,0 0,15.44189 -15.44091,0 0,-15.44189 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6408"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6410"
+         d="m 119.99805,406.78174 15.44091,0 0,15.44336 -15.44091,0 0,-15.44336 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6412"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6414"
+         d="m 119.99805,422.80371 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6416"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6418"
+         d="m 119.99805,438.82373 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6420"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6422"
+         d="m 119.99805,454.84424 15.44091,0 0,15.4414 -15.44091,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6424"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6426"
+         d="m 119.99805,470.86426 15.44091,0 0,15.4414 -15.44091,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6536"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6538"
+         d="m 232.45801,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6540"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6542"
+         d="m 232.45801,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6544"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6546"
+         d="m 232.45801,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6548"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6550"
+         d="m 232.45801,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6552"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6554"
+         d="m 232.45801,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6556"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6558"
+         d="m 232.45801,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6560"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6562"
+         d="m 232.45801,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6564"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6566"
+         d="m 232.45801,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6568"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6570"
+         d="m 232.45801,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6572"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6574"
+         d="m 232.45801,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6576"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6578"
+         d="m 232.45801,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6688"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6690"
+         d="m 216.34521,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6692"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6694"
+         d="m 216.34521,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6696"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6698"
+         d="m 216.34521,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6700"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6702"
+         d="m 216.34521,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6704"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6706"
+         d="m 216.34521,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6708"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6710"
+         d="m 216.34521,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6712"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6714"
+         d="m 216.34521,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6716"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6718"
+         d="m 216.34521,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6720"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6722"
+         d="m 216.34521,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6724"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6726"
+         d="m 216.34521,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6728"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6730"
+         d="m 216.34521,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6840"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6842"
+         d="m 184.04492,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6844"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6846"
+         d="m 184.04492,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6848"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6850"
+         d="m 184.04492,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6852"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6854"
+         d="m 184.04492,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6856"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6858"
+         d="m 184.04492,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6860"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6862"
+         d="m 184.04492,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6864"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6866"
+         d="m 184.04492,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6868"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6870"
+         d="m 184.04492,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6872"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6874"
+         d="m 184.04492,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6876"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6878"
+         d="m 184.04492,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6880"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6882"
+         d="m 184.04492,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6992"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6994"
+         d="m 200.18604,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath6996"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6998"
+         d="m 200.18604,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7000"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7002"
+         d="m 200.18604,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7004"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7006"
+         d="m 200.18604,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7008"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7010"
+         d="m 200.18604,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7012"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7014"
+         d="m 200.18604,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7016"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7018"
+         d="m 200.18604,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7020"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7022"
+         d="m 200.18604,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7024"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7026"
+         d="m 200.18604,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7028"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7030"
+         d="m 200.18604,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7032"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7034"
+         d="m 200.18604,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7144"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7146"
+         d="m 167.99707,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7148"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7150"
+         d="m 167.99707,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7152"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7154"
+         d="m 167.99707,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7156"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7158"
+         d="m 167.99707,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7160"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7162"
+         d="m 167.99707,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7164"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7166"
+         d="m 167.99707,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7168"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7170"
+         d="m 167.99707,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7172"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7174"
+         d="m 167.99707,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7176"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7178"
+         d="m 167.99707,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7180"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7182"
+         d="m 167.99707,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7184"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7186"
+         d="m 167.99707,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7296"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7298"
+         d="m 248.59229,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7300"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7302"
+         d="m 248.59229,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7304"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7306"
+         d="m 248.59229,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7308"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7310"
+         d="m 248.59229,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7312"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7314"
+         d="m 248.59229,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7316"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7318"
+         d="m 248.59229,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7320"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7322"
+         d="m 248.59229,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7324"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7326"
+         d="m 248.59229,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7328"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7330"
+         d="m 248.59229,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7332"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7334"
+         d="m 248.59229,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7336"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7338"
+         d="m 248.59229,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7448"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7450"
+         d="m 344.50879,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7452"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7454"
+         d="m 344.50879,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7456"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7458"
+         d="m 344.50879,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7460"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7462"
+         d="m 344.50879,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7464"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7466"
+         d="m 344.50879,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7468"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7470"
+         d="m 344.50879,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7472"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7474"
+         d="m 344.50879,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7476"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7478"
+         d="m 344.50879,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7480"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7482"
+         d="m 344.50879,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7484"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7486"
+         d="m 344.50879,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7488"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7490"
+         d="m 344.50879,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7600"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 312.58691,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7604"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7606"
+         d="m 312.58691,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7608"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7610"
+         d="m 312.58691,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7612"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7614"
+         d="m 312.58691,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7616"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7618"
+         d="m 312.58691,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7620"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7622"
+         d="m 312.58691,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7624"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7626"
+         d="m 312.58691,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7628"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7630"
+         d="m 312.58691,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7632"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7634"
+         d="m 312.58691,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7636"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7638"
+         d="m 312.58691,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7640"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7642"
+         d="m 312.58691,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7752"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7754"
+         d="m 280.55371,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7756"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7758"
+         d="m 280.55371,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7760"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7762"
+         d="m 280.55371,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7764"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7766"
+         d="m 280.55371,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7768"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7770"
+         d="m 280.55371,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7772"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7774"
+         d="m 280.55371,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7776"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7778"
+         d="m 280.55371,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7780"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7782"
+         d="m 280.55371,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7784"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7786"
+         d="m 280.55371,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7788"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7790"
+         d="m 280.55371,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7792"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7794"
+         d="m 280.55371,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7904"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7906"
+         d="m 296.45996,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7908"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7910"
+         d="m 296.45996,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7912"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7914"
+         d="m 296.45996,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7916"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7918"
+         d="m 296.45996,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7920"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7922"
+         d="m 296.45996,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7924"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7926"
+         d="m 296.45996,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7930"
+         d="m 296.45996,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7932"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7934"
+         d="m 296.45996,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7936"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7938"
+         d="m 296.45996,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7940"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7942"
+         d="m 296.45996,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath7944"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7946"
+         d="m 296.45996,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8056"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8058"
+         d="m 264.5459,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8060"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8062"
+         d="m 264.5459,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8064"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8066"
+         d="m 264.5459,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8068"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8070"
+         d="m 264.5459,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8072"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8074"
+         d="m 264.5459,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8076"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8078"
+         d="m 264.5459,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8080"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8082"
+         d="m 264.5459,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8084"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8086"
+         d="m 264.5459,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8088"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8090"
+         d="m 264.5459,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8092"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8094"
+         d="m 264.5459,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8096"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8098"
+         d="m 264.5459,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8208"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8210"
+         d="m 328.63379,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8212"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8214"
+         d="m 328.63379,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8216"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8218"
+         d="m 328.63379,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8220"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8222"
+         d="m 328.63379,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8224"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8226"
+         d="m 328.63379,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8228"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8230"
+         d="m 328.63379,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8232"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8234"
+         d="m 328.63379,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8236"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8238"
+         d="m 328.63379,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8240"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8242"
+         d="m 328.63379,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8244"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8246"
+         d="m 328.63379,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8248"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8250"
+         d="m 328.63379,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8360"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8362"
+         d="m 392.56836,326.68164 15.44141,0 0,159.62402 -15.44141,0 0,-159.62402 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8364"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8366"
+         d="m 392.56836,326.68164 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8368"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8370"
+         d="m 392.56836,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8372"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8374"
+         d="m 392.56836,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8376"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8378"
+         d="m 392.56836,374.74219 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8380"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8382"
+         d="m 392.56836,390.76367 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8384"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8386"
+         d="m 392.56836,406.78369 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8388"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8390"
+         d="m 392.56836,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8392"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8394"
+         d="m 392.56836,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8396"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8398"
+         d="m 392.56836,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8400"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8402"
+         d="m 392.56836,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8512"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8514"
+         d="m 151.93799,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8516"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8518"
+         d="m 151.93799,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8520"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8522"
+         d="m 151.93799,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8524"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8526"
+         d="m 151.93799,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8528"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8530"
+         d="m 151.93799,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8532"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8534"
+         d="m 151.93799,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8536"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8538"
+         d="m 151.93799,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8540"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8542"
+         d="m 151.93799,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8544"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8546"
+         d="m 151.93799,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8548"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8550"
+         d="m 151.93799,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8552"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8554"
+         d="m 151.93799,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8664"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8666"
+         d="m 424.74902,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8668"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8670"
+         d="m 424.74902,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8672"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8674"
+         d="m 424.74902,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8676"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8678"
+         d="m 424.74902,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8680"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8682"
+         d="m 424.74902,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8684"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8686"
+         d="m 424.74902,390.76367 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8688"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8690"
+         d="m 424.74902,406.7832 15.44336,0 0,15.4419 -15.44336,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8692"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8694"
+         d="m 424.74902,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8696"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8698"
+         d="m 424.74902,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8700"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8702"
+         d="m 424.74902,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8704"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8706"
+         d="m 424.74902,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8816"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8818"
+         d="m 440.83203,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8820"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8822"
+         d="m 440.83203,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8824"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8826"
+         d="m 440.83203,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8828"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8830"
+         d="m 440.83203,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8832"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8834"
+         d="m 440.83203,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8836"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8838"
+         d="m 440.83203,390.76367 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8840"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8842"
+         d="m 440.83203,406.7832 15.44336,0 0,15.4419 -15.44336,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8844"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8846"
+         d="m 440.83203,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8848"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8850"
+         d="m 440.83203,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8852"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8854"
+         d="m 440.83203,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8856"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8858"
+         d="m 440.83203,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8968"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8970"
+         d="m 456.79199,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8972"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8974"
+         d="m 456.79199,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8976"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8978"
+         d="m 456.79199,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8980"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8982"
+         d="m 456.79199,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8984"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8986"
+         d="m 456.79199,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8988"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8990"
+         d="m 456.79199,390.76367 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8992"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8994"
+         d="m 456.79199,406.7832 15.44336,0 0,15.4419 -15.44336,0 0,-15.4419 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath8996"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8998"
+         d="m 456.79199,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9000"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9002"
+         d="m 456.79199,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9004"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9006"
+         d="m 456.79199,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9008"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9010"
+         d="m 456.79199,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9120"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9122"
+         d="m 472.84082,326.68457 15.44336,0 0,159.62109 -15.44336,0 0,-159.62109 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9124"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9126"
+         d="m 472.84082,326.68457 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9128"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9130"
+         d="m 472.84082,342.7041 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9132"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9134"
+         d="m 472.84082,358.72363 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9136"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9138"
+         d="m 472.84082,374.74512 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9140"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9142"
+         d="m 472.84082,390.76465 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9144"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9146"
+         d="m 472.84082,406.78418 15.44336,0 0,15.44092 -15.44336,0 0,-15.44092 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9148"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9150"
+         d="m 472.84082,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9152"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9154"
+         d="m 472.84082,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9156"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9158"
+         d="m 472.84082,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath9160"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9162"
+         d="m 472.84082,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient18855">
+      <stop
+         style="stop-color:#a4b1c7;stop-opacity:1;"
+         offset="0"
+         id="stop18857" />
+      <stop
+         id="stop18859"
+         offset="0.50000364"
+         style="stop-color:#e1e9f8;stop-opacity:0" />
+      <stop
+         style="stop-color:#e7eefa;stop-opacity:0"
+         offset="1"
+         id="stop18861" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18808">
+      <stop
+         id="stop18810"
+         offset="0"
+         style="stop-color:#a4b1c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e1e9f8;stop-opacity:1"
+         offset="0.24999017"
+         id="stop18816" />
+      <stop
+         id="stop18812"
+         offset="1"
+         style="stop-color:#e7eefa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18543">
+      <stop
+         id="stop18545"
+         offset="0"
+         style="stop-color:#a79c68;stop-opacity:1;" />
+      <stop
+         style="stop-color:#687692;stop-opacity:1"
+         offset="0.31919643"
+         id="stop18555" />
+      <stop
+         style="stop-color:#8c99a6;stop-opacity:1"
+         offset="0.42585152"
+         id="stop18553" />
+      <stop
+         style="stop-color:#7b8da7;stop-opacity:1"
+         offset="0.671875"
+         id="stop18551" />
+      <stop
+         id="stop18547"
+         offset="1"
+         style="stop-color:#5e78a8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4862">
+      <stop
+         id="stop4864"
+         offset="0"
+         style="stop-color:#937323;stop-opacity:1;" />
+      <stop
+         id="stop4866"
+         offset="1"
+         style="stop-color:#79601d;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5156">
+      <stop
+         id="stop5158"
+         offset="0"
+         style="stop-color:#fdf3cb;stop-opacity:1;" />
+      <stop
+         style="stop-color:#fdf3cb;stop-opacity:1"
+         offset="0.48612955"
+         id="stop5166" />
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:0.502"
+         offset="0.56520796"
+         id="stop5164" />
+      <stop
+         id="stop5160"
+         offset="1"
+         style="stop-color:#a77e1c;stop-opacity:0.5" />
+    </linearGradient>
+    <mask
+       id="mask8608"
+       maskUnits="userSpaceOnUse">
+      <rect
+         ry="0.67081022"
+         rx="0.67081022"
+         y="1037.3622"
+         x="1"
+         height="14"
+         width="14"
+         id="rect8610"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       id="linearGradient4886"
+       inkscape:collect="always">
+      <stop
+         id="stop4888"
+         offset="0"
+         style="stop-color:#dec26f;stop-opacity:1" />
+      <stop
+         id="stop4890"
+         offset="1"
+         style="stop-color:#fce69e;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       id="filter5152"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5154"
+         stdDeviation="0.32374297"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient4878"
+       inkscape:collect="always">
+      <stop
+         id="stop4880"
+         offset="0"
+         style="stop-color:#925218;stop-opacity:1" />
+      <stop
+         id="stop4882"
+         offset="1"
+         style="stop-color:#c1aa38;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1040.9708"
+       x2="30.0625"
+       y1="1034.4965"
+       x1="30.0625"
+       gradientTransform="translate(-42.734657,2.4992546)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8465"
+       xlink:href="#linearGradient4862"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1040.7358"
+       x2="32.325939"
+       y1="1049.9935"
+       x1="32.325939"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8469"
+       xlink:href="#linearGradient4886"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1049.7878"
+       x2="32.558262"
+       y1="1041.8381"
+       x1="27.20822"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8471"
+       xlink:href="#linearGradient5156"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1040.7803"
+       x2="29.263437"
+       y1="1048.656"
+       x1="29.263437"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8473"
+       xlink:href="#linearGradient4878"
+       inkscape:collect="always" />
+    <mask
+       id="mask8608-4"
+       maskUnits="userSpaceOnUse">
+      <rect
+         ry="0.67081022"
+         rx="0.67081022"
+         y="1037.3622"
+         x="1"
+         height="14"
+         width="14"
+         id="rect8610-4"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       id="linearGradient3783">
+      <stop
+         style="stop-color:#dce2f4;stop-opacity:1"
+         offset="0"
+         id="stop3785" />
+      <stop
+         id="stop3787"
+         offset="0.31933746"
+         style="stop-color:#c4cee4;stop-opacity:1" />
+      <stop
+         style="stop-color:#c4cef4;stop-opacity:1"
+         offset="1"
+         id="stop3789" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4903-7-7">
+      <stop
+         id="stop4905-2-3"
+         offset="0"
+         style="stop-color:#ffe69f;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffcb2f;stop-opacity:1"
+         offset="0.41477016"
+         id="stop4911-4-9" />
+      <stop
+         id="stop4907-3-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4256-9">
+      <path
+         d="m 520.90039,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path4258-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4260-6">
+      <path
+         d="m 520.90039,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4262-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4264-7">
+      <path
+         d="m 520.90039,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4266-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4268-8">
+      <path
+         d="m 520.90039,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4270-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4272-5">
+      <path
+         d="m 520.90039,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4274-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4276-8">
+      <path
+         d="m 520.90039,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4278-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4280-3">
+      <path
+         d="m 520.90039,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path4282-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4284-0">
+      <path
+         d="m 520.90039,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4286-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4288-3">
+      <path
+         d="m 520.90039,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4290-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4292-7">
+      <path
+         d="m 520.90039,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4294-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4296-2">
+      <path
+         d="m 520.90039,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4298-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4408-8">
+      <path
+         d="m 536.87793,326.68359 15.44141,0 0,159.62207 -15.44141,0 0,-159.62207 z"
+         id="path4410-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4412-2">
+      <path
+         d="m 536.87793,326.68359 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4414-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4416-3">
+      <path
+         d="m 536.87793,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4418-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4420-5">
+      <path
+         d="m 536.87793,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4422-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4424-1">
+      <path
+         d="m 536.87793,374.74414 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4426-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4428-6">
+      <path
+         d="m 536.87793,390.76367 15.44141,0 0,15.44092 -15.44141,0 0,-15.44092 z"
+         id="path4430-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4432-2">
+      <path
+         d="m 536.87793,406.78271 15.44141,0 0,15.44239 -15.44141,0 0,-15.44239 z"
+         id="path4434-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4436-4">
+      <path
+         d="m 536.87793,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4438-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4440-3">
+      <path
+         d="m 536.87793,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4442-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4444-9">
+      <path
+         d="m 536.87793,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4446-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4448-7">
+      <path
+         d="m 536.87793,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4450-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4560-0">
+      <path
+         d="m 488.81348,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path4562-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4564-8">
+      <path
+         d="m 488.81348,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4566-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4568-6">
+      <path
+         d="m 488.81348,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4570-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4572-4">
+      <path
+         d="m 488.81348,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4574-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4576-5">
+      <path
+         d="m 488.81348,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4578-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4580-0">
+      <path
+         d="m 488.81348,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4582-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4584-4">
+      <path
+         d="m 488.81348,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path4586-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4588-4">
+      <path
+         d="m 488.81348,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4590-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4592-7">
+      <path
+         d="m 488.81348,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4594-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4596-5">
+      <path
+         d="m 488.81348,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4598-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4600-3">
+      <path
+         d="m 488.81348,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4602-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4712-3">
+      <path
+         d="m 504.86816,326.68164 15.44141,0 0,159.62402 -15.44141,0 0,-159.62402 z"
+         id="path4714-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4716-4">
+      <path
+         d="m 504.86816,326.68164 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4718-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4720-5">
+      <path
+         d="m 504.86816,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4722-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4724-4">
+      <path
+         d="m 504.86816,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4726-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4728-9">
+      <path
+         d="m 504.86816,374.74219 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4730-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4732-7">
+      <path
+         d="m 504.86816,390.76367 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path4734-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4736-0">
+      <path
+         d="m 504.86816,406.78369 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4738-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4740-9">
+      <path
+         d="m 504.86816,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4742-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4744-3">
+      <path
+         d="m 504.86816,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path4746-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4748-0">
+      <path
+         d="m 504.86816,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4750-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4752-1">
+      <path
+         d="m 504.86816,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path4754-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4864-0">
+      <path
+         d="m 56.09717,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path4866-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4868-9">
+      <path
+         d="m 56.09717,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4870-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4872-9">
+      <path
+         d="m 56.09717,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4874-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4876-1">
+      <path
+         d="m 56.09717,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4878-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4880-7">
+      <path
+         d="m 56.09717,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4882-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4884-6">
+      <path
+         d="m 56.09717,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4886-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4888-7">
+      <path
+         d="m 56.09717,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path4890-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4892-7">
+      <path
+         d="m 56.09717,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4894-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4896-6">
+      <path
+         d="m 56.09717,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path4898-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4900-7">
+      <path
+         d="m 56.09717,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4902-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4904-4">
+      <path
+         d="m 56.09717,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path4906-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5016-3">
+      <path
+         d="m 360.56055,326.68359 15.43945,0 0,159.62207 -15.43945,0 0,-159.62207 z"
+         id="path5018-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5020-3">
+      <path
+         d="m 360.56055,326.68359 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z"
+         id="path5022-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5024-6">
+      <path
+         d="m 360.56055,342.70313 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z"
+         id="path5026-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5028-9">
+      <path
+         d="m 360.56055,358.72266 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z"
+         id="path5030-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5032-7">
+      <path
+         d="m 360.56055,374.74414 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z"
+         id="path5034-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5036-6">
+      <path
+         d="m 360.56055,390.76367 15.43945,0 0,15.44092 -15.43945,0 0,-15.44092 z"
+         id="path5038-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5040-6">
+      <path
+         d="m 360.56055,406.78271 15.43945,0 0,15.44239 -15.43945,0 0,-15.44239 z"
+         id="path5042-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5044-3">
+      <path
+         d="m 360.56055,422.80371 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z"
+         id="path5046-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5048-3">
+      <path
+         d="m 360.56055,438.82373 15.43945,0 0,15.44141 -15.43945,0 0,-15.44141 z"
+         id="path5050-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5052-2">
+      <path
+         d="m 360.56055,454.84424 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z"
+         id="path5054-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5056-8">
+      <path
+         d="m 360.56055,470.86426 15.43945,0 0,15.4414 -15.43945,0 0,-15.4414 z"
+         id="path5058-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5168-3">
+      <path
+         d="m 376.57031,326.68164 15.44141,0 0,159.62402 -15.44141,0 0,-159.62402 z"
+         id="path5170-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5172-0">
+      <path
+         d="m 376.57031,326.68164 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5174-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5176-8">
+      <path
+         d="m 376.57031,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5178-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5180-4">
+      <path
+         d="m 376.57031,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5182-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5184-7">
+      <path
+         d="m 376.57031,374.74219 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5186-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5188-5">
+      <path
+         d="m 376.57031,390.76367 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path5190-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5192-5">
+      <path
+         d="m 376.57031,406.78369 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5194-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5196-6">
+      <path
+         d="m 376.57031,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5198-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5200-2">
+      <path
+         d="m 376.57031,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5202-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5204-8">
+      <path
+         d="m 376.57031,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5206-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5208-7">
+      <path
+         d="m 376.57031,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5210-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5320-2">
+      <path
+         d="m 568.88672,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path5322-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5324-9">
+      <path
+         d="m 568.88672,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5326-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5328-2">
+      <path
+         d="m 568.88672,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5330-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5332-3">
+      <path
+         d="m 568.88672,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5334-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5336-4">
+      <path
+         d="m 568.88672,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5338-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5340-1">
+      <path
+         d="m 568.88672,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5342-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5344-1">
+      <path
+         d="m 568.88672,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path5346-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5348-0">
+      <path
+         d="m 568.88672,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5350-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5352-9">
+      <path
+         d="m 568.88672,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path5354-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5356-5">
+      <path
+         d="m 568.88672,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5358-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5360-4">
+      <path
+         d="m 568.88672,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path5362-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5472-1">
+      <path
+         d="m 552.90137,326.68359 15.4414,0 0,159.62207 -15.4414,0 0,-159.62207 z"
+         id="path5474-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5476-0">
+      <path
+         d="m 552.90137,326.68359 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path5478-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5480-2">
+      <path
+         d="m 552.90137,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5482-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5484-6">
+      <path
+         d="m 552.90137,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5486-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5488-3">
+      <path
+         d="m 552.90137,374.74414 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path5490-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5492-4">
+      <path
+         d="m 552.90137,390.76367 15.4414,0 0,15.44092 -15.4414,0 0,-15.44092 z"
+         id="path5494-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5496-1">
+      <path
+         d="m 552.90137,406.78271 15.4414,0 0,15.44239 -15.4414,0 0,-15.44239 z"
+         id="path5498-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5500-2">
+      <path
+         d="m 552.90137,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path5502-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5504-8">
+      <path
+         d="m 552.90137,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path5506-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5508-7">
+      <path
+         d="m 552.90137,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5510-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5512-4">
+      <path
+         d="m 552.90137,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5514-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5624-0">
+      <path
+         d="m 408.64648,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z"
+         id="path5626-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5628-7">
+      <path
+         d="m 408.64648,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path5630-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5632-3">
+      <path
+         d="m 408.64648,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path5634-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5636-2">
+      <path
+         d="m 408.64648,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path5638-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5640-8">
+      <path
+         d="m 408.64648,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path5642-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5644-2">
+      <path
+         d="m 408.64648,390.76367 15.44336,0 0,15.44092 -15.44336,0 0,-15.44092 z"
+         id="path5646-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5648-6">
+      <path
+         d="m 408.64648,406.78271 15.44336,0 0,15.44239 -15.44336,0 0,-15.44239 z"
+         id="path5650-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5652-4">
+      <path
+         d="m 408.64648,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path5654-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5656-2">
+      <path
+         d="m 408.64648,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path5658-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5660-8">
+      <path
+         d="m 408.64648,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path5662-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5664-8">
+      <path
+         d="m 408.64648,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path5666-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5776-9">
+      <path
+         d="m 72.09766,326.68164 15.4414,0 0,159.62402 -15.4414,0 0,-159.62402 z"
+         id="path5778-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5780-1">
+      <path
+         d="m 72.09766,326.68164 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path5782-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5784-9">
+      <path
+         d="m 72.09766,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5786-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5788-3">
+      <path
+         d="m 72.09766,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5790-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5792-9">
+      <path
+         d="m 72.09766,374.74219 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5794-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5796-6">
+      <path
+         d="m 72.09766,390.76367 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path5798-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5800-9">
+      <path
+         d="m 72.09766,406.78369 15.4414,0 0,15.44092 -15.4414,0 0,-15.44092 z"
+         id="path5802-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5804-8">
+      <path
+         d="m 72.09766,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path5806-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5808-3">
+      <path
+         d="m 72.09766,438.82422 15.4414,0 0,15.44092 -15.4414,0 0,-15.44092 z"
+         id="path5810-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5812-2">
+      <path
+         d="m 72.09766,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5814-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5816-1">
+      <path
+         d="m 72.09766,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path5818-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5928-7">
+      <path
+         d="m 88.02344,326.68262 15.44238,0 0,159.62304 -15.44238,0 0,-159.62304 z"
+         id="path5930-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5932-2">
+      <path
+         d="m 88.02344,326.68262 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z"
+         id="path5934-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5936-9">
+      <path
+         d="m 88.02344,342.70313 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z"
+         id="path5938-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5940-7">
+      <path
+         d="m 88.02344,358.72266 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z"
+         id="path5942-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5944-2">
+      <path
+         d="m 88.02344,374.74316 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z"
+         id="path5946-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5948-7">
+      <path
+         d="m 88.02344,390.76367 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z"
+         id="path5950-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5952-1">
+      <path
+         d="m 88.02344,406.7832 15.44238,0 0,15.44239 -15.44238,0 0,-15.44239 z"
+         id="path5954-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5956-6">
+      <path
+         d="m 88.02344,422.80371 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z"
+         id="path5958-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5960-4">
+      <path
+         d="m 88.02344,438.82324 15.44238,0 0,15.44141 -15.44238,0 0,-15.44141 z"
+         id="path5962-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5964-4">
+      <path
+         d="m 88.02344,454.84424 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z"
+         id="path5966-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5968-0">
+      <path
+         d="m 88.02344,470.86426 15.44238,0 0,15.4414 -15.44238,0 0,-15.4414 z"
+         id="path5970-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6080-1">
+      <path
+         d="m 104.01172,326.68262 15.44189,0 0,159.62304 -15.44189,0 0,-159.62304 z"
+         id="path6082-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6084-5">
+      <path
+         d="m 104.01172,326.68262 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z"
+         id="path6086-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6088-7">
+      <path
+         d="m 104.01172,342.70313 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z"
+         id="path6090-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6092-6">
+      <path
+         d="m 104.01172,358.72266 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z"
+         id="path6094-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6096-9">
+      <path
+         d="m 104.01172,374.74316 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z"
+         id="path6098-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6100-2">
+      <path
+         d="m 104.01172,390.76367 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z"
+         id="path6102-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6104-1">
+      <path
+         d="m 104.01172,406.7832 15.44189,0 0,15.4419 -15.44189,0 0,-15.4419 z"
+         id="path6106-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6108-6">
+      <path
+         d="m 104.01172,422.80371 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z"
+         id="path6110-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6112-2">
+      <path
+         d="m 104.01172,438.82373 15.44189,0 0,15.44141 -15.44189,0 0,-15.44141 z"
+         id="path6114-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6116-8">
+      <path
+         d="m 104.01172,454.84424 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z"
+         id="path6118-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6120-9">
+      <path
+         d="m 104.01172,470.86426 15.44189,0 0,15.4414 -15.44189,0 0,-15.4414 z"
+         id="path6122-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6232-8">
+      <path
+         d="m 135.93994,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path6234-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6236-8">
+      <path
+         d="m 135.93994,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6238-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6240-1">
+      <path
+         d="m 135.93994,342.70215 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6242-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6244-2">
+      <path
+         d="m 135.93994,358.72168 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6246-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6248-6">
+      <path
+         d="m 135.93994,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6250-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6252-4">
+      <path
+         d="m 135.93994,390.7627 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6254-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6256-4">
+      <path
+         d="m 135.93994,406.78223 15.44141,0 0,15.44287 -15.44141,0 0,-15.44287 z"
+         id="path6258-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6260-3">
+      <path
+         d="m 135.93994,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6262-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6264-2">
+      <path
+         d="m 135.93994,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6266-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6268-5">
+      <path
+         d="m 135.93994,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6270-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6272-0">
+      <path
+         d="m 135.93994,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6274-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6384-4">
+      <path
+         d="m 119.99805,326.68164 15.44091,0 0,159.62402 -15.44091,0 0,-159.62402 z"
+         id="path6386-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6388-3">
+      <path
+         d="m 119.99805,326.68164 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z"
+         id="path6390-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6392-4">
+      <path
+         d="m 119.99805,342.70117 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z"
+         id="path6394-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6396-9">
+      <path
+         d="m 119.99805,358.7207 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z"
+         id="path6398-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6400-2">
+      <path
+         d="m 119.99805,374.74219 15.44091,0 0,15.4414 -15.44091,0 0,-15.4414 z"
+         id="path6402-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6404-6">
+      <path
+         d="m 119.99805,390.76172 15.44091,0 0,15.44189 -15.44091,0 0,-15.44189 z"
+         id="path6406-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6408-3">
+      <path
+         d="m 119.99805,406.78174 15.44091,0 0,15.44336 -15.44091,0 0,-15.44336 z"
+         id="path6410-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6412-0">
+      <path
+         d="m 119.99805,422.80371 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z"
+         id="path6414-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6416-3">
+      <path
+         d="m 119.99805,438.82373 15.44091,0 0,15.44141 -15.44091,0 0,-15.44141 z"
+         id="path6418-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6420-2">
+      <path
+         d="m 119.99805,454.84424 15.44091,0 0,15.4414 -15.44091,0 0,-15.4414 z"
+         id="path6422-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6424-1">
+      <path
+         d="m 119.99805,470.86426 15.44091,0 0,15.4414 -15.44091,0 0,-15.4414 z"
+         id="path6426-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6536-6">
+      <path
+         d="m 232.45801,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path6538-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6540-6">
+      <path
+         d="m 232.45801,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path6542-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6544-8">
+      <path
+         d="m 232.45801,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path6546-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6548-9">
+      <path
+         d="m 232.45801,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path6550-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6552-5">
+      <path
+         d="m 232.45801,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path6554-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6556-8">
+      <path
+         d="m 232.45801,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path6558-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6560-8">
+      <path
+         d="m 232.45801,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path6562-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6564-3">
+      <path
+         d="m 232.45801,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path6566-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6568-3">
+      <path
+         d="m 232.45801,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path6570-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6572-0">
+      <path
+         d="m 232.45801,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path6574-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6576-5">
+      <path
+         d="m 232.45801,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path6578-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6688-3">
+      <path
+         d="m 216.34521,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path6690-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6692-7">
+      <path
+         d="m 216.34521,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6694-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6696-3">
+      <path
+         d="m 216.34521,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6698-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6700-9">
+      <path
+         d="m 216.34521,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6702-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6704-9">
+      <path
+         d="m 216.34521,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6706-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6708-6">
+      <path
+         d="m 216.34521,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6710-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6712-3">
+      <path
+         d="m 216.34521,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path6714-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6716-1">
+      <path
+         d="m 216.34521,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6718-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6720-3">
+      <path
+         d="m 216.34521,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6722-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6724-3">
+      <path
+         d="m 216.34521,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6726-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6728-6">
+      <path
+         d="m 216.34521,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6730-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6840-2">
+      <path
+         d="m 184.04492,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path6842-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6844-3">
+      <path
+         d="m 184.04492,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6846-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6848-4">
+      <path
+         d="m 184.04492,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6850-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6852-7">
+      <path
+         d="m 184.04492,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6854-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6856-8">
+      <path
+         d="m 184.04492,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6858-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6860-8">
+      <path
+         d="m 184.04492,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6862-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6864-5">
+      <path
+         d="m 184.04492,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path6866-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6868-3">
+      <path
+         d="m 184.04492,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6870-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6872-1">
+      <path
+         d="m 184.04492,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path6874-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6876-0">
+      <path
+         d="m 184.04492,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6878-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6880-4">
+      <path
+         d="m 184.04492,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path6882-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6992-1">
+      <path
+         d="m 200.18604,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path6994-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6996-3">
+      <path
+         d="m 200.18604,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path6998-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7000-1">
+      <path
+         d="m 200.18604,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7002-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7004-5">
+      <path
+         d="m 200.18604,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7006-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7008-1">
+      <path
+         d="m 200.18604,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7010-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7012-6">
+      <path
+         d="m 200.18604,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7014-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7016-6">
+      <path
+         d="m 200.18604,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path7018-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7020-6">
+      <path
+         d="m 200.18604,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7022-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7024-3">
+      <path
+         d="m 200.18604,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7026-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7028-2">
+      <path
+         d="m 200.18604,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7030-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7032-7">
+      <path
+         d="m 200.18604,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7034-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7144-4">
+      <path
+         d="m 167.99707,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path7146-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7148-1">
+      <path
+         d="m 167.99707,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7150-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7152-6">
+      <path
+         d="m 167.99707,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7154-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7156-3">
+      <path
+         d="m 167.99707,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7158-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7160-7">
+      <path
+         d="m 167.99707,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7162-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7164-6">
+      <path
+         d="m 167.99707,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7166-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7168-4">
+      <path
+         d="m 167.99707,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path7170-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7172-4">
+      <path
+         d="m 167.99707,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7174-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7176-4">
+      <path
+         d="m 167.99707,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7178-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7180-5">
+      <path
+         d="m 167.99707,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7182-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7184-1">
+      <path
+         d="m 167.99707,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7186-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7296-2">
+      <path
+         d="m 248.59229,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path7298-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7300-8">
+      <path
+         d="m 248.59229,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7302-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7304-8">
+      <path
+         d="m 248.59229,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7306-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7308-6">
+      <path
+         d="m 248.59229,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7310-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7312-3">
+      <path
+         d="m 248.59229,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7314-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7316-5">
+      <path
+         d="m 248.59229,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7318-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7320-9">
+      <path
+         d="m 248.59229,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path7322-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7324-2">
+      <path
+         d="m 248.59229,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7326-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7328-1">
+      <path
+         d="m 248.59229,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path7330-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7332-6">
+      <path
+         d="m 248.59229,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7334-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7336-7">
+      <path
+         d="m 248.59229,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path7338-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7448-9">
+      <path
+         d="m 344.50879,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path7450-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7452-1">
+      <path
+         d="m 344.50879,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7454-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7456-3">
+      <path
+         d="m 344.50879,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7458-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7460-8">
+      <path
+         d="m 344.50879,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7462-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7464-6">
+      <path
+         d="m 344.50879,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7466-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7468-5">
+      <path
+         d="m 344.50879,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7470-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7472-9">
+      <path
+         d="m 344.50879,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path7474-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7476-2">
+      <path
+         d="m 344.50879,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7478-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7480-7">
+      <path
+         d="m 344.50879,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7482-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7484-9">
+      <path
+         d="m 344.50879,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7486-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7488-4">
+      <path
+         d="m 344.50879,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7490-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7600-1">
+      <path
+         d="m 312.58691,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path7602-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7604-4">
+      <path
+         d="m 312.58691,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7606-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7608-2">
+      <path
+         d="m 312.58691,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7610-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7612-3">
+      <path
+         d="m 312.58691,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7614-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7616-3">
+      <path
+         d="m 312.58691,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7618-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7620-2">
+      <path
+         d="m 312.58691,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7622-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7624-2">
+      <path
+         d="m 312.58691,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path7626-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7628-3">
+      <path
+         d="m 312.58691,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7630-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7632-2">
+      <path
+         d="m 312.58691,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7634-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7636-4">
+      <path
+         d="m 312.58691,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7638-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7640-4">
+      <path
+         d="m 312.58691,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7642-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7752-0">
+      <path
+         d="m 280.55371,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path7754-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7756-8">
+      <path
+         d="m 280.55371,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7758-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7760-3">
+      <path
+         d="m 280.55371,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7762-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7764-2">
+      <path
+         d="m 280.55371,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7766-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7768-9">
+      <path
+         d="m 280.55371,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7770-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7772-6">
+      <path
+         d="m 280.55371,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7774-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7776-3">
+      <path
+         d="m 280.55371,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path7778-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7780-8">
+      <path
+         d="m 280.55371,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7782-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7784-8">
+      <path
+         d="m 280.55371,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7786-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7788-4">
+      <path
+         d="m 280.55371,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7790-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7792-0">
+      <path
+         d="m 280.55371,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7794-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7904-4">
+      <path
+         d="m 296.45996,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path7906-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7908-3">
+      <path
+         d="m 296.45996,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7910-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7912-4">
+      <path
+         d="m 296.45996,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7914-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7916-7">
+      <path
+         d="m 296.45996,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7918-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7920-3">
+      <path
+         d="m 296.45996,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7922-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7924-0">
+      <path
+         d="m 296.45996,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7926-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7928-7">
+      <path
+         d="m 296.45996,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path7930-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7932-7">
+      <path
+         d="m 296.45996,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7934-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7936-7">
+      <path
+         d="m 296.45996,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path7938-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7940-3">
+      <path
+         d="m 296.45996,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7942-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7944-4">
+      <path
+         d="m 296.45996,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path7946-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8056-7">
+      <path
+         d="m 264.5459,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path8058-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8060-2">
+      <path
+         d="m 264.5459,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8062-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8064-8">
+      <path
+         d="m 264.5459,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8066-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8068-4">
+      <path
+         d="m 264.5459,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8070-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8072-3">
+      <path
+         d="m 264.5459,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8074-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8076-1">
+      <path
+         d="m 264.5459,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8078-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8080-4">
+      <path
+         d="m 264.5459,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path8082-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8084-6">
+      <path
+         d="m 264.5459,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8086-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8088-9">
+      <path
+         d="m 264.5459,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8090-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8092-2">
+      <path
+         d="m 264.5459,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8094-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8096-6">
+      <path
+         d="m 264.5459,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8098-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8208-1">
+      <path
+         d="m 328.63379,326.68262 15.44141,0 0,159.62304 -15.44141,0 0,-159.62304 z"
+         id="path8210-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8212-6">
+      <path
+         d="m 328.63379,326.68262 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8214-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8216-1">
+      <path
+         d="m 328.63379,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8218-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8220-1">
+      <path
+         d="m 328.63379,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8222-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8224-1">
+      <path
+         d="m 328.63379,374.74316 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8226-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8228-5">
+      <path
+         d="m 328.63379,390.76367 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8230-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8232-3">
+      <path
+         d="m 328.63379,406.7832 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path8234-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8236-9">
+      <path
+         d="m 328.63379,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8238-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8240-3">
+      <path
+         d="m 328.63379,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8242-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8244-3">
+      <path
+         d="m 328.63379,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8246-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8248-9">
+      <path
+         d="m 328.63379,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8250-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8360-9">
+      <path
+         d="m 392.56836,326.68164 15.44141,0 0,159.62402 -15.44141,0 0,-159.62402 z"
+         id="path8362-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8364-6">
+      <path
+         d="m 392.56836,326.68164 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8366-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8368-4">
+      <path
+         d="m 392.56836,342.70313 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8370-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8372-4">
+      <path
+         d="m 392.56836,358.72266 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8374-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8376-2">
+      <path
+         d="m 392.56836,374.74219 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8378-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8380-8">
+      <path
+         d="m 392.56836,390.76367 15.44141,0 0,15.4419 -15.44141,0 0,-15.4419 z"
+         id="path8382-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8384-7">
+      <path
+         d="m 392.56836,406.78369 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8386-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8388-9">
+      <path
+         d="m 392.56836,422.80371 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8390-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8392-5">
+      <path
+         d="m 392.56836,438.82373 15.44141,0 0,15.44141 -15.44141,0 0,-15.44141 z"
+         id="path8394-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8396-7">
+      <path
+         d="m 392.56836,454.84424 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8398-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8400-4">
+      <path
+         d="m 392.56836,470.86426 15.44141,0 0,15.4414 -15.44141,0 0,-15.4414 z"
+         id="path8402-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8512-5">
+      <path
+         d="m 151.93799,326.68262 15.4414,0 0,159.62304 -15.4414,0 0,-159.62304 z"
+         id="path8514-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8516-6">
+      <path
+         d="m 151.93799,326.68262 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8518-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8520-1">
+      <path
+         d="m 151.93799,342.70313 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8522-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8524-3">
+      <path
+         d="m 151.93799,358.72266 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8526-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8528-3">
+      <path
+         d="m 151.93799,374.74316 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8530-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8532-0">
+      <path
+         d="m 151.93799,390.76367 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8534-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8536-8">
+      <path
+         d="m 151.93799,406.7832 15.4414,0 0,15.4419 -15.4414,0 0,-15.4419 z"
+         id="path8538-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8540-4">
+      <path
+         d="m 151.93799,422.80371 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8542-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8544-0">
+      <path
+         d="m 151.93799,438.82373 15.4414,0 0,15.44141 -15.4414,0 0,-15.44141 z"
+         id="path8546-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8548-5">
+      <path
+         d="m 151.93799,454.84424 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8550-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8552-6">
+      <path
+         d="m 151.93799,470.86426 15.4414,0 0,15.4414 -15.4414,0 0,-15.4414 z"
+         id="path8554-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8664-2">
+      <path
+         d="m 424.74902,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z"
+         id="path8666-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8668-1">
+      <path
+         d="m 424.74902,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8670-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8672-4">
+      <path
+         d="m 424.74902,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8674-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8676-6">
+      <path
+         d="m 424.74902,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8678-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8680-6">
+      <path
+         d="m 424.74902,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8682-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8684-3">
+      <path
+         d="m 424.74902,390.76367 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8686-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8688-0">
+      <path
+         d="m 424.74902,406.7832 15.44336,0 0,15.4419 -15.44336,0 0,-15.4419 z"
+         id="path8690-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8692-1">
+      <path
+         d="m 424.74902,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8694-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8696-0">
+      <path
+         d="m 424.74902,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8698-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8700-7">
+      <path
+         d="m 424.74902,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8702-3"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8704-2">
+      <path
+         d="m 424.74902,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8706-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8816-7">
+      <path
+         d="m 440.83203,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z"
+         id="path8818-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8820-9">
+      <path
+         d="m 440.83203,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8822-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8824-9">
+      <path
+         d="m 440.83203,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8826-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8828-9">
+      <path
+         d="m 440.83203,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8830-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8832-0">
+      <path
+         d="m 440.83203,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8834-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8836-9">
+      <path
+         d="m 440.83203,390.76367 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8838-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8840-8">
+      <path
+         d="m 440.83203,406.7832 15.44336,0 0,15.4419 -15.44336,0 0,-15.4419 z"
+         id="path8842-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8844-8">
+      <path
+         d="m 440.83203,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8846-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8848-4">
+      <path
+         d="m 440.83203,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8850-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8852-0">
+      <path
+         d="m 440.83203,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8854-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8856-7">
+      <path
+         d="m 440.83203,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8858-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8968-1">
+      <path
+         d="m 456.79199,326.68359 15.44336,0 0,159.62207 -15.44336,0 0,-159.62207 z"
+         id="path8970-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8972-2">
+      <path
+         d="m 456.79199,326.68359 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8974-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8976-1">
+      <path
+         d="m 456.79199,342.70313 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8978-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8980-2">
+      <path
+         d="m 456.79199,358.72266 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path8982-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8984-6">
+      <path
+         d="m 456.79199,374.74414 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8986-5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8988-4">
+      <path
+         d="m 456.79199,390.76367 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8990-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8992-4">
+      <path
+         d="m 456.79199,406.7832 15.44336,0 0,15.4419 -15.44336,0 0,-15.4419 z"
+         id="path8994-7"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8996-1">
+      <path
+         d="m 456.79199,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path8998-0"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9000-7">
+      <path
+         d="m 456.79199,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path9002-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9004-5">
+      <path
+         d="m 456.79199,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path9006-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9008-3">
+      <path
+         d="m 456.79199,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path9010-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9120-4">
+      <path
+         d="m 472.84082,326.68457 15.44336,0 0,159.62109 -15.44336,0 0,-159.62109 z"
+         id="path9122-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9124-9">
+      <path
+         d="m 472.84082,326.68457 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path9126-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9128-7">
+      <path
+         d="m 472.84082,342.7041 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path9130-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9132-2">
+      <path
+         d="m 472.84082,358.72363 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path9134-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9136-8">
+      <path
+         d="m 472.84082,374.74512 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path9138-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9140-3">
+      <path
+         d="m 472.84082,390.76465 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path9142-9"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9144-7">
+      <path
+         d="m 472.84082,406.78418 15.44336,0 0,15.44092 -15.44336,0 0,-15.44092 z"
+         id="path9146-6"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9148-0">
+      <path
+         d="m 472.84082,422.80371 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path9150-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9152-4">
+      <path
+         d="m 472.84082,438.82373 15.44336,0 0,15.44141 -15.44336,0 0,-15.44141 z"
+         id="path9154-2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9156-1">
+      <path
+         d="m 472.84082,454.84424 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path9158-8"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9160-6">
+      <path
+         d="m 472.84082,470.86426 15.44336,0 0,15.4414 -15.44336,0 0,-15.4414 z"
+         id="path9162-1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4794-9">
+      <stop
+         id="stop4796-8"
+         offset="0"
+         style="stop-color:#3a9ed6;stop-opacity:1" />
+      <stop
+         style="stop-color:#2692d1;stop-opacity:1"
+         offset="0.38869566"
+         id="stop4802-2" />
+      <stop
+         id="stop4798-4"
+         offset="1"
+         style="stop-color:#3a9ed6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4695-9">
+      <stop
+         id="stop4697-8"
+         offset="0"
+         style="stop-color:#1385cc;stop-opacity:1" />
+      <stop
+         style="stop-color:#6eb6e0;stop-opacity:1"
+         offset="0.17353664"
+         id="stop4719-3" />
+      <stop
+         style="stop-color:#e3eefa;stop-opacity:1"
+         offset="0.34707329"
+         id="stop4713-8" />
+      <stop
+         style="stop-color:#c1ddf0;stop-opacity:1"
+         offset="0.5"
+         id="stop4711-6" />
+      <stop
+         id="stop4715-9"
+         offset="0.63836575"
+         style="stop-color:#53aadb;stop-opacity:1" />
+      <stop
+         style="stop-color:#2692d1;stop-opacity:1"
+         offset="0.81918287"
+         id="stop4717-8" />
+      <stop
+         id="stop4699-6"
+         offset="1"
+         style="stop-color:#1385cc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#f61212;stop-opacity:1" />
+      <stop
+         style="stop-color:#d31919;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#df2020;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4293"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.83730975,0,0,0.83704396,-316.98085,652.42707)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.675681"
+     inkscape:cx="13.120152"
+     inkscape:cy="8.4842089"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="856"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-nodes="false"
+     inkscape:snap-page="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-bbox="true"
+     inkscape:object-paths="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="false"
+     inkscape:bbox-paths="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Model Object"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline;opacity:1"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="18"
+       id="image5764"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAADO0lEQVR42m2TX0hTcRTHv/dubcjU
+RDcls2msSa2HFVsbEZk1kYJu2dJsr6kM/z1U9FA9lNJLBEagUlREWIH6IrMFbhNRBEMRTMXltLRr
+NvyTzrS5dN51rqFodeA83N/9nc/3nPM7h8FfptFoZMnJyed0Ol2WWq3eyzAMeJ4f83q9Hr/f7/D5
+fCtb7zNbPywWC0dWrZfL1UxPDzA+vn7OpqoRMR5BXzjMO53OMpfL1fwP4GJu7rVCq/WBUFPDKilQ
+FRcHCakLS0vAzp2Y9vsR0GjAlJUJzx2OG/X19VWbgMzMTO56QUET7txl90QrMB0TAyEUQmRxEfsJ
+wCgUEORyLAoCvi0vAxUVQlVdXY7b7W5m0tLSZHa7feSA06lO9PkQGxuLT1evwnD+PL729iKppAQS
+lQqrBAuGw/gZDGKeMhm4cIF/+uyZljGbzbm38vMbZZWV2J2QACmpTd68iaMch7GODkQXFgKU0TKp
+C5EI1ggwRVkIt2/jXlNTHmOz2R7bduywx7x9CyXVLV6ae/gQR7Ky8Lm1FVFFRQhLpViTSBChf5G1
+NQRWVrB8+jResewTpry8vOXk4GC2qr8fcTIZBFL68eIFDmdkYMzjQWJBAcLUzF/kIfIwy2KJSpnX
+6eAxGFxMcXFxi8XrzU4aGICKVCSkMP3mDfTHjmGcAGlXrkCgRq+S/6Rg0edJ5DsBXHq9i7FarY/z
+pVJ7stuNVALI6Ofo69c4dPw4FmZm0Nfejggpg1x5/z52TU1hku7MWiyoA54wBoMhtyg7u1FfWwst
+AaRU54eXL2E4dWrbhIr1fzlzBklDQ/hEgBF6nerW1jwmJSVFdpbjRi719qoPDQ9DTim2lZZCYzb/
+iVyl5MW3p2dkHz1CIg3UsFaLVyYT73z3Trs+SCaTics5caLpckMDm7iwAJYg/zOxwQGakwabTWjs
+6Mjp6upq3hxlmsZrmXr9A66zk9WOjkJCEHGRNtIXgyf27YMjI0No6eu70dbWVrVtF0QzGo1cenp6
+tTEqSn2Q55EQCKxD5mkXPqam4n0oxNM2lnV3d/+7TBsm9kSpVJ6Lj4/PUigUe8WzYDA4Njc355md
+nXVMTExsW+ffsOdeUfdtBg0AAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53754,913.06908)"
+       style="display:inline"
+       id="g11331-3-1-1-2">
+      <g
+         id="g13408-8-9"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="translate(15.078854,7.0344292)" />
+    <ellipse
+       cy="1044.3622"
+       cx="7.9999967"
+       style="font-style:normal;font-weight:normal;font-size:medium;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4293);fill-opacity:1;stroke:#5c5c5c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path10796-2-6-2"
+       rx="7.5011916"
+       ry="7.4988108" />
+    <g
+       transform="matrix(1.1817785,0,0,1.3206695,17.499057,-248.29019)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       transform="translate(-0.01998305,0.97979109)"
+       id="text4259"
+       style="font-style:normal;font-weight:normal;font-size:11.25px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       id="text52463"
+       style="font-style:normal;font-weight:normal;font-size:11.25px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="translate(-2.4816833,1.8877826)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#f4f4f4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 8.4816799,1038.4744 0,7 5.0000001,0"
+         id="path5769"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Decorators"
+     style="display:none;opacity:1">
+    <g
+       transform="matrix(0.87968602,0,0,0.71944079,5.9144653,-747.05937)"
+       style="display:inline"
+       id="layer1-9"
+       inkscape:label="Layer 1">
+      <g
+         transform="matrix(0.60714811,0,0,0.60714811,16.028618,409.50264)"
+         id="g8451">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient8465);stroke-width:2.47056675;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m -10.059546,1045.0618 0,-2.9375 c 0,-2.7586 -1.253608,-5 -4.012192,-5 -2.758584,0 -4.162918,2.2414 -4.162918,5 l 0,2.9375"
+           id="rect4838-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csssc" />
+        <rect
+           style="display:inline;fill:url(#linearGradient8469);fill-opacity:1;stroke:none"
+           id="rect4838"
+           width="11.998713"
+           height="7.9382153"
+           x="-19.876328"
+           y="1042.9824"
+           rx="1.1048543"
+           ry="1.1048543" />
+        <rect
+           style="display:inline;fill:none;stroke:url(#linearGradient8471);stroke-width:0.87896538;stroke-opacity:1;filter:url(#filter5152)"
+           id="rect4838-4"
+           width="10.729074"
+           height="6.8243604"
+           x="-19.241508"
+           y="1043.4849"
+           rx="0.62204111"
+           ry="0.60104567" />
+        <rect
+           style="display:inline;opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none"
+           id="rect4894"
+           width="11.031251"
+           height="1"
+           x="-19.392597"
+           y="1045.48" />
+        <rect
+           style="display:inline;opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none"
+           id="rect4894-7"
+           width="11.031251"
+           height="1"
+           x="-19.392597"
+           y="1047.48" />
+        <rect
+           style="display:inline;opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none"
+           id="rect4894-7-4"
+           width="11.031251"
+           height="1"
+           x="-19.392597"
+           y="1049.48" />
+        <circle
+           r="1.016466"
+           cy="12.531184"
+           cx="9.4796505"
+           transform="translate(-23.389764,1033.4176)"
+           style="display:inline;fill:#785b13;fill-opacity:1;stroke:none"
+           id="path4066" />
+        <rect
+           style="display:inline;fill:#785b13;fill-opacity:1;stroke:none"
+           id="rect4836"
+           width="1.0606602"
+           height="2.8063302"
+           x="-14.440443"
+           y="1046.5895" />
+        <rect
+           style="display:inline;fill:none;stroke:url(#linearGradient8473);stroke-width:1.64704454;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4838-12"
+           width="11.509747"
+           height="8.2291298"
+           x="-19.876328"
+           y="1042.6913"
+           rx="1.1048543"
+           ry="1.1048543" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.86783246,0,0,0.86783246,5.6599727,-893.87978)"
+       style="display:inline"
+       id="layer1-7"
+       inkscape:label="Layer 1">
+      <g
+         id="g11331-3-1-1"
+         style="display:inline"
+         transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
+        <g
+           style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+           id="g13408-8" />
+      </g>
+      <g
+         transform="translate(-13.081475,-10.429825)"
+         id="g4953"
+         style="display:inline">
+        <g
+           transform="matrix(0.87603817,0,0,0.87603817,2.3796281,130.92509)"
+           id="g3773" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/methpub_obj.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/methpub_obj.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="methpub_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#75ba7a;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       id="linearGradient9837"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="8.1831043"
+     inkscape:cy="7.2601498"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6438"
+     showgrid="true"
+     inkscape:window-width="1287"
+     inkscape:window-height="862"
+     inkscape:window-x="623"
+     inkscape:window-y="113"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3960" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+         id="g6438">
+        <path
+           sodipodi:type="arc"
+           style="fill:url(#linearGradient9837);fill-opacity:1;stroke:#058149;stroke-width:3.17967892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="path10796-2-6-2"
+           sodipodi:cx="388.125"
+           sodipodi:cy="468.23718"
+           sodipodi:rx="10.625"
+           sodipodi:ry="10.625"
+           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+           transform="matrix(0.32984735,0,0,0.32984735,-136.12701,882.92787)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/refresh.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/refresh.svg
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="refresh.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7608-3"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345"
+       gradientTransform="translate(-0.35355341,-0.48613593)" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient7610-5"
+       gradientUnits="userSpaceOnUse"
+       x1="23.107393"
+       y1="1042.9795"
+       x2="23.107393"
+       y2="1046.6238"
+       gradientTransform="translate(-0.35355341,-0.48613593)" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3"
+       id="linearGradient7608-9-7"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-0-5"
+       id="linearGradient7610-7-6"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="12.871772"
+     inkscape:cy="11.737298"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7604"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="150"
+     inkscape:window-y="150"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4074" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-12.551145,-2.6983344e-7)">
+      <path
+         sodipodi:nodetypes="ccssscscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 23.231602,1038.8387 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 1.546796,1.4584 1.546796,0.088 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.694788,0.3552 2.039845,0.6884 0.345482,0.3336 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.174793,-1.2439 -0.71875,-1.9687 -0.293544,-0.3911 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-3);fill-opacity:1;stroke:url(#linearGradient7610-5);stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 22.715806,1038.5073 0,-0.5966 c 0,0 0.110485,-0.3756 -0.220971,-0.2431 -0.331456,0.1326 -0.972272,0.6629 -1.038563,0.7734 -0.06629,0.1105 -0.751301,0.5967 -0.596622,0.8176 0.15468,0.221 1.458408,0.066 1.458408,0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       style="display:inline"
+       id="g7604-6"
+       transform="matrix(-1,0,0,-1,29.009738,2088.8723)">
+      <path
+         sodipodi:nodetypes="ccssscsscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-7"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-9-7);fill-opacity:1;stroke:url(#linearGradient7610-7-6);stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-2"
+         d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/icons/valueincontext.svg
+++ b/ui/org.eclipse.pde.spy.context/icons/valueincontext.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="valueincontext.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#857cff;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#746cff;stop-opacity:1" />
+      <stop
+         style="stop-color:#a297ff;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       id="linearGradient9837"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="462.11539" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="19.09375"
+     inkscape:cx="12.231759"
+     inkscape:cy="7.2601498"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6438"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="856"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3960" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+         id="g6438">
+        <path
+           sodipodi:type="arc"
+           style="fill:url(#linearGradient9837);fill-opacity:1;stroke:#464fff;stroke-width:3.17967892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="path10796-2-6-2"
+           sodipodi:cx="388.125"
+           sodipodi:cy="468.23718"
+           sodipodi:rx="10.625"
+           sodipodi:ry="10.625"
+           d="m 398.75,468.23718 a 10.625,10.625 0 0 1 -10.625,10.625 10.625,10.625 0 0 1 -10.625,-10.625 10.625,10.625 0 0 1 10.625,-10.625 10.625,10.625 0 0 1 10.625,10.625 z"
+           transform="matrix(0.32984735,0,0,0.32984735,-136.12701,882.92787)" />
+        <image
+           y="1028.3481"
+           x="0.87041003"
+           id="image4230"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAMJJREFU
+OI3tkL0OQUEQhT8isTck9yokfqJ0Owkab6D1Eko6j6CkovQSSl5Bp9C7N0qXws92q5gGu8IDOMnJ
+7JyZOZkd+CP1qbCYGbOPIEmg1YT+MOXsdYqjgTGFAGpVyeMDnM4wmdsm6XdhOjYmnwOl4HYXKgWe
+J7WvBquNRK3hmAi1fq09I/MuFH24XF0fg0pga9YG7VBiPidre568ARp128B5xG7PmE4IKiv56Qzb
+GNbLH44I0hj4sIuE5ZJ7+A/BAyjYNrwfTTLxAAAAAElFTkSuQmCC
+"
+           style="image-rendering:optimizeSpeed"
+           preserveAspectRatio="none"
+           height="16"
+           width="16" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.context/plugin.xml
+++ b/ui/org.eclipse.pde.spy.context/plugin.xml
@@ -4,7 +4,7 @@
          point="org.eclipse.pde.spy.core.spyPart">
       <spyPart
             description="%description"
-            icon="$nl$/icons/annotation_obj.png"
+            icon="$nl$/icons/annotation_obj.svg"
             name="%name"
             part="org.eclipse.pde.spy.context.ContextSpyPart"
             shortcut="M2+M3+F10">

--- a/ui/org.eclipse.pde.spy.context/src/org/eclipse/pde/internal/spy/context/ContextDataProvider.java
+++ b/ui/org.eclipse.pde.spy.context/src/org/eclipse/pde/internal/spy/context/ContextDataProvider.java
@@ -62,13 +62,13 @@ public class ContextDataProvider extends ColumnLabelProvider implements ITreeCon
 	private static final String INJECTED_IN_METHOD = Messages.ContextDataProvider_6;
 
 	// Image keys constants
-	private static final String PUBLIC_METHOD_IMG_KEY = "icons/methpub_obj.png"; //$NON-NLS-1$
-	private static final String PUBLIC_FIELD_IMG_KEY = "icons/field_public_obj.png"; //$NON-NLS-1$
-	private static final String VALUE_IN_CONTEXT_IMG_KEY = "icons/valueincontext.png"; //$NON-NLS-1$
-	private static final String INHERITED_VARIABLE_IMG_KEY = "icons/inher_co.png"; //$NON-NLS-1$
-	private static final String LOCAL_VARIABLE_IMG_KEY = "icons/letter-l-icon.png"; //$NON-NLS-1$
-	private static final String CONTEXT_FUNCTION_IMG_KEY = "icons/contextfunction.png"; //$NON-NLS-1$
-	private static final String INJECT_IMG_KEY = "icons/annotation_obj.png"; //$NON-NLS-1$
+	private static final String PUBLIC_METHOD_IMG_KEY = "icons/methpub_obj.svg"; //$NON-NLS-1$
+	private static final String PUBLIC_FIELD_IMG_KEY = "icons/field_public_obj.svg"; //$NON-NLS-1$
+	private static final String VALUE_IN_CONTEXT_IMG_KEY = "icons/valueincontext.svg"; //$NON-NLS-1$
+	private static final String INHERITED_VARIABLE_IMG_KEY = "icons/inher_co.svg"; //$NON-NLS-1$
+	private static final String LOCAL_VARIABLE_IMG_KEY = "icons/letter-l-icon.svg"; //$NON-NLS-1$
+	private static final String CONTEXT_FUNCTION_IMG_KEY = "icons/contextfunction.svg"; //$NON-NLS-1$
+	private static final String INJECT_IMG_KEY = "icons/annotation_obj.svg"; //$NON-NLS-1$
 
 	private ImageRegistry imgReg;
 

--- a/ui/org.eclipse.pde.spy.context/src/org/eclipse/pde/spy/context/ContextSpyPart.java
+++ b/ui/org.eclipse.pde.spy.context/src/org/eclipse/pde/spy/context/ContextSpyPart.java
@@ -54,9 +54,9 @@ import jakarta.inject.Inject;
  */
 public class ContextSpyPart {
 
-	private static final String ICON_COLLAPSEALL = "icons/collapseall.png"; //$NON-NLS-1$
-	private static final String ICON_EXPANDALL = "icons/expandall.png"; //$NON-NLS-1$
-	private static final String ICON_REFRESH = "icons/refresh.png"; //$NON-NLS-1$
+	private static final String ICON_COLLAPSEALL = "icons/collapseall.svg"; //$NON-NLS-1$
+	private static final String ICON_EXPANDALL = "icons/expandall.svg"; //$NON-NLS-1$
+	private static final String ICON_REFRESH = "icons/refresh.svg"; //$NON-NLS-1$
 
 	// The ID for this part descriptor
 	static final String CONTEXT_SPY_VIEW_DESC = "org.eclipse.e4.tools.context.spy.view"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  org.w3c.css.sac;version="1.3.0"
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/ui/org.eclipse.pde.spy.css/icons/css_scratchpad.svg
+++ b/ui/org.eclipse.pde.spy.css/icons/css_scratchpad.svg
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="open_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147"
+       inkscape:collect="always">
+      <stop
+         id="stop5149"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141"
+       inkscape:collect="always">
+      <stop
+         id="stop5143"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135"
+       inkscape:collect="always">
+      <stop
+         id="stop5137"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#b4903d;stop-opacity:1"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#7b744f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.9449709,-2.9907914)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0013691,0,0,0.98980409,-2.0191666,7.6358418)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0035898,0,0,0.96856508,-2.0502566,29.955202)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135"
+       id="linearGradient4873"
+       x1="7.0070496"
+       y1="1051.857"
+       x2="12.016466"
+       y2="1051.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812022,0,0,0.98971353,0.00612244,7.8250365)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141"
+       id="linearGradient4875"
+       x1="7.0070496"
+       y1="1049.857"
+       x2="14"
+       y2="1049.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0013691,0,0,1.0006833,-2.03023,-3.7729963)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4900"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.023379,-0.9900341)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99287847,0,0,1.0029935,-1.9581335,-4.1515444)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient5000"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0112622,-1.0460341)" />
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6204">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-1"
+       xlink:href="#linearGradient4852-7-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-9"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-1"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-0"
+       xlink:href="#linearGradient4844-4-1-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-4">
+      <stop
+         id="stop4846-8-4-2"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-2"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-4"
+       xlink:href="#linearGradient4852-7-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-5"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-9"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-8"
+       xlink:href="#linearGradient4844-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-7">
+      <stop
+         id="stop4846-8-4-5"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-3"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,-3.754382)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-1"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,-1.7543822)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-2"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,0.24561776)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-6"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,2.2456178)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-0"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,4.2456178)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="68.758621"
+     inkscape:cx="17.5"
+     inkscape:cy="8.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient5000);fill-opacity:1;stroke:none"
+       d="m 3.4860203,1037.8577 7.0096687,0 3.062057,3.0066 0,9.9546 -10.0717257,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900);fill-opacity:1;stroke:none"
+       d="m 10,1037.451 0,3.9112 3.977476,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 3.5,1037.8622 6.959749,0 3.040251,3.0156 0,9.9844 -10,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+       id="rect4001-1"
+       width="2.0223048"
+       height="0.99932742"
+       x="6.9995785"
+       y="1040.3611" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+       id="rect4001-1-7"
+       width="5"
+       height="1.0000174"
+       x="7"
+       y="1042.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4"
+       width="5"
+       height="1.0000174"
+       x="7"
+       y="1044.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0"
+       width="5"
+       height="1.0000174"
+       x="7"
+       y="1046.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4873);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-9"
+       width="5"
+       height="1"
+       x="7"
+       y="1048.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5);fill-opacity:1;stroke:none"
+       id="rect4001-1-1"
+       width="1"
+       height="1"
+       x="5"
+       y="1040.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-1);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-2"
+       width="1"
+       height="1"
+       x="5"
+       y="1042.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-2);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-7"
+       width="1"
+       height="1"
+       x="5"
+       y="1044.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-6);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-1"
+       width="1"
+       height="1"
+       x="5"
+       y="1046.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-0);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-8"
+       width="1"
+       height="1"
+       x="5"
+       y="1048.3622" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4248"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAVhJREFU
+OI2lk88rRFEUxz/3pdnMcv4BBqVoklBMo6wUZUGpsZiVDSnK3zE1/gIrSxuNnVKUJEVRIn+I9949
+51g886s318ap273ndvqc7/2erjMz/hMj/cnV6cqftI2jW5e7NLPuardqFid+6Hq73Ld2q2b99WZG
+1A/z5lAzzDJw7wyFYomx8kxO5cATvESowXn7mThJiWNPknqOGzUKxRIAo+VpLpqrtn1y43KAVCNE
+oL4+iwEOwEAUSpXDbt3rx9pwBak6FLi+/8R7JUk937EfUHOwWyMVFwBIhIixujiJy5rnQtRIpWfd
+ACARh6hx+/QVVLC3UyUJKUgkwitU5yaG9M4UiWZ1AQ8iVOHhJaygsVXFawggEaLGQmV8qIKOB0EF
+XhxqcPf4nutc31z6NdXhg1PQzMTl+anuFDq7WscHCwNEI86a9azMwLneMLMcMPeLzcL99zv/AN06
+ELrjUgfZAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.css/icons/cssspy.svg
+++ b/ui/org.eclipse.pde.spy.css/icons/cssspy.svg
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="cssspy.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4652">
+      <stop
+         style="stop-color:#98b4e2;stop-opacity:1"
+         offset="0"
+         id="stop4654" />
+      <stop
+         id="stop4660"
+         offset="0.46666783"
+         style="stop-color:#adbed3;stop-opacity:1" />
+      <stop
+         style="stop-color:#adbed3;stop-opacity:1"
+         offset="1"
+         id="stop4656" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4638">
+      <stop
+         style="stop-color:#fefefe;stop-opacity:1"
+         offset="0"
+         id="stop4640" />
+      <stop
+         id="stop4646"
+         offset="0.49489403"
+         style="stop-color:#c5d6e9;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.67223424"
+         id="stop4648" />
+      <stop
+         id="stop4650"
+         offset="0.81818181"
+         style="stop-color:#d2ddea;stop-opacity:1" />
+      <stop
+         style="stop-color:#cad9ea;stop-opacity:1"
+         offset="1"
+         id="stop4642" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4575">
+      <stop
+         id="stop4577"
+         offset="0"
+         style="stop-color:#fff900;stop-opacity:1" />
+      <stop
+         id="stop4579"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4569">
+      <stop
+         id="stop4571"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0" />
+      <stop
+         id="stop4573"
+         offset="1"
+         style="stop-color:#ec9b00;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3803">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3795">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3803-1"
+       id="linearGradient3809-1"
+       x1="6.5151834"
+       y1="-1.094625"
+       x2="6.026401"
+       y2="-1.5485992"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3803-1">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3795-0"
+       id="linearGradient3801-7"
+       x1="6.026401"
+       y1="-1.5485992"
+       x2="7.0246148"
+       y2="0.55446869"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3795-0">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-3" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-8" />
+    </linearGradient>
+    <linearGradient
+       y2="-1.5485992"
+       x2="6.026401"
+       y1="-1.094625"
+       x1="6.5151834"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3859-7"
+       xlink:href="#linearGradient3803-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3803-1-0">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-6-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-5-7" />
+    </linearGradient>
+    <linearGradient
+       y2="0.55446869"
+       x2="7.0246148"
+       y1="-1.5485992"
+       x1="6.026401"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3861-6"
+       xlink:href="#linearGradient3795-0-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3795-0-3">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-3-9" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-8-0" />
+    </linearGradient>
+    <linearGradient
+       y2="-1.5485992"
+       x2="6.026401"
+       y1="-1.094625"
+       x1="6.5151834"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3909-1"
+       xlink:href="#linearGradient3803-1-0-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3803-1-0-6">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-6-8-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-5-7-1" />
+    </linearGradient>
+    <linearGradient
+       y2="0.55446869"
+       x2="7.0246148"
+       y1="-1.5485992"
+       x1="6.026401"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3911-7"
+       xlink:href="#linearGradient3795-0-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3795-0-3-0">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-3-9-2" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-8-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3803-1-1">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-6-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3795-0-8">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-3-92" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-8-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3803-1-0-63">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-6-8-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-5-7-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3795-0-3-8">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-3-9-4" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-8-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3803-5"
+       id="linearGradient3809-2"
+       x1="6.5151834"
+       y1="-1.094625"
+       x2="6.026401"
+       y2="-1.5485992"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3803-5">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-58" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3795-2"
+       id="linearGradient3801-1"
+       x1="6.026401"
+       y1="-1.5485992"
+       x2="7.0246148"
+       y2="0.55446869"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3795-2">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-9" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3803-1-0-6-2">
+      <stop
+         style="stop-color:#8ea1bf;stop-opacity:1;"
+         offset="0"
+         id="stop3805-6-8-5-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3807-5-7-1-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3795-0-3-0-9">
+      <stop
+         style="stop-color:#5b779a;stop-opacity:1;"
+         offset="0"
+         id="stop3797-3-9-2-2" />
+      <stop
+         style="stop-color:#37649c;stop-opacity:1;"
+         offset="1"
+         id="stop3799-8-0-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4638"
+       id="linearGradient4644"
+       x1="1038.3622"
+       y1="-3"
+       x2="1049.3622"
+       y2="-14"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4652"
+       id="linearGradient4658"
+       x1="1036.3622"
+       y1="-8.5"
+       x2="1051.3622"
+       y2="-8.5"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.073372"
+     inkscape:cx="16.004277"
+     inkscape:cy="7.960503"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3811"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="-548,82"
+       id="guide3836" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <circle
+       r="7.0499997"
+       cy="-8.5"
+       cx="1043.8622"
+       style="opacity:0.76000001;fill:url(#linearGradient4644);fill-opacity:1;stroke:url(#linearGradient4658);stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1-5"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4398"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAArhJREFU
+OI2dk8FrHHUUxz+/yc7M7uxm09mQNNUaDVXMqQppbSmKF28KKkWQ/gFeKl68epJePKQgCIr1pFC8
+FIXipWigRUpbpDZhq0TddWRpcHezu0k2O5mZnZ2vh4WQSr34vT147/ve9/H9Gkn8G8FGT63eLj8H
+4/rJSkil7DHrl3jqMd8c7DUHCVq9XdUaHRw7x+FKEb/s4eVtwmhIbyek2R2QDFOOPTHNrF8yANbB
+4fWgzfwRn6X4dQpXfYrrZ5DgiwfP8t43R/nRfpH5Iz7rQZtWb3e8WRKSuLkaqPH3tuJkpM1LSDHa
+vITiZKQ3Py0q1Ud6+6uy4iRVo7mtm6uBJI0vCDZ6su0J/CmPdJQxfWKJzpcwfWKJdJTx8iszvPXZ
+h5w+XcGxJ/DLHrY9QbDRk5HEnfsNHT3sUyw4CDAY9uIhQXsAwFTB5lDJxXMnwACCztYum1uD8QXd
+nRCAwq3nKXz8OIVbzxG0B2SZyDLR3xvSDxPON08yd9HlfPMkedehuxOOCcJoCBh0u4376ia63SZn
+WViW4VDRYXoyj5fPceXyGssfvMOVy2uAIYyG5AC8vM1ekmJOzRB/B+bUDJWSg52zcB0L184x5dmc
+PXec9y98ztlzx4mSFC9vs/+DYsHFcfP7Gu2cxaTnUC7a2JahsTkgikdgBIIkThjsRWMJs36JfhiT
+jjKGacbTD+r89doZKr/+wh+NbS7eF/MvBVzdmiRNxXCU0Q8jZv3Swz6o1lu6V+9oZW5B6Q/fa2Vu
+Qau1jlis6utIYrGqe7WOqvXWvg/2CZrdvq7frWut1lJ87YZW5hYUX7uhn35ra7maicWqlquZ1mot
+Xb9bV7Pbl6RHZ0HGkHcdZCwyGYwRVpYRJQlGeigL5lFp/OTbP/XCMzm6OyFhNMTL21TKHnd+T3n3
+jYX/TuP/wT9HTo9AAVWvFAAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <circle
+       r="1.0499998"
+       cy="-6.5"
+       cx="1039.8622"
+       style="opacity:1;fill:#fff900;fill-opacity:1;stroke:#ec9b00;stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <circle
+       r="1.0499998"
+       cy="-10.5"
+       cx="1039.8622"
+       style="opacity:1;fill:#fcff89;fill-opacity:1;stroke:#51970b;stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1-25"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <circle
+       r="1.0499998"
+       cy="-12.5"
+       cx="1043.8622"
+       style="opacity:1;fill:#95ff66;fill-opacity:1;stroke:#088300;stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1-25-2"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <circle
+       r="1.0499998"
+       cy="-10.5"
+       cx="1047.8622"
+       style="opacity:1;fill:#a8f8ff;fill-opacity:1;stroke:#0028d4;stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1-25-2-9"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <circle
+       r="1.0499998"
+       cy="-6.5"
+       cx="1047.8622"
+       style="opacity:1;fill:#fcbdbc;fill-opacity:1;stroke:#be1821;stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1-25-2-1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <circle
+       r="1.0499998"
+       cy="-4.5"
+       cx="1043.8622"
+       style="opacity:1;fill:#ffd000;fill-opacity:1;stroke:#f88514;stroke-width:0.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3793-6-1-25-2-0"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.css/plugin.xml
+++ b/ui/org.eclipse.pde.spy.css/plugin.xml
@@ -5,14 +5,14 @@
          point="org.eclipse.pde.spy.core.spyPart">
       <spyPart
             description="%description"
-            icon="$nl$/icons/cssspy.png"
+            icon="$nl$/icons/cssspy.svg"
             name="%name"
             part="org.eclipse.pde.spy.css.CssSpyPart"
             shortcut="M2+M3+F5">
       </spyPart>
       <spyPart
             description="%css_scratchpad_description"
-            icon="$nl$/icons/css_scratchpad.png"
+            icon="$nl$/icons/css_scratchpad.svg"
             name="%css_scratchpad_name"
             part="org.eclipse.pde.spy.css.CSSScratchPadPart"
             shortcut="M2+M3+F6">

--- a/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.spy.event
 Automatic-Module-Name: org.eclipse.e4.tools.event.spy
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.event/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.event;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-Vendor: Eclipse Foundation
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/ui/org.eclipse.pde.spy.event/icons/eventspy.svg
+++ b/ui/org.eclipse.pde.spy.event/icons/eventspy.svg
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="configs.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="1.2239013"
+     inkscape:cy="5.7033411"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="1497"
+     inkscape:window-height="814"
+     inkscape:window-x="226"
+     inkscape:window-y="512"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.spy.event/plugin.xml
+++ b/ui/org.eclipse.pde.spy.event/plugin.xml
@@ -4,7 +4,7 @@
          point="org.eclipse.pde.spy.core.spyPart">
       <spyPart
             description="%description"
-            icon="$nl$/icons/eventspy.png"
+            icon="$nl$/icons/eventspy.svg"
             name="%name"
             part="org.eclipse.pde.spy.event.internal.ui.EventSpyPart"
             shortcut="M2+M3+F8">


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.pde.spy.bundle`, `org.eclipse.pde.spy.context`, `org.eclipse.pde.spy.css` and `org.eclipse.pde.spy.event` except for the following as these are not available as SVG yet:

org.eclipse.pde.spy.context/splash.svg (is not used in this bundle)

The bundle `org.eclipse.pde.spy.core` uses only one icon `spyicon.png` in the file `fragment.e4xmi` which is not available as SVG yet.

The bundle `org.eclipse.pde.spy.model` uses only one icon `application_lightning.png` which is also not available as SVG yet.

Almost all icons in bundle `org.eclipse.pde.spy.preferences` are named like enabled icons but are disabled looking. I ignored this bundle as no similar SVGs are available.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.