### PR TITLE
Include fragments when computing dependencies for Extensible-API bundles

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -602,6 +602,7 @@ public class BundleLauncherHelper {
 				throw new IllegalStateException("Plugins have different TP state"); //$NON-NLS-1$
 			}
 			BundleDescription launchBundle = launchState.getFactory().createBundleDescription(bundle);
+			launchBundle.setUserObject(plugin);
 			if (!launchState.addBundle(launchBundle)) {
 				throw new IllegalStateException("Failed to add bundle to launch state: " + launchBundle); //$NON-NLS-1$
 			}


### PR DESCRIPTION
Currently there is an option to either include all fragments, or only non-test fragments. But there is some kind of special bundles (like SWT) that declare a custom 'Eclipse-ExtensibleAPI' header, these are handled special in the way that PDE attaches their fragments to the classpath of projects requiring these. This behavior is currently not reflected when computing required dependencies leading to ClassNotFoundException when launching them.

This now adds another check, that if such special bundle is found its fragments are considered when it is not a test bundle project.