### PR TITLE
Quick fix to add available matching version

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
@@ -1099,7 +1099,9 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 		int severity = CompilerFlags.getFlag(fProject, CompilerFlags.P_MISSING_VERSION_REQ_BUNDLE);
 		if (severity != CompilerFlags.IGNORE && versionRange == null) {
 			VirtualMarker marker = report(NLS.bind(PDECoreMessages.BundleErrorReporter_MissingVersion, element.getValue()),
-					getPackageLine(header, element), severity, PDEMarkerFactory.CAT_OTHER);
+					getPackageLine(header, element), severity, PDEMarkerFactory.M_MISSINGVERSION_REQ_BUNDLE,
+					PDEMarkerFactory.CAT_OTHER);
+			marker.setAttribute("bundleId", element.getValue()); //$NON-NLS-1$
 			addMarkerAttribute(marker,PDEMarkerFactory.compilerKey, CompilerFlags.P_MISSING_VERSION_REQ_BUNDLE);
 		}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
@@ -76,6 +76,8 @@ public class PDEMarkerFactory {
 	public static final int M_EXEC_ENV_TOO_LOW = 0x1029; // other problem
 	public static final int M_CONFLICTING_AUTOMATIC_MODULE = 0x1030; // other
 																		// problem
+	public static final int M_MISSINGVERSION_REQ_BUNDLE = 0x1031; // other
+																	// problem
 
 	// build properties fixes
 	public static final int B_APPEND_SLASH_FOLDER_ENTRY = 0x2001;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3425,5 +3425,6 @@ public class PDEUIMessages extends NLS {
 	public static String ProjectUpdateChange_convert_build_to_bnd;
 	public static String ProjectUpdateChange_set_pde_preference;
 
-}
+	public static String AddMatchingVersion_RequireBundle;
 
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
@@ -147,6 +147,9 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 		case PDEMarkerFactory.M_CONFLICTING_AUTOMATIC_MODULE:
 			return new IMarkerResolution[] {
 					new RemoveRedundantAutomaticModuleHeader(AbstractPDEMarkerResolution.REMOVE_TYPE, marker) };
+		case PDEMarkerFactory.M_MISSINGVERSION_REQ_BUNDLE:
+			return new IMarkerResolution[] {
+					new VersionMatchResolution(AbstractPDEMarkerResolution.CREATE_TYPE, marker) };
 		}
 		return NO_RESOLUTIONS;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/VersionMatchResolution.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/VersionMatchResolution.java
@@ -1,0 +1,45 @@
+package org.eclipse.pde.internal.ui.correction;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.core.text.bundle.Bundle;
+import org.eclipse.pde.internal.core.text.bundle.BundleModel;
+import org.eclipse.pde.internal.core.text.bundle.RequireBundleHeader;
+import org.eclipse.pde.internal.core.text.bundle.RequireBundleObject;
+import org.eclipse.pde.internal.core.util.VersionUtil;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.osgi.framework.Constants;
+
+public class VersionMatchResolution extends AbstractManifestMarkerResolution {
+	public VersionMatchResolution(int type, IMarker marker) {
+		super(type, marker);
+	}
+
+	@Override
+	protected void createChange(BundleModel model) {
+		String bundleId = marker.getAttribute("bundleId", (String) null); //$NON-NLS-1$
+		Bundle bundle = (Bundle) model.getBundle();
+		RequireBundleHeader header = (RequireBundleHeader) bundle.getManifestHeader(Constants.REQUIRE_BUNDLE);
+		if (header != null) {
+			RequireBundleObject[] requiredBundles = header.getRequiredBundles();
+			for (int i = 0; i < requiredBundles.length; i++) {
+				if (bundleId.equals(requiredBundles[i].getId())) {
+					IPluginModelBase modelBase = PluginRegistry.findModel(bundleId);
+					String version = null;
+					if (modelBase != null) {
+						version = VersionUtil
+								.computeInitialPluginVersion(modelBase.getBundleDescription().getVersion().toString());
+						requiredBundles[i].setVersion(version);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public String getLabel() {
+		return PDEUIMessages.AddMatchingVersion_RequireBundle;
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1299,6 +1299,7 @@ UpdateClasspathResolution_label=Update the classpath and compliance settings
 UpdateExecutionEnvironment_label=Update the execution environment based on JRE on the classpath
 UpdateClasspathJob_task = Update classpaths...
 UpdateClasspathJob_title = Updating Plug-in Classpaths
+AddMatchingVersion_RequireBundle = Add available matching version
 
 RuntimeWorkbenchShortcut_title=Select Configuration
 RuntimeWorkbenchShortcut_select_debug=Select a launch configuration to debug:


### PR DESCRIPTION
This is to provide a quick fix for adding the available matching version for Required bundles in MANIFEST.MF warning.
Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/1623

Attaching the screenshot for the quick fix:

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/9ac462a4-c3e5-44c9-85dd-f5949a75f7d7" />

After applying the version match quick fix:

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/34cbb9c9-157d-4924-b431-3e33255ccedc" />
