### PR TITLE
Filter Feature Imports according to their specified filter property

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeatureImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ifeature/IFeatureImport.java
@@ -15,6 +15,7 @@ package org.eclipse.pde.internal.core.ifeature;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.pde.core.plugin.IPluginReference;
+import org.eclipse.pde.core.target.ITargetDefinition;
 
 public interface IFeatureImport extends IFeatureObject, IPluginReference {
 	String P_TYPE = "type"; //$NON-NLS-1$
@@ -36,4 +37,6 @@ public interface IFeatureImport extends IFeatureObject, IPluginReference {
 	String getFilter();
 
 	void setFilter(String filter) throws CoreException;
+
+	boolean matchesEnvironment(ITargetDefinition target);
 }

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -207,7 +207,7 @@ public class BundleLauncherHelper {
 			if (addRequirements) {
 				IFeatureImport[] featureImports = feature.getImports();
 				for (IFeatureImport featureImport : featureImports) {
-					if (featureImport.getType() == IFeatureImport.PLUGIN) {
+					if (featureImport.getType() == IFeatureImport.PLUGIN && featureImport.matchesEnvironment(target)) {
 						IPluginModelBase plugin = getRequiredPlugin(featureImport.getId(), featureImport.getVersion(), featureImport.getMatch(), pluginResolution);
 						if (plugin != null) {
 							launchPlugins.add(plugin);


### PR DESCRIPTION
If a feature currently uses a 'filter' on an imported plugin this is not considered by PDE and possibly always included. This then leads to the situation that the product launch validation complains because the filter does not match and when running such a launch OSGi prints an error for this plugin as well.

This now checks if the plugin has a filter defined and only add it if it matches.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/1820