### PR TITLE
Print framework state on failing bundles

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.junit.runtime; singleton:=true
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.8.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.4.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -235,7 +235,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 			//if this is a junit container project it means a user can use additional classes (from the junit container and possible other) that
 			//are not required to be imported, we compute a fragment manifest here to add additional imports ...
 			try (PdeProjectAnalyzer analyzer = new PdeProjectAnalyzer(javaProject.getProject(), true)) {
-				analyzer.setImportPackage("*;resolution:=optional"); //$NON-NLS-1$
+				analyzer.setImportPackage("*"); //$NON-NLS-1$
 				String bsn = testPlugin.getId() + "-additional-test-probe-imports"; //$NON-NLS-1$
 				analyzer.setBundleSymbolicName(bsn);
 				analyzer.set(Constants.FRAGMENT_HOST, testPlugin.getId());


### PR DESCRIPTION
If plugin test do not work as expected the user is currently quite blind. At best there is an exception in the log about a failing bundle, at worst there is only a message "No tests found" and then nothing is executed at all.

This now first checks if there are any unresolved plugins and print the current bundles and their state if anything is failing, and also makes the additional manifest to use non optional imports as otherwise things are possibly missing.