### PR TITLE
OSGI Repositories view: lower required version ranges for bndtools

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Generic UI components related to BND
 Bundle-SymbolicName: org.eclipse.pde.bnd.ui;singleton:=true
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Export-Package: org.eclipse.pde.bnd.ui.autocomplete;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.plugins;x-internal:=true,
  org.eclipse.pde.bnd.ui.preferences;version="1.0.0";x-friends:="org.eclipse.pde.ui",
@@ -48,7 +48,7 @@ Import-Package: aQute.bnd.build;version="4.5.0",
 Require-Bundle: org.eclipse.jdt.ui,
  org.eclipse.jdt.core,
  org.eclipse.core.resources,
- org.eclipse.core.runtime;bundle-version="3.30.0",
+ org.eclipse.core.runtime;bundle-version="3.26.0",
  org.eclipse.jface.text,
  org.eclipse.swt,
  org.eclipse.jface,
@@ -56,8 +56,8 @@ Require-Bundle: org.eclipse.jdt.ui,
  org.eclipse.core.expressions,
  org.eclipse.ui.forms,
  org.eclipse.e4.core.services,
- org.eclipse.ui;bundle-version="3.205.100",
- org.eclipse.ui.ide;bundle-version="3.22.100",
+ org.eclipse.ui;bundle-version="3.201.0",
+ org.eclipse.ui.ide;bundle-version="3.19.0",
  org.eclipse.core.filesystem,
  org.eclipse.team.core,
  org.eclipse.core.databinding.observable


### PR DESCRIPTION
- to be compatible with bndtools which uses Eclipse 2022-09