### PR TITLE
Created buttons for PluginVersionPart to increment the exported version

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3351,6 +3351,10 @@ public class PDEUIMessages extends NLS {
 
 	public static String PluginVersionPart_groupTitle;
 	public static String PluginVersionPart_buttonTitle;
+	public static String PluginVersionPart_incrementTitle;
+    public static String PluginVersionPart_bumpMajor;
+    public static String PluginVersionPart_bumpMinor;
+    public static String PluginVersionPart_bumpMicro;
 
 	public static String FilteredPluginArtifactsSelectionDialog_title;
 	public static String FilteredPluginArtifactsSelectionDialog_message;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/PluginVersionPart.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/PluginVersionPart.java
@@ -288,6 +288,38 @@ public class PluginVersionPart {
 		fMinVersionText = new Text(parent, SWT.SINGLE | SWT.BORDER);
 		fMinVersionText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		fMinVersionText.setEnabled(editable);
+
+		if (!fRangeAllowed) {
+			Label incrLabel = new Label(parent, SWT.NONE);
+			incrLabel.setText(PDEUIMessages.PluginVersionPart_incrementTitle);
+			incrLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+
+			Composite btnBar = new Composite(parent, SWT.NONE);
+			btnBar.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+			GridLayout btnBarLayout = new GridLayout(3, true);
+			btnBarLayout.marginWidth = 0;
+			btnBar.setLayout(btnBarLayout);
+
+			Button majorBtn = new Button(btnBar, SWT.PUSH);
+			majorBtn.setText(PDEUIMessages.PluginVersionPart_bumpMajor);
+			majorBtn.setEnabled(editable);
+			majorBtn.addListener(SWT.Selection, e -> bumpVersion(Type.MAJOR));
+			majorBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+			Button minorBtn = new Button(btnBar, SWT.PUSH);
+			minorBtn.setText(PDEUIMessages.PluginVersionPart_bumpMinor);
+			minorBtn.setEnabled(editable);
+			minorBtn.addListener(SWT.Selection, e -> bumpVersion(Type.MINOR));
+			minorBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+			Button microBtn = new Button(btnBar, SWT.PUSH);
+			microBtn.setText(PDEUIMessages.PluginVersionPart_bumpMicro);
+			microBtn.setEnabled(editable);
+			microBtn.addListener(SWT.Selection, e -> bumpVersion(Type.MICRO));
+			microBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		}
+
 	}
 
 	public void preloadFields() {
@@ -454,4 +486,35 @@ public class PluginVersionPart {
 	protected String getGroupText() {
 		return PDEUIMessages.DependencyPropertiesDialog_groupText;
 	}
+	
+	private enum Type {
+        MAJOR, MINOR, MICRO
+    }
+
+    private void bumpVersion(Type type) {
+        String target;
+        try {
+            Version v = new Version(fMinVersionText.getText().trim());
+            int maj = v.getMajor(), min = v.getMinor(), mic = v.getMicro();
+            switch (type) {
+                case MAJOR:
+                    maj++;
+                    min = 0;
+                    mic = 0;
+                    break;
+                case MINOR:
+                    min++;
+                    mic = 0;
+                    break;
+                case MICRO:
+                    mic++;
+                    break;
+            }
+            target = new Version(maj, min, mic).toString();
+        } catch (IllegalArgumentException e) {
+            target = "1.0.0"; //$NON-NLS-1$
+        }
+        setVersion(target);
+        preloadFields();
+    }
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2562,6 +2562,10 @@ AntGeneratingExportWizard_1=The following projects contain build.xml files that 
 AntGeneratingExportWizard_2=Always overwrite existing build.xml files
 PluginVersionPart_groupTitle=Available versions to match
 PluginVersionPart_buttonTitle=Match
+PluginVersionPart_bumpMajor=Major
+PluginVersionPart_bumpMinor=Minor
+PluginVersionPart_bumpMicro=Micro
+PluginVersionPart_incrementTitle=Increment:
 FilteredPluginArtifactsSelectionDialog_title=Open Plug-in Artifact
 FilteredPluginArtifactsSelectionDialog_message=&Select an artifact to open (? = any character, * = any string):
 FilteredPluginArtifactsSelectionDialog_searching=Searching...


### PR DESCRIPTION
Original Issue: [#1561 ](https://github.com/eclipse-pde/eclipse.pde/issues/1561)

My team and I created three additional buttons that will allow for incrementing of the major, minor, and micro versions of an exported package by 1. We did this by:
- Defining Strings for each of the text properties attached to these buttons in [PDEUIMessages.java](https://github.com/Shyesta/eclipse.pde/blob/master/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java)
- Attaching values to the defined Strings at [pderesources.properties](https://github.com/Shyesta/eclipse.pde/blob/master/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties)
- Adding buttons to [PluginVersionPart.java](https://github.com/Shyesta/eclipse.pde/blob/master/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/PluginVersionPart.java) that have all relevant text and layout properties.

These changes can be viewed in Eclipse by building the project with all dependencies, creating a plugin project with a plugin template, entering the Runtime section, and then viewing the properties of a plugin.

One thing my team and I noticed was that the versions of these exported packages are not validated, meaning we could enter a clearly incorrect version number like 10000.0.0 and it would still apply. This validation could be a potential enhancement made in the future.

Here is a preview of the changes made: 

![image](https://github.com/user-attachments/assets/4529baee-e2d8-49f0-ba0a-d9bf813676e1)
