### PR TITLE
Adds more keywords to the OSGi declarative service preference page

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/OSGI-INF/l10n/bundle.properties
+++ b/ds/org.eclipse.pde.ds.annotations/OSGI-INF/l10n/bundle.properties
@@ -13,7 +13,7 @@
 ###############################################################################
 Bundle-Vendor = Eclipse.org
 Bundle-Name = Declarative Services Annotations Support
-keyword.label = ds
+keyword.label = ds, OSGi, declarative service
 property.page.name = DS Annotations
 preference.page.name = DS Annotations
 problem.marker.name = DS Annotation Problem


### PR DESCRIPTION
Adds OSGi and declarative service to the key words for the preference page to make it easier to find this setting.