### PR TITLE
Change path for missing svgs

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -672,7 +672,7 @@
    <extension
          point="org.eclipse.debug.ui.launchConfigurationTypeImages">
       <launchConfigurationTypeImage
-            icon="$nl$/icons/etool16/eclipse.svg"
+            icon="$nl$/icons/etool16/eclipse.png"
             configTypeID="org.eclipse.pde.ui.RuntimeWorkbench"
             id="org.eclipse.pde.ui.runtimeWorkbenchLaunchImage">
       </launchConfigurationTypeImage>
@@ -773,7 +773,7 @@
       <shortcut
             class="org.eclipse.pde.ui.launcher.EclipseLaunchShortcut"
             helpContextId="org.eclipse.pde.doc.user.launcher_eclipse_application"
-            icon="$nl$/icons/etool16/eclipse.svg"
+            icon="$nl$/icons/etool16/eclipse.png"
             id="org.eclipse.pde.ui.runtimeWorkbenchShortcut"
             label="%launcher.shortcut.label"
             modes="run, debug">


### PR DESCRIPTION
This PR changes the path of missing icons that were falsely changed in https://github.com/eclipse-pde/eclipse.pde/pull/1734.

The SVGs are not yet available.

Contributes to https://github.com/eclipse-pde/eclipse.pde/issues/1766.

I don't know if the issue is fixed completely by this.