### PR TITLE
[Build|GH] Use quick-fix to avoid need for EF-infrastrucutre

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
     with:
       projectId: eclipse.pde
   build:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@master
+    uses: HannesWell/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@gh-workflow-quickfix
     with:
       maven-goals: clean verify -Ptck

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   callCodeQLworkflow:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/codeQLworkflow.yml@master
+    uses: HannesWell/eclipse.platform.releng.aggregator/.github/workflows/codeQLworkflow.yml@gh-workflow-quickfix

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
   check-merge-commits:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
   check-versions:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkVersions.yml@master
+    uses: HannesWell/eclipse.platform.releng.aggregator/.github/workflows/checkVersions.yml@gh-workflow-quickfix
     with:
       botName: Eclipse PDE Bot
       botMail: pde-bot@eclipse.org


### PR DESCRIPTION
Use
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2997

This is currently a draft to fully test the updated workflow.