### PR TITLE
BndWorkspace improvements

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/Workspaces.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/Workspaces.java
@@ -38,25 +38,45 @@ public class Workspaces {
 			if (bndProject != null) {
 				return Optional.ofNullable(bndProject.getWorkspace());
 			} else {
-				IFile bndFile = project.getFile(Project.BNDFILE);
-				if (bndFile.exists()) {
-					IPath location = bndFile.getLocation();
-					if (location != null) {
-						File file = location.toFile();
-						if (file != null) {
-							try {
-								Project nativeProject = Workspace.getProject(file.getParentFile());
-								if (nativeProject != null) {
-									return Optional.ofNullable(nativeProject.getWorkspace());
+				
+				if(isCnf(project)) {
+					
+					try {
+						File wsDir = project.getLocation().toFile().getParentFile();
+						return Optional.ofNullable(Workspace.getWorkspace(wsDir));
+					} catch (Exception e) {
+					}
+				}
+				else {
+					IFile bndFile = project.getFile(Project.BNDFILE);
+					if (bndFile.exists()) {
+						IPath location = bndFile.getLocation();
+						if (location != null) {
+							File file = location.toFile();
+							if (file != null) {
+								try {
+									Project nativeProject = Workspace.getProject(file.getParentFile());
+									if (nativeProject != null) {
+										return Optional.ofNullable(nativeProject.getWorkspace());
+									}
+								} catch (Exception e) {
 								}
-							} catch (Exception e) {
 							}
 						}
 					}
 				}
+				
 			}
 		}
 		return Optional.empty();
+	}
+	
+	private static boolean isCnf(IProject project) {
+		IPath projectPath = project.getLocation();
+		if (projectPath != null) {
+			return Project.BNDCNF.equals(projectPath.lastSegment());
+		}
+		return false;
 	}
 
 	public static synchronized Optional<Workspace> getGlobalWorkspace() {


### PR DESCRIPTION
WIP
- find correct workspace for cnf

The current change has the following effect:
If you click in a project called "cnf" (which is kind of a marker project name for a bnd workspace) then the correct Bnd Workspace is returned. 
In the RepositoriesView this has the effect that the Bnd Workspace Repository and all other bnd repos are also shown if you click on "cnf" project. 
<img width="359" alt="image" src="https://github.com/user-attachments/assets/9c51c660-0a46-4d20-8fdc-754af9e7c1df" />


Before this change clicking on a "cnf" project did not show any of the Bnd Workspace repositories (just the PDE Target Repo). 