### PR TITLE
Use more generic ResourceProvider instead of RepositoryResourceElement

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/model/repo/ResourceProvider.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/model/repo/ResourceProvider.java
@@ -15,6 +15,13 @@ package org.eclipse.pde.bnd.ui.model.repo;
 
 import org.osgi.resource.Resource;
 
+/**
+ * Interface implemented by objects that can provide a resource
+ */
 public interface ResourceProvider {
+
+	/**
+	 * @return the resource associated with this object
+	 */
 	Resource getResource();
 }

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/resolution/ResolutionView.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/resolution/ResolutionView.java
@@ -69,7 +69,7 @@ import org.eclipse.pde.bnd.ui.FilterPanelPart;
 import org.eclipse.pde.bnd.ui.HelpButtons;
 import org.eclipse.pde.bnd.ui.Resources;
 import org.eclipse.pde.bnd.ui.internal.PartAdapter;
-import org.eclipse.pde.bnd.ui.model.repo.RepositoryResourceElement;
+import org.eclipse.pde.bnd.ui.model.repo.ResourceProvider;
 import org.eclipse.pde.bnd.ui.model.resolution.CapReqMapContentProvider;
 import org.eclipse.pde.bnd.ui.model.resolution.CapabilityLabelProvider;
 import org.eclipse.pde.bnd.ui.model.resolution.RequirementWrapper;
@@ -647,17 +647,21 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 		if (loader != null) {
 			return loader;
 		}
-		if (element instanceof RepositoryResourceElement) {
-			Resource resource = ((RepositoryResourceElement) element).getResource();
+		ResourceProvider resourceProvider = Adapters.adapt(element, ResourceProvider.class);
+		if (resourceProvider != null) {
+			return new ResourceCapReqLoader(resourceProvider.getResource());
+		}
+		Resource resource = Adapters.adapt(element, Resource.class);
+		if (resource != null) {
 			return new ResourceCapReqLoader(resource);
 		}
 		File file = Adapters.adapt(element, File.class);
 		if (file != null) {
 			return getLoaderForFile(file);
 		}
-		IResource resource = Adapters.adapt(element, IResource.class);
-		if (resource != null) {
-			IPath location = resource.getLocation();
+		IResource eclipseResource = Adapters.adapt(element, IResource.class);
+		if (eclipseResource != null) {
+			IPath location = eclipseResource.getLocation();
 			if (location != null) {
 				return getLoaderForFile(location.toFile());
 			}


### PR DESCRIPTION
Currently the ResolutionView tries to adapt to the special class RepositoryResourceElement but it does not really need that specific one. That leads to the situation that other elements (for example RepositoryBundle) are not handled for this case and are later tried to be converted in a much more complex way (e.g. by using a file).

This now changes the code to use the base interface ResourceProvider what can cover a lot more use-cases, and the implementors of such interface probably know best how to fetch a resource. Additionally another step is taken here to adapt the element itself to a resource before falling back to file based approaches.

FYI @chrisrueger 

See also
- https://github.com/eclipse-pde/eclipse.pde/issues/1818