### PR TITLE
Add getAdditionalEntries to IClasspathContributor

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Added new method to IBuildEntry
+https://github.com/eclipse-pde/eclipse.pde/issues/1846

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IClasspathContributor2.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/IClasspathContributor2.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.pde.core;
+
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.osgi.resource.Resource;
+
+/**
+ * Extension interface for {@link org.eclipse.pde.core.IClasspathContributor}.
+ * <p>
+ * This interface allows adding classpath entries after the classpath has been
+ * calculated.
+ * </p>
+ *
+ * @since 3.21
+ */
+public interface IClasspathContributor2 extends IClasspathContributor {
+
+	/**
+	 * Get any additional classpath entries to add to a project when its
+	 * classpath is first computed. The provided {@link BundleDescription}
+	 * describes the plug-in project that the classpath is being computed for.
+	 * The entries are added at the end of the calculation process. Additional
+	 * PDE model information can be obtained using
+	 * {@link PluginRegistry#findModel(Resource)}.
+	 *
+	 * @param project
+	 *            the bundle descriptor for the plug-in project having its
+	 *            classpath computed
+	 * @return additional classpath entries to add to the project at the end of
+	 *         the classpath calculation, possibly empty, must not be
+	 *         <code>null</code>
+	 * @since 3.21
+	 */
+	Stream<IClasspathEntry> getAdditionalEntries(BundleDescription project);
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -52,6 +52,7 @@ import org.eclipse.osgi.service.resolver.HostSpecification;
 import org.eclipse.osgi.service.resolver.ImportPackageSpecification;
 import org.eclipse.osgi.service.resolver.StateHelper;
 import org.eclipse.pde.core.IClasspathContributor;
+import org.eclipse.pde.core.IClasspathContributor2;
 import org.eclipse.pde.core.build.IBuild;
 import org.eclipse.pde.core.build.IBuildEntry;
 import org.eclipse.pde.core.build.IBuildModel;
@@ -259,6 +260,11 @@ class RequiredPluginsClasspathContainer {
 
 			addJunit5RuntimeDependencies(added, entries);
 			addImplicitDependencies(desc, added, entries);
+
+			// Add any additional library entries contributed via classpath
+			// contributor
+			entries.addAll(getClasspathContributors().filter(IClasspathContributor2.class::isInstance)
+					.map(IClasspathContributor2.class::cast).flatMap(cc -> cc.getAdditionalEntries(desc)).toList());
 
 		return entries;
 	}


### PR DESCRIPTION
Currently, it is only possible to add classpath entries at the beginning of the calculation process. However, in order to properly take AccessRule.IgnoreIfBetter into account from all other entries, it is necessary to add entries at the end of the calculation.

This PR introduces a new method that allows classpath contributors to append additional entries at the end of the calculation process, enabling more accurate handling of access rules.