### PR TITLE
Support selection of MANIFEST.MF file in the ResolutionView

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Generic UI components related to BND
 Bundle-SymbolicName: org.eclipse.pde.bnd.ui;singleton:=true
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.bnd.ui.autocomplete;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.plugins;x-internal:=true,

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/tasks/ManifestCapReqLoader.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/tasks/ManifestCapReqLoader.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+* This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+*******************************************************************************/
+package org.eclipse.pde.bnd.ui.tasks;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Manifest;
+
+import org.eclipse.pde.bnd.ui.model.resolution.RequirementWrapper;
+import org.osgi.resource.Capability;
+
+import aQute.bnd.osgi.resource.ResourceBuilder;
+
+/**
+ * Using a manifest file supply its cap and req
+ */
+public class ManifestCapReqLoader implements CapReqLoader {
+
+	private File manifestFile;
+	private ResourceCapReqLoader resourceCapReqLoader;
+
+	public ManifestCapReqLoader(File manifestFile) {
+		this.manifestFile = manifestFile;
+	}
+
+	@Override
+	public synchronized void close() throws IOException {
+		if (resourceCapReqLoader != null) {
+			resourceCapReqLoader.close();
+			resourceCapReqLoader = null;
+		}
+	}
+
+	@Override
+	public String getShortLabel() {
+		return manifestFile.getName();
+	}
+
+	@Override
+	public String getLongLabel() {
+		return manifestFile.getAbsolutePath();
+	}
+
+	@Override
+	public Map<String, List<Capability>> loadCapabilities() throws Exception {
+		loadManifest();
+		return loadManifest().loadCapabilities();
+	}
+
+	@Override
+	public Map<String, List<RequirementWrapper>> loadRequirements() throws Exception {
+		return loadManifest().loadRequirements();
+	}
+
+	private synchronized ResourceCapReqLoader loadManifest() throws IOException {
+		if (resourceCapReqLoader == null) {
+			Manifest manifest;
+			try (FileInputStream stream = new FileInputStream(manifestFile)) {
+				manifest = new Manifest(stream);
+			}
+			ResourceBuilder builder = new ResourceBuilder();
+			builder.addManifest(manifest);
+			resourceCapReqLoader = new ResourceCapReqLoader(builder.build());
+		}
+		return resourceCapReqLoader;
+	}
+
+}


### PR DESCRIPTION
Currently if one selects a MANIFEST.MF file nothing is shown in the ResolutionView but actually a manifest is what actually is a set of requirements and capabilities in an OSGi framework.

This now adds support for displaying a MANIFEST.MF in the ResolutionView by converting it into a Resource first and the use the existing ResourceCapReqLoader.

![grafik](https://github.com/user-attachments/assets/f0181306-5c28-4f92-9da7-daee5b661b5a)

FYI @chrisrueger 

See:
- https://github.com/eclipse-pde/eclipse.pde/issues/1818