### PR TITLE
Improve and fix the markdown documentation

### DIFF
--- a/docs/.project
+++ b/docs/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.pde.docs</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/docs/.settings/org.eclipse.core.resources.prefs
+++ b/docs/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/docs/API_Tools.md
+++ b/docs/API_Tools.md
@@ -1,30 +1,8 @@
 PDE/API Tools
 ========================
 
-
-Contents
---------
-
-*	[1 User Guide](#user-guide)
-*	[2 Resources](#resources)
-*	[3 Use Cases](#use-cases)
-*	[4 Links](#links)
-
-
 User Guide
 ==========
-
-Contents
---------
-
-*   [1 Current State](#Current-State)
-*   [2 API Tooling Setup](#API-Tooling-Setup)
-    *   [2.1 Define an API Baseline](#Define-an-API-Baseline)
-    *   [2.2 Configure Bundles for API Tooling](#Configure-Bundles-for-API-Tooling)
-*   [3 API Problems](#API-Problems)
-    *   [3.1 Adjusting Problem Severities](#Adjusting-Problem-Severities)
-    *   [3.2 Filtering Known Problems](#Filtering-Known-Problems)
-*   [4 Ant Tasks](#Ant-Tasks)
 
 Current State
 -------------
@@ -47,7 +25,7 @@ For example, if you are developing bundles for Eclipse 3.4, you will use Eclipse
 API baselines are managed on the **Plug-in Development > API Baselines** preference page. Here you can create, edit, and delete API baselines. 
 You can select one baseline as the 'default' - this is the baseline that the workspace will be compared against.
 
-![Api_profiles_pref_page_2.PNG](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Api_profiles_pref_page_2.PNG)
+![Api_profiles_pref_page_2.PNG](images/Api_profiles_pref_page_2.PNG)
 
 Use the **Add Baseline...** button to open a wizard to define a baseline. 
 Any Eclipse SDK can be used as a baseline simply by giving it a name and specifying the root location of the plug-ins.
@@ -69,19 +47,19 @@ You can use content assist to insert tags with appropriate comments.
 
 Using the **PDE Tools > API Tooling Setup...** action to configure your projects.
 
-![Api_tooling_setup.PNG](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Api_tooling_setup.PNG)
+![Api_tooling_setup.PNG](images/Api_tooling_setup.PNG)
 
 
 A dialog appears allowing you to select projects you want to setup for API tooling.
 
-![Api_tooling_setup_refactoring.PNG](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Api_tooling_setup_refactoring.PNG)
+![Api_tooling_setup_refactoring.PNG](images/Api_tooling_setup_refactoring.PNG)
 
 
 **Note**: By default, **component.xml files are deleted** from your workspace after corresponding Javadoc tags are inserted into source code. 
 There is a checkbox to disable this option. 
 You can also preview the text changes that will be made, by clicking 'next'.
 
-![Api_tooling_setup_preview.PNG](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Api_tooling_setup_preview.PNG)
+![Api_tooling_setup_preview.PNG](images/Api_tooling_setup_preview.PNG)
 
 After pressing finish, Javadoc tags will be inserted and the API Tooling nature (and builder) will be added to your projects. 
 API problems will now appear in the workspace where appropriate. 
@@ -103,7 +81,7 @@ The tooling breaks down the types of problems reported into one of three categor
 Similar to the way you can set compiler problem severities (error vs. warning vs. ignore), API tooling provides an **API Errors/Warnings** preference page that allows you to configure API problem severities. 
 You can configure the problem severities on a **per project basis** as well, by using the **API Errors/Warnings** property page for a project, available from the **Properties...** action.
 
-![Api_errors_pref.PNG](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Api_errors_pref.PNG)
+![Api_errors_pref.PNG](images/Api_errors_pref.PNG)
 
 #### Filtering Known Problems
 
@@ -114,7 +92,7 @@ You can add a filter for a specific api problem using the Eclipse 'quickfix' mec
 
 Once a filter has been added you can edit / remove it from the 'Api Problem Filters' project property page.
 
-![Api_tooling_problem_filters_page.PNG](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Api_tooling_problem_filters_page.PNG)
+![Api_tooling_problem_filters_page.PNG](images/Api_tooling_problem_filters_page.PNG)
 
 Ant Tasks
 ---------
@@ -122,35 +100,8 @@ Ant Tasks
 API Tools provides a number of ant tasks to integrate the tooling into your build process. 
 
 
-
-
 Resources
 =========
-
-Contents
---------
-
-*   [1 Articles](#Articles)
-*   [2 Examples](#Examples)
-    *   [2.1 Important Notes](#Important-Notes)
-    *   [2.2 Running an API use scan (IDE)](#Running-an-API-use-scan-ide)
-        *   [2.2.1 Creating a new scan configuration](#Creating-a-new-scan-configuration)
-        *   [2.2.2 Configuring the new use scan](#Configuring-the-new-use-scan)
-    *   [2.3 Running an API use scan (commandline)](#Running-an-API-use-scan-commandline)
-        *   [2.3.1 Initial Setup](#Initial-Setup)
-        *   [2.3.2 The Build File](#The-Build-File)
-        *   [2.3.3 Use Scan Buildfile](#Use-Scan-Buildfile)
-        *   [2.3.4 Running The Buildfile](#Running-The-Buildfile)
-    *   [2.4 Generating Javadoc](#Generating-Javadoc)
-        *   [2.4.1 Using the Wizard](#Using-the-Wizard)
-        *   [2.4.2 Using the Commandline](#Using-the-Commandline)
-        *   [2.4.3 Customizing the Custom Tags](#Customizing-the-Custom-Tags)
-        *   [2.4.4 Ant Tasks](#Ant-Tasks)
-
-Articles
---------
-
-There are currently no articles.
 
 Examples
 ========
@@ -160,7 +111,7 @@ Important Notes
 
 There are a few things that should be noted prior to getting started with the examples.
 
-1.  Whenever we refer to a "pattern" we are referring to a Java regular expression as defined [here](http://java.sun.com/docs/books/tutorial/essential/regex/). Take note of escaping, etc, that is used when formulating your regular expression. If a invalid regular expression is given, the use scanner will report it back to you and abort.
+1.  Whenever we refer to a "pattern" we are referring to a Java regular expression as defined [here](https://java.sun.com/docs/books/tutorial/essential/regex/). Take note of escaping, etc, that is used when formulating your regular expression. If a invalid regular expression is given, the use scanner will report it back to you and abort.
 2.  When using the Ant tasks from the command line you should always make sure the `eclipse.install.dir` property points to the most recent Eclipse build available. This way you get all the latest and greatest versions of the tasks. The other reason to do this is that the build file (`api-tasks.xml`) uses the API tools core jar from that directory on the Ant classpath.
 3.  Any Ant tasks used from the command line must be called by their name as specified in the `ant-tasks.properties` file. This can cause some confusion for users who try out the Ant tasks in Eclipse and notice that the tasks are qualified with `apitooling` but they are not qualified in the `ant-tasks.properties` file. Consider the following example:
 
@@ -193,7 +144,7 @@ Running an API use scan (IDE)
 In the IDE API use scans can be run from the External tools dialog. 
 The benefits of providing the scanning as an external tool are many, the foremost being: 1. you can create as many different configurations as you want for scanning different distributions of your products and 2. each configuration can have its own persisted settings.
 
-![The external tools dialog showing a use scan configuration](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Usescan-ext-dialog.png)
+![The external tools dialog showing a use scan configuration](images/Usescan-ext-dialog.png)
 
 ### Creating a new scan configuration
 
@@ -361,11 +312,11 @@ It can be found by using the Generate Javadoc command located in the Project mai
 
 Once the wizard starts you will have to locate the Javadoc executable (if not already specified) and select the bundles you wish to generate Javadoc for.
 
-![The first page of the Generate Javadoc wizard](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Jdoc_wizard_p1.png)
+![The first page of the Generate Javadoc wizard](images/Jdoc_wizard_p1.png)
 
 On the next page, you can configure additional options.
 
-![The second page of the Generate Javadoc wizard](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Jdoc_wizard_p2.png)
+![The second page of the Generate Javadoc wizard](images/Jdoc_wizard_p2.png)
 
 On the last page is where we need to tell the wizard about the custom API tools tags. 
 In the `Extra Javadoc options` area you will want to enter the following tag definitions:
@@ -382,11 +333,11 @@ In the `Extra Javadoc options` area you will want to enter the following tag def
 
 The wizard will then look like the following:
 
-![The third page of the Generate Javadoc wizard](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Jdoc_wizard_p3.png)
+![The third page of the Generate Javadoc wizard](images/Jdoc_wizard_p3.png)
 
 Once you press finish and the Javadoc tool completes you should see API tools tag restrictions appearing in your documentation like the following example:
 
-![How the API tools tags look in the HTML documentation](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Doc_example.png)
+![How the API tools tags look in the HTML documentation](images/Doc_example.png)
 
 ### Using the Commandline
 
@@ -411,7 +362,7 @@ Where the `apitags` file would contain the following:
  
 
 You will also have to specify where the source is and any extra parameter for javadoc to be able to complete. 
-For a description of these and further information on using `javadoc` see [the Sun Javadoc guide](http://java.sun.com/j2se/1.4.2/docs/tooldocs/windows/javadoc.html)
+For a description of these and further information on using `javadoc` see [the Sun Javadoc guide](https://java.sun.com/j2se/1.4.2/docs/tooldocs/windows/javadoc.html)
 
 ### Customizing the Custom Tags
 
@@ -449,19 +400,6 @@ API Tools provides a number of ant tasks to integrate the tooling into your buil
 Use Cases
 =========
 
-
-Contents
---------
-
-*   [1 Introduction](#Introduction)
-    *   [1.1 Binary Compatibility Reporting (Batch Mode)](#Binary-Compatibility-Reporting-Batch-Mode)
-    *   [1.2 Binary Compatibility Reporting (IDE Mode)](#Binary-Compatibility-Reporting-IDE-Mode)
-    *   [1.3 API Usage Reporting (Batch Mode)](#API-Usage-Reporting-Batch-Mode)
-    *   [1.4 API Usage Reporting (IDE Mode)](#API-Usage-Reporting-IDE-Mode)
-    *   [1.5 API Usage Searching (IDE Mode)](#API-Usage-Searching-IDE-Mode)
-    *   [1.6 Version Management](#Version-Management)
-    *   [1.7 Building API Components & Baselines](#Building-API-Components--Baselines)
-    *   [1.8 Javadoc Tags, API Visibilities & Restrictions](#Javadoc-Tags-API-Visibilities--Restrictions)
 
 Introduction
 ============
@@ -564,13 +502,15 @@ The platform provides a default set of Javadoc tags. The tags and the Java membe
 Links
 =====
 
-* [Website](http://www.eclipse.org/pde/pde-api-tools/)
-* [Download](http://download.eclipse.org/eclipse/downloads/)
+<!--
+* [Website](https://www.eclipse.org/pde/pde-api-tools/)
+-->
+* [Download](https://download.eclipse.org/eclipse/downloads/)
  
 **Community** 
 * [Mailing List](https://dev.eclipse.org/mailman/listinfo/pde-dev) 
-* [Forums](http://www.eclipse.org/forums/eclipse.platform) 
+* [Dicusssions](https://github.com/eclipse-pde/eclipse.pde/discussions) 
 
 **Contribute**
-* [Browse Source](http://dev.eclipse.org/viewcvs/index.cgi/) 
+* [Browse Source](https://github.com/eclipse-pde/) 
 

--- a/docs/Execution_Environments.md
+++ b/docs/Execution_Environments.md
@@ -18,8 +18,8 @@ Second, an application written entirely of bundles such as A can ship on a Java 
 
 ## How can this be configured?
 
-[OSGi](https://en.wikipedia.org/wiki/OSGi) allows bundles to be marked with the minimum execution environment they require (see the [ Setting the
-Execution Environment](#setting-the-execution-environment)).
+[OSGi](https://www.osgi.org/) allows bundles to be marked with the minimum execution environment they require 
+(see the [ Setting the Execution Environment](#setting-the-execution-environment)).
 Setting this value has two effects.
 
 1.  The compiler attempts to compile your bundle against the JRE
@@ -53,8 +53,8 @@ Increasing your EE can create a lot of work with no real value, such as exposing
 
 Projects should not leave these choices to chance. 
 Dependency structures are key parts of an architecture. 
-For example, the [Eclipse Project](https://eclipse.org/eclipse) has explicitly identified EEs for all of their bundles. 
-These choices are documented in the [project plan](https://www.eclipse.org/projects/project-plan.php?projectid=eclipse#appendix).
+For example, the [Eclipse Project](https://eclipse.dev/eclipse) has explicitly identified EEs for all of their bundles. 
+These choices are documented in the [project plan](https://eclipse.dev/eclipse/development/plans.html).
 The execution environment listed in the table is based on the needs of the bundle and the expected use scenarios for the bundle.
 
 ## I have prerequisites that require version X to run, so shouldn't I require version X too?
@@ -71,7 +71,6 @@ However, with the the fast evolving Java runtime environment, you may want to up
 4.  Note the section in the lower left corner entitled **Execution
     Environments**.
 5.  Add your appropriate environment(s) noting the [special
-    cases](#special-cases) below.
 6.  Save the file.
 7.  Select the link "update the classpath and compiler compliance
     settings".

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -5,36 +5,6 @@ Frequently Asked Questions for PDE.
 Community members are encouraged to maintain the page, and make sure the information is accurate.
 
 
-Contents
---------
-
-*   [1 General](#General)
-    *   [1.1 What is PDE](#What-is-PDE)
-    *   [1.2 How do I test my plug-ins](#How-do-I-test-my-plug-ins)
-*   [2 PDE Build](#PDE-Build)
-*   [3 Target Management](#Target-Management)
-    *   [3.1 Why do I get an popup dialog saying I have selected a target with a newer version than your current Eclipse installation?](#Why-do-I-get-an-popup-dialog-saying-I-have-selected-a-target-with-a-newer-version-than-your-current-Eclipse-installation.3F)
-*   [4 Products](#Products)
-    *   [4.1 Why doesn't my JRE get included in a headless build?](#Why-doesnt-my-JRE-get-included-in-a-headless-build)
-*   [5 Classpath](#Classpath)
-    *   [5.1 How do I find a plug-in (bundle) given a class](#How-do-I-find-a-plug-in-bundle-given-a-class)
-    *   [5.2 How do I get access to a plug-in (bundle) in my workspace or target](#How-do-I-get-access-to-a-plug-in-bundle-in-my-workspace-or-target)
-    *   [5.3 I have an error that says some package (e.g., com.sun.misc) isn't accessible but it's on my classpath](#i-have-an-error-that-says-some-package-eg-comsunmisc-isnt-accessible-but-its-on-my-classpath)
-*   [6 API Tooling](#API-Tooling)
-    *   [6.1 How do I enable API Tooling for my projects](#How-do-I-enable-API-Tooling-for-my-projects)
-    *   [6.2 How do I enable API Tooling for headless builds](#How-do-I-enable-API-Tooling-for-headless-builds)
-*   [7 Build and Deployment Errors](#Build-and-Deployment-Errors)
-    *   [7.1 My product fails to start](#My-product-fails-to-start)
-    *   [7.2 My bundles aren't loading](#My-bundles-arent-loading)
-    *   [7.3 Why aren't my launcher icons being found?](#Why-arent-my-launcher-icons-being-found)
-    *   [7.4 Why aren't my class files being bundled?](#Why-arent-my-class-files-being-bundled)
-    *   [7.5 Why aren't my class files being resolved? (ClassNotFoundException and NoClassDefFoundError)](#why-arent-my-class-files-being-resolved-classnotfoundexception-and-noclassdeffounderror)
-    *   [7.6 Why am I getting a "package uses conflict"?](#Why-am-I-getting-a-package-uses-conflict)
-*   [8 Misc](#Misc)
-    *   [8.1 How do I add my own template to the New Plug-in Project Wizard](#How-do-I-add-my-own-template-to-the-New-Plug-in-Project-Wizard)
-    *   [8.2 How do I know if my project is a plug-in project](#How-do-I-know-if-my-project-is-a-plug-in-project)
-    *   [8.3 How do source attachments for bundles work](#How-do-source-attachments-for-bundles-work)
-
 General
 -------
 
@@ -62,14 +32,15 @@ Target Management
 
 This happens because PDE detects a newer version of the OSGi runtime in your target platform than in your host installation. To resolve this problem, don't point to a target that may contain future versions of Eclipse or just upgrade your current host to a newer version of Eclipse. In the end, this message is trying to convey that PDE is backwards compatible only, not forward compatible.
 
-Also, see our [Target Definitions](https://github.com/eclipse-pde/eclipse.pde/blob/master/docs/Target_Definitions.md) page.
+Also, see our [Target Definitions](Target_Definitions.md) page.
 
 Products
 --------
 
 ### Why doesn't my JRE get included in a headless build?
 
-At the moment, there is a disparity between PDE UI and Build when it comes to JREs and product definitions. The best way to get your JRE to be included in a headless and UI build is to use [root files](https://help.eclipse.org/galileo/index.jsp?topic=/org.eclipse.pde.doc.user/tasks/pde_rootfiles.htm).
+At the moment, there is a disparity between PDE UI and Build when it comes to JREs and product definitions.
+The best way to get your JRE to be included in a headless and UI build is to use [root files](https://help.eclipse.org/index.jsp?topic=/org.eclipse.pde.doc.user/tasks/pde_rootfiles.htm).
 
 Classpath
 ---------
@@ -95,7 +66,7 @@ API Tooling
 
 ### How do I enable API Tooling for my projects
 
-Enabling API Tooling on a project is described [here](https://github.com/eclipse-pde/eclipse.pde/blob/master/docs/User_Guide.md).
+Enabling API Tooling on a project is described [here](User_Guide.md).
 
 Build and Deployment Errors
 ---------------------------
@@ -152,18 +123,28 @@ Earlier versions of PDE did not automatically add a "." when a Bundle-Classpath 
 
 ### Why am I getting a "package uses conflict"?
 
-["Package uses"](http://blog.springsource.com/2008/10/20/understanding-the-osgi-uses-directive/) are akin to a bundle's require-bundles: they specify a package's dependent packages.  Package uses conflicts  are fortunately somewhat rare, but are obscure and difficult-to-diagnose problems. Basically they occur when a bundle's imports causes two different versions of a package to be available within the same bundle — there is no way for the framework to decide which package to allow. The articles linked to earlier in this paragraph provide more detail.
+[Package uses](https://spring.io/blog/2008/10/20/understanding-the-osgi-uses-directive) are akin to a bundle's require-bundles: they specify a package's dependent packages.
+Package uses conflicts  are fortunately somewhat rare, but are obscure and difficult-to-diagnose problems.
+Basically they occur when a bundle's imports causes two different versions of a package to be available within the same bundle — there is no way for the framework to decide which package to allow.
+ The articles linked to earlier in this paragraph provide more detail.
 
-Package uses conflicts often occur with system-level packages from the JVM's execution environment (e.g., javax.transaction) are made available, either via system bundle extensions or the org.osgi.framework.system.packages and org.osgi.framework.system.packages.extra properties (and possibly the Equinox Launcher's [compatibility boot-delegation](/Equinox_Boot_Delegation "Equinox Boot Delegation") too). For example, many modern JREs now include javax.transaction, javax.annotation, javax.inject, and javax.vecmath, which many apps previously brought in through other bundles. When these packages are exposed through the system bundle, any bundle that re-exports the system bundle (notably org.eclipse.core.runtime) will also expose those classes. Conflicts arise when also including a bundle using a "Dynamic-ImportPackage" as the import set has to be verified against the packages available.
+Package uses conflicts often occur with system-level packages from the JVM's execution environment (e.g., javax.transaction) are made available,
+either via system bundle extensions or the org.osgi.framework.system.packages and org.osgi.framework.system.packages.extra properties
+(and possibly the Equinox Launcher's [compatibility boot-delegation](/Equinox_Boot_Delegation "Equinox Boot Delegation") too).
+For example, many modern JREs now include javax.transaction, javax.annotation, javax.inject, and javax.vecmath, which many apps previously brought in through other bundles.
+When these packages are exposed through the system bundle, any bundle that re-exports the system bundle (notably org.eclipse.core.runtime) will also expose those classes.
+Conflicts arise when also including a bundle using a "Dynamic-ImportPackage" as the import set has to be verified against the packages available.
 
-Diagnosing package-uses conflicts can be painful, and Equinox's diagnostics unfortunately omit the offending package names. The Eclipse Virgo project apparently has [some enhanced diagnostics](http://blog.springsource.com/2008/10/20/understanding-the-osgi-uses-directive/). Given a bundle, use the Equinox Console to examine the bundles providing that package using the packages command. Otherwise set a breakpoint in Equinox's org.eclipse.osgi.internal.module.ResolverImpl#findBestCombination(ResolverBundle\[\],Dictionary) to examine the local packageConstraints variable.
+Diagnosing package-uses conflicts can be painful, and Equinox's diagnostics unfortunately omit the offending package names.
+The Eclipse Virgo project apparently has [some enhanced diagnostics](https://blog.springsource.com/2008/10/20/understanding-the-osgi-uses-directive/).
+Given a bundle, use the Equinox Console to examine the bundles providing that package using the packages command. Otherwise set a breakpoint in Equinox's org.eclipse.osgi.internal.module.ResolverImpl#findBestCombination(ResolverBundle\[\],Dictionary) to examine the local packageConstraints variable.
 
 Misc
 ----
 
 ### How do I add my own template to the New Plug-in Project Wizard
 
-The _org.eclipse.pde.ui.pluginContent_ extension point is what you need. There's a fantastic [article](http://www.ibm.com/developerworks/library/os-eclipse-pde/) on this topic at developerWorks.
+The _org.eclipse.pde.ui.pluginContent_ extension point is what you need.
 
 ### How do I know if my project is a plug-in project
 
@@ -210,12 +191,12 @@ A typical .project in a plug-in project will look like this:
 
 ### How do source attachments for bundles work
 
-Since Eclipse 3.4 Eclipse Bundle JARs are accompanied by separate source bundles (see [Bug 202462 simplify the way source is contributed](http://bugs.eclipse.org/202462)):
+Since Eclipse 3.4 Eclipse Bundle JARs are accompanied by separate source bundles (see [Bug 202462 simplify the way source is contributed](https://bugs.eclipse.org/202462)):
 
         javax.servlet_2.5.0.v200910301333
         javax.servlet.source_2.5.0.v200910301333
 
-The source bundle has to contain the [Eclipse-SourceBundle](https://help.eclipse.org/galileo/index.jsp?topic=/org.eclipse.pde.doc.user/tasks/pde_individual_source.htm) header in its MANIFEST.MF, attaching the sources to the actual bundle:
+The source bundle has to contain the [Eclipse-SourceBundle](https://help.eclipse.org/index.jsp?topic=/org.eclipse.pde.doc.user/tasks/pde_individual_source.htm) header in its MANIFEST.MF, attaching the sources to the actual bundle:
 
         Bundle-SymbolicName: javax.servlet.source
         Eclipse-SourceBundle: javax.servlet;version="2.5.0.v200910301333"

--- a/docs/Target_Definitions.md
+++ b/docs/Target_Definitions.md
@@ -1,16 +1,6 @@
 PDE/Target Definitions
 ======================
 
-Contents
---------
-
-*   [1 Introduction](#Introduction)
-*   [2 The Basics](#The-Basics)
-*   [3 Examples](#Examples)
-*   [4 Known Issues](#Known-Issues)
-    *   [4.1 Redownloading of Bundles](#Redownloading-of-Bundles)
-*   [5 Links](#Links)
-
 Introduction
 ------------
 

--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -3,69 +3,6 @@ PDE/User Guide
 
 Community members are encouraged to maintain the page, and make sure the information is accurate.
   
-Contents
---------
-
-*   [1 Getting Started](#Getting-Started)
-    *   [1.1 PDE Overview](#PDE-Overview)
-*   [2 Concepts](#Concepts)
-    *   [2.1 Extensions and Extension Points](#Extensions-and-Extension-Points)
-    *   [2.2 Feature](#Feature)
-    *   [2.3 Fragment](#Fragment)
-    *   [2.4 Plug-in](#Plug-in)
-    *   [2.5 Product](#Product)
-    *   [2.6 Target Platform](#Target-Platform)
-    *   [2.7 Update Site](#Update-Site)
-*   [3 Tasks](#Tasks)
-    *   [3.1 PDE Build](#PDE-Build)
-        *   [3.1.1 Automated building of Products](#Automated-building-of-Products)
-        *   [3.1.2 Automated building of Features](#Automated-building-of-Features)
-        *   [3.1.3 Automated building of Plug-ins](#Automated-building-of-Plug-ins)
-        *   [3.1.4 Generating Ant scripts](#Generating-Ant-scripts)
-        *   [3.1.5 Generating Ant scripts from the command line](#Generating-Ant-scripts-from-the-command-line)
-    *   [3.2 PDE Build Advanced Topics](#PDE-Build-Advanced-Topics)
-    *   [3.3 PDE Build Integration with p2](#PDE-Build-Integration-with-p2)
-    *   [3.4 PDE API Tooling](#PDE-API-Tooling)
-        *   [3.4.1 Setting up API Tooling](#Setting-up-API-Tooling)
-        *   [3.4.2 Setting up a baseline](#Setting-up-a-baseline)
-        *   [3.4.3 Creating filters](#Creating-filters)
-        *   [3.4.4 Removing filters](#Removing-filters)
-        *   [3.4.5 Changing API Tooling options](#Changing-API-Tooling-options)
-        *   [3.4.6 Comparing to an API Baseline](#Comparing-to-an-API-Baseline)
-    *   [3.5 PDE UI](#PDE-UI)
-        *   [3.5.1 Export and Install into the Running Host](#Export-and-Install-into-the-Running-Host)
-*   [4 Reference](#Reference)
-    *   [4.1 API Tools Ant Tasks](#API-Tools-Ant-Tasks)
-    *   [4.2 Build Configuration](#Build-Configuration)
-    *   [4.3 Editors](#Editors)
-    *   [4.4 Launchers](#Launchers)
-    *   [4.5 Menus and Actions](#Menus-and-Actions)
-        *   [4.5.1 API Tooling Setup](#API-Tooling-Setup)
-        *   [4.5.2 API Baseline](#API-Baseline)
-    *   [4.6 Preferences](#Preferences)
-    *   [4.7 Property Pages](#Property-Pages)
-        *   [4.7.1 API Errors and Warnings](#API-Errors-and-Warnings)
-        *   [4.7.2 API Problem Filters](#API-Problem-Filters)
-    *   [4.8 Quickfixes](#Quickfixes)
-        *   [4.8.1 Create API Problem Filter](#Create-API-Problem-Filter)
-        *   [4.8.2 Missing API Baseline](#Missing-API-Baseline)
-        *   [4.8.3 Since Tags](#Since-Tags)
-        *   [4.8.4 Version Numbering](#Version-Numbering)
-        *   [4.8.5 Remove Unused API Problem Filters](#Remove-Unused-API-Problem-Filters)
-    *   [4.9 Views](#Views)
-    *   [4.10 Wizards and Dialogs](#Wizards-and-Dialogs)
-    *   [4.11 API Reference](#API-Reference)
-    *   [4.12 Extension Points Reference](#Extension-Points-Reference)
-    *   [4.13 Other Reference Information](#Other-Reference-Information)
-    *   [4.14 Defining API Restrictions](#Defining-API-Restrictions)
-    *   [4.15 Javadoc @since Tag Management](#Javadoc-since-Tag-Management)
-*   [5 Tips and Tricks](#Tips-and-Tricks)
-    *   [5.1 Creating a Rich Client Application](#Creating-a-Rich-Client-Application)
-    *   [5.2 Creating an Eclipse Plug-in](#Creating-an-Eclipse-Plug-in)
-    *   [5.3 To clean or not to clean](#To-clean-or-not-to-clean)
-    *   [5.4 Templates](#Templates)
-    *   [5.5 Dependency Extent](#Dependency-Extent)
-    *   [5.6 Extending the Java Search Scope](#Extending-the-Java-Search-Scope)
 
 Getting Started
 ===============
@@ -373,7 +310,7 @@ Since Ant scripts use the replacement variables in build.properties, you can typ
 
 To create scripts, you can simply select **Create Ant Build File** while a suitable manifest file (plugin.xml, fragment.xml or feature.xml) is selected in the Navigator or Package Explorer views. The command will generate the build script. After selecting Run Ant... from the pop-up menu while the newly generated script file is selected, the following wizard will open:
 
-![Pde-feature-jar.png](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Pde-feature-jar.png)
+![Pde-feature-jar.png](images/Pde-feature-jar.png)
 
 The standard Ant wizard allows customization in two ways: by providing the execution arguments and by selecting one or more build targets.
 
@@ -489,7 +426,9 @@ Each attribute=value pair will be inserted into the generated xml corresponding 
 
 **Directory file format**
 
-Directory files are used to indicate where the plug-ins and features can be obtained, as well as their versions. It is a Java property file whose keys are always of the form type@id\[,version\] but where the value is open ended. When using map files to fetch your elements, the directory file is a concatenation of all the map files, for more details on map files see Fetching From Repositories.
+Directory files are used to indicate where the plug-ins and features can be obtained, as well as their versions.
+It is a Java property file whose keys are always of the form type@id\[,version\] but where the value is open ended.
+When using map files to fetch your elements, the directory file is a concatenation of all the map files, for more details on map files see Fetching From Repositories.
 
 **Using the targets**
 
@@ -531,7 +470,7 @@ This section explains how to enable a new plug-ins for API analysis.
 3.  Fill the first page as you would do for any other plug-in and click Next.
 4.  Check the option _Enable API Analysis_.
 
-![Pde plugin creation wizard.png](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Pde_plugin_creation_wizard.png)
+![Pde plugin creation wizard.png](images/Pde_plugin_creation_wizard.png)
 
 1.  Complete your Plug-in setup
 2.  Click Finish.
@@ -580,7 +519,7 @@ If you want to remove an existing API filter, do the following steps:
 *   Right-click on the project and select **Properties**.
 *   Go to Plug-in Development > API Problem Filters
 
-![Pde api filter properties.png](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Pde_api_filter_properties.png)
+![Pde api filter properties.png](images/Pde_api_filter_properties.png)
 
 *   From the list of existing filters, select the one you want to remove
 *   Select **Remove**.
@@ -603,7 +542,8 @@ The options can be changed per project or workspace.
 
 ### Comparing to an API Baseline
 
-Any API tooling enabled project in your workspace can be compared to any one of the API baselines set up in your workspace. In addition to selecting projects to compare to a baseline you can also select (or multi-select) any of the following within an API tools enabled project:
+Any API tooling enabled project in your workspace can be compared to any one of the API baselines set up in your workspace.
+In addition to selecting projects to compare to a baseline you can also select (or multi-select) any of the following within an API tools enabled project:
 
 *   source folders
 *   package fragments
@@ -622,7 +562,11 @@ PDE UI
 
 ### Export and Install into the Running Host
 
-PDE provides several tools for launching plug-ins and features in your workspace. The Eclipse Application Launcher can be used to create a second running instance of Eclipse that runs the code you have in your workspace. This is commonly referred to as self-hosting. Self-hosting is a powerful debugging and testing tool. However it is sometimes necessary for code to be tested in your host, your currently running Eclipse instance. To test code in the host, you need to export and install into the running Eclipse instance.
+PDE provides several tools for launching plug-ins and features in your workspace.
+The Eclipse Application Launcher can be used to create a second running instance of Eclipse that runs the code you have in your workspace.
+This is commonly referred to as self-hosting. Self-hosting is a powerful debugging and testing tool.
+However it is sometimes necessary for code to be tested in your host, your currently running Eclipse instance.
+To test code in the host, you need to export and install into the running Eclipse instance.
 
 To export plug-ins and features and install them into the host Eclipse do the following:
 
@@ -664,7 +608,7 @@ Menus and Actions
 ### API Tooling Setup
 
 
-Select the **API Tooling Setup** command ![Pde category menu.gif](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Pde_category_menu.gif) to start the API Setup wizard.
+Select the **API Tooling Setup** command ![Pde category menu.gif](images/Pde_category_menu.gif) to start the API Setup wizard.
 
 ### API Baseline
 
@@ -686,7 +630,7 @@ API problems are created during project builds (auto and full builds), the tooli
 2.  **Binary Incompatibilities** \- changes between versions are not binary compatible.
 3.  **Version Problems** \- plug-in versions or code versions (@since tags) not correct.
 
-![Pde-errorwarning-prop-page.png](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Pde-errorwarning-prop-page.png)
+![Pde-errorwarning-prop-page.png](images/Pde-errorwarning-prop-page.png)
 
 You can also configure the problem severities for the entire workspace as well using the **Plug-in Development > API Errors/Warnings** preference page.
 
@@ -703,7 +647,7 @@ To locate this property page:
 1.  Open the context menu for any API tooling enabled project and select **Properties**.
 2.  Navigate to **Plug-in Development > API Problem Filters**.
 
-![Pde-api-problem-filter-prop.png](https://raw.githubusercontent.com/eclipse-pde/eclipse.pde/master/docs/images/Pde-api-problem-filter-prop.png)
+![Pde-api-problem-filter-prop.png](images/Pde-api-problem-filter-prop.png)
 
 Quickfixes
 ----------


### PR DESCRIPTION
- Add a .project file to `docs` folder  for a project named `org.eclipse.pde.docs`
- Remove internal table of content entries.
- Fix broken links and avoid absolute raw links.