### PR TITLE
Add missing eclipse.svg

### DIFF
--- a/ui/org.eclipse.pde.ui/icons/etool16/eclipse.svg
+++ b/ui/org.eclipse.pde.ui/icons/etool16/eclipse.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 1.3617021 1.3617021"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse16.svg"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.3906251"
+     inkscape:cy="5.2343751"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1682"
+     inkscape:window-height="1033"
+     inkscape:window-x="220"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 0.40346119,0.84984676 H 0.21424145 c 0.0250542,0.0911041 0.0715448,0.17275664 0.13960955,0.24492124 0.10850978,0.1150391 0.23898823,0.1724809 0.39157083,0.1724809 0.0305008,0 0.0600526,-0.00242 0.0887563,-0.00699 C 0.94910676,1.2418648 1.0497284,1.186783 1.1359419,1.0947681 1.2044471,1.022627 1.2512661,0.94095104 1.2765119,0.84984685 H 1.1997235 1.0874392 Z"
+       id="path2" />
+    <path
+       d="m 0.29912249,0.57740797 h -0.0988478 c -0.003616,0.0230246 -0.00608,0.0465284 -0.007199,0.0706312 h 0.1174827 0.0589335 0.85066471 0.077648 c -0.00113,-0.0241028 -0.00359,-0.0476066 -0.00724,-0.0706312"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133164" />
+    <path
+       d="m 0.19307616,0.71362698 c 0.001119,0.0241148 0.003571,0.0476186 0.007199,0.0706312 h 0.10276911 0.0778961 0.83227843 0.077365 c 0.00364,-0.0230126 0.00612,-0.0465164 0.00726,-0.0706312"
+       id="path6"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133164" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 1.2765345,0.51180881 C 1.2513112,0.42045308 1.2044808,0.33841738 1.1359418,0.26574966 1.0499544,0.17459763 0.94961507,0.11991109 0.83505943,0.1015106 0.80608483,0.0968525 0.77623933,0.0944056 0.74542233,0.0944056 c -0.1525826,0 -0.28307238,0.05712998 -0.39157084,0.17134289 -0.0680866,0.0726676 -0.11460096,0.1547034 -0.13964335,0.24605915"
+       id="path10" />
+    <path
+       d="m 0.16022485,0.68085105 c 0,-0.30935886 0.21917824,-0.56640322 0.50430771,-0.61161389 -0.007074,-2.7553e-4 -0.0141825,-5.7502e-4 -0.0213245,-5.7502e-4 -0.31996972,0 -0.57937867,0.2740912 -0.57937867,0.61218891 0,0.33810975 0.25939765,0.61218895 0.57937867,0.61218895 0.007165,0 0.0142729,-2.875e-4 0.0213697,-5.63e-4 C 0.37940309,1.2472663 0.16022485,0.9902219 0.16022485,0.68085105 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       style="fill:#f7941e;stroke-width:0.133164" />
+    <path
+       d="M 1.1213884,0.6480272 C 1.1195384,0.6238166 1.1156884,0.60020499 1.1099524,0.577396 H 0.38093999 c -0.005741,0.022797 -0.009594,0.0464086 -0.0114477,0.0706312 z"
+       id="path37"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_1_);stroke-width:0.133164" />
+    <path
+       d="M 1.1213884,0.71362698 H 0.36950362 c 0.001853,0.0242106 0.005684,0.0478222 0.0114364,0.0706312 H 1.1099633 c 0.00574,-0.022809 0.00957,-0.0464206 0.011425,-0.0706312 z"
+       id="path44"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_2_);stroke-width:0.133164" />
+    <path
+       d="m 0.745446,1.080823 c 0.15139629,0 0.2818975,-0.0945544 0.3419949,-0.23097701 H 0.4034511 C 0.46354855,0.98626865 0.59404972,1.080823 0.745446,1.080823 Z"
+       id="path51"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_3_);stroke-width:0.133164" />
+    <path
+       d="M 0.31377957,0.71362698 H 0.36897247 1.122801 1.22183 1.297059 c 5.198e-4,-0.0104342 8.137e-4,-0.0209402 8.137e-4,-0.0315181 0,-0.0114404 -3.956e-4,-0.022785 -0.00101,-0.0340817 H 1.2218182 1.1227897 0.36896118 0.30986951 0.19307616 c -6.1025e-4,0.0112847 -0.001006,0.0226413 -0.001006,0.0340817 0,0.0105779 2.9382e-4,0.0210839 8.1365e-4,0.0315181 z"
+       id="path55"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+    <path
+       d="M 0.40124746,0.51180818 H 0.21419728 c -0.006148,0.0213595 -0.0101142,0.04327 -0.0139225,0.0655998 h 0.096339 0.0820322 0.73092182 0.103515 0.073986 c -0.00382,-0.0223178 -0.00874,-0.0442283 -0.014872,-0.0655998"
+       id="path57"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+    <path
+       d="M 1.2160096,0.7842462 H 1.1124947 0.38158413 0.30347328 0.20026344 c 0.003707,0.0223178 0.007922,0.0442164 0.0139677,0.0655998 h 0.18993187 0.68575279 0.1125781 0.073319 c 0.00603,-0.0213714 0.010905,-0.04327 0.014623,-0.0655998 z"
+       id="path59"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+  </g>
+</svg>


### PR DESCRIPTION
- This was copied here https://github.com/eclipse-pde/eclipse.pde/blob/master/apitools/org.eclipse.pde.api.tools.ui/icons/full/obj16/eclipse16.svg
- The SVG is also missing here https://github.com/eclipse-platform/eclipse.platform.images/tree/master/org.eclipse.images/eclipse-svg/org.eclipse.pde.ui/icons/etool16

https://github.com/eclipse-pde/eclipse.pde/issues/1766