### PR TITLE
Add SVG support to ImageBrowser

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/AbstractRepository.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/AbstractRepository.java
@@ -22,10 +22,10 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.SequencedMap;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -45,7 +45,7 @@ import org.eclipse.swt.graphics.ImageData;
 
 public abstract class AbstractRepository extends Job {
 
-	protected List<ImageElement> mElementsCache = new LinkedList<>();
+	private SequencedMap<String, ImageElement> mElementsCache = new LinkedHashMap<>();
 
 	private final IImageTarget mTarget;
 
@@ -55,7 +55,7 @@ public abstract class AbstractRepository extends Job {
 		mTarget = target;
 	}
 
-	private static final String[] KNOWN_EXTENSIONS = new String[] {".gif", ".png"}; //$NON-NLS-1$ //$NON-NLS-2$
+	private static final String[] KNOWN_EXTENSIONS = new String[] { ".gif", ".png", ".svg" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 	@Override
 	protected synchronized IStatus run(IProgressMonitor monitor) {
@@ -69,7 +69,7 @@ public abstract class AbstractRepository extends Job {
 				}
 			} else {
 				// return 1 image from cache
-				mTarget.notifyImage(mElementsCache.remove(0));
+				mTarget.notifyImage(mElementsCache.sequencedValues().removeFirst());
 			}
 		}
 
@@ -77,7 +77,13 @@ public abstract class AbstractRepository extends Job {
 	}
 
 	public synchronized void clearCache() {
-		mElementsCache.clear();
+		if (mElementsCache != null) {
+			mElementsCache.clear();
+		}
+	}
+
+	public ImageElement getImageElement(String key) {
+		return mElementsCache.get(key);
 	}
 
 	protected abstract boolean populateCache(IProgressMonitor monitor);
@@ -211,6 +217,6 @@ public abstract class AbstractRepository extends Job {
 	}
 
 	protected void addImageElement(ImageElement element) {
-		mElementsCache.add(element);
+		mElementsCache.put(element.getPath(), element);
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/TargetPlatformRepository.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/TargetPlatformRepository.java
@@ -122,9 +122,7 @@ public class TargetPlatformRepository extends AbstractRepository {
 			fBundles.clear();
 			fBundles = null;
 		}
-		if (mElementsCache != null) {
-			mElementsCache.clear();
-		}
+		clearCache();
 		return Status.OK_STATUS;
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/WorkspaceRepository.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/repositories/WorkspaceRepository.java
@@ -118,9 +118,7 @@ public class WorkspaceRepository extends AbstractRepository {
 			fProjects.clear();
 			fProjects = null;
 		}
-		if (mElementsCache != null) {
-			mElementsCache.clear();
-		}
+		clearCache();
 		return Status.OK_STATUS;
 	}
 


### PR DESCRIPTION
This PR enables the display of SVGs in the `ImageBrowser`. 

When both a PNG and an SVG version of an icon are present, only the SVG will be shown.
To allow this behavior a new filter `PNGReplacementFilter` is introduced which decides depending on the icons in the cache (future icons) and existing filters if a PNG should be added or suppressed. If an SVG with the same path exists in the cache and if it passes all active filters the PNG will be discarded.

Using the existing text pattern filter to only view specific icons (e.g. "*.png" for only PNGs) continues to work as expected with this implementation showing only PNGs for all available icons. 

For this change to work a new public method `public getElementsCache()` is added to `AbstractRepository`. This should be no problem as the package is marked as internal. 

This change follows the recommeded behaviour for the `ImageBrowser` regarding SVGs by @HeikoKlare in this [comment](https://github.com/eclipse-pde/eclipse.pde/issues/1722#issuecomment-2830868565).

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1722.