### PR TITLE
[target] Remove Content and Environment Section from the Definition page

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/DefinitionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/DefinitionPage.java
@@ -19,21 +19,14 @@ import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.editor.FormLayoutFactory;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.SWTException;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.FormPage;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.events.IHyperlinkListener;
-import org.eclipse.ui.forms.widgets.ExpandableComposite;
-import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
-import org.eclipse.ui.forms.widgets.Section;
-import org.eclipse.ui.forms.widgets.TableWrapData;
 
 /**
  * First page in the target definition editor.  Allows for editing of the name
@@ -84,47 +77,6 @@ public class DefinitionPage extends FormPage implements IHyperlinkListener {
 		body.setLayout(FormLayoutFactory.createFormGridLayout(true, 1));
 		managedForm.addPart(new InformationSection(this, body));
 		managedForm.addPart(new LocationsSection(this, body));
-		Composite linkComposite = toolkit.createComposite(body);
-		linkComposite.setLayout(FormLayoutFactory.createFormGridLayout(true, 2));
-		linkComposite.setLayoutData(new GridData(GridData.FILL_BOTH));
-		createContentsSection(linkComposite, toolkit);
-		createEnvironmentSection(linkComposite, toolkit);
-	}
-
-	private void createContentsSection(Composite parent, FormToolkit toolkit) {
-		Section section = createSection(parent, toolkit, PDEUIMessages.OverviewPage_contentTitle);
-		createText(section, PDEUIMessages.OverviewPage_contentDescription, toolkit);
-	}
-
-	private void createEnvironmentSection(Composite parent, FormToolkit toolkit) {
-		Section section = createSection(parent, toolkit, PDEUIMessages.OverviewPage_environmentTitle);
-		createText(section, PDEUIMessages.OverviewPage_environmentDescription, toolkit);
-	}
-
-	private Section createSection(Composite parent, FormToolkit toolkit, String title) {
-		Section section = toolkit.createSection(parent, ExpandableComposite.TITLE_BAR);
-		section.clientVerticalSpacing = FormLayoutFactory.SECTION_HEADER_VERTICAL_SPACING;
-		section.setText(title);
-		section.setLayout(FormLayoutFactory.createClearTableWrapLayout(false, 1));
-		section.setLayoutData(new GridData(GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_BEGINNING));
-		return section;
-	}
-
-	private FormText createText(Section section, String content, FormToolkit toolkit) {
-		Composite container = toolkit.createComposite(section, SWT.NONE);
-		container.setLayout(FormLayoutFactory.createSectionClientTableWrapLayout(false, 1));
-		section.setClient(container);
-		FormText text = toolkit.createFormText(container, true);
-		try {
-			text.setText(content, true, false);
-		} catch (SWTException e) {
-			text.setText(e.getMessage(), false, false);
-		}
-		TableWrapData data = new TableWrapData(TableWrapData.FILL_GRAB);
-		data.maxWidth = 250;
-		text.setLayoutData(data);
-		text.addHyperlinkListener(this);
-		return text;
 	}
 
 	@Override


### PR DESCRIPTION
Currently the Target-Editor contains two sections "Content" and "Environment" that roughly explain what these things can be used for if one clicks on the corresponding tabs. In practice, these information is barley usable for todays work an users uncertain would better consult the Eclipse Help or read a tutorial on PDE. More worse, these clutter the UI and steal valuable space not available for the actual content of the location leading to scrollbars appearing.

This now removes the sections entirely ro reclaim the space for something the user is actually interested in.

## Before
![grafik](https://github.com/user-attachments/assets/64cc1db8-14ab-4c1e-830c-433a87b4493f)

## After
![grafik](https://github.com/user-attachments/assets/2f9fd1e4-255f-47e4-81b3-5ef3a6d9ecb9)
