### PR TITLE
Add version bumps for 4.37

### DIFF
--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: org.eclipse.pde.build.tests;singleton:=true
-Bundle-Version: 1.4.800.qualifier
+Bundle-Version: 1.4.900.qualifier
 Bundle-Activator: org.eclipse.pde.build.tests.Activator
 Export-Package: org.eclipse.pde.build.internal.tests;x-internal:=true,
  org.eclipse.pde.build.internal.tests.ant;x-internal:=true,

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -10,7 +10,7 @@
 		<version>4.37.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.pde.build.tests</artifactId>
-	<version>1.4.800-SNAPSHOT</version>
+	<version>1.4.900-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>

--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde"
       label="%featureName"
-      version="3.16.300.qualifier"
+      version="3.16.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde;singleton:=true
-Bundle-Version: 3.13.3100.qualifier
+Bundle-Version: 3.13.3200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde/pom.xml
+++ b/ui/org.eclipse.pde/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde</artifactId>
-  <version>3.13.3100-SNAPSHOT</version>
+  <version>3.13.3200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>


### PR DESCRIPTION
This just adds a dummy change to provoke the automated version-bumps.
Once they are applied I plan to update the PR and remove the dummy commit so that only the version bump commit remains.