### PR TITLE
Add OSGi test dependencies feature for target consumption

### DIFF
--- a/features/org.eclipse.pde.osgitest.dependencies.feature/.project
+++ b/features/org.eclipse.pde.osgitest.dependencies.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.pde.osgitest.dependencies.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.pde.osgitest.dependencies.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.pde.osgitest.dependencies.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.pde.osgitest.dependencies.feature/build.properties
+++ b/features/org.eclipse.pde.osgitest.dependencies.feature/build.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2025 Christoph Läubrich and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Christoph Läubrich - initial API and implementation
+###############################################################################
+bin.includes = feature.properties,\
+               feature.xml

--- a/features/org.eclipse.pde.osgitest.dependencies.feature/feature.properties
+++ b/features/org.eclipse.pde.osgitest.dependencies.feature/feature.properties
@@ -1,0 +1,28 @@
+###############################################################################
+# Copyright (c) 2025 Christoph Läubrich and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     Christoph Läubrich - initial API and implementation
+###############################################################################
+featureName=OSGi Test Dependencies Feature
+providerName=Eclipse.org
+description=Feature to consume OSGi Test (https://github.com/osgi/osgi-test/) dependencies in target platforms using an Eclipse Release. 
+copyright=\
+Copyright (c) 2025 Christoph Läubrich and others.\n\
+\n\
+This program and the accompanying materials\n\
+are made available under the terms of the Eclipse Public License 2.0\n\
+which accompanies this distribution, and is available at\n\
+https://www.eclipse.org/legal/epl-2.0/\n\
+\n\
+SPDX-License-Identifier: EPL-2.0\n\
+\n\
+Contributors:\n\
+    Christoph Läubrich - initial API and implementation\n

--- a/features/org.eclipse.pde.osgitest.dependencies.feature/feature.xml
+++ b/features/org.eclipse.pde.osgitest.dependencies.feature/feature.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.pde.osgitest.dependencies.feature"
+      label="%featureName"
+      version="1.0.0.qualifier"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description url="https://github.com/eclipse-osgi-technology/osgi-test">
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <requires>
+      <import plugin="org.osgi.test.common"/>
+      <import plugin="org.osgi.test.junit5"/>
+      <import plugin="org.osgi.test.junit5.cm"/>
+      <import plugin="org.osgi.test.junit4"/>
+      <import plugin="org.osgi.test.assertj.framework"/>
+      <import plugin="org.osgi.test.assertj.log"/>
+      <import plugin="org.osgi.test.assertj.promise"/>
+   </requires>
+
+</feature>


### PR DESCRIPTION
Currently consuming OSGi test dependencies in PDE is a bit cumbersome, providing a feature for easier consumption would help users to adopt this powerful technology and enables advanced use-cases in PDE.

This is a split-up from
- https://github.com/eclipse-pde/eclipse.pde/pull/1619

and could already be independently be used.