### PR TITLE
Remove dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Project description:
 --------------------
 
 The PDE project the Eclipse tooling to develop plug-ins and OSGI bundles.  
-Website: https://www.eclipse.org/pde/
-
-- https://projects.eclipse.org/projects/eclipse.pde
+Website: https://projects.eclipse.org/projects/eclipse.pde
 
 How to contribute:
 --------------------


### PR DESCRIPTION
https://www.eclipse.org/pde/ is returning 404 (and has been for a couple months according to the Wayback Machine). 

https://projects.eclipse.org/projects/eclipse.pde looks to be the current homepage for the project, is that correct? If so I'll search for other instances of the old link and update them accordingly.