### PR TITLE
Prevent mouse wheel from changing selection in product and application

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
@@ -231,7 +231,10 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 		fProductCombo.add(""); //$NON-NLS-1$
 		fProductCombo.addSelectionListener(
 				widgetSelectedAdapter(e -> getProduct().setProductId(fProductCombo.getSelection())));
-
+		fProductCombo.getControl().addListener(SWT.MouseWheel, event -> {
+			// Cancel the event to prevent default scrolling
+			event.doit = false;
+		});
 		Button button = toolkit.createButton(client, PDEUIMessages.ProductInfoSection_new, SWT.PUSH);
 		button.setEnabled(isEditable());
 		button.addSelectionListener(widgetSelectedAdapter(e -> handleNewDefinition()));
@@ -264,7 +267,10 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 		fAppCombo.add(""); //$NON-NLS-1$
 		fAppCombo.addSelectionListener(
 				widgetSelectedAdapter(e -> getProduct().setApplication(fAppCombo.getSelection())));
-
+		fProductCombo.getControl().addListener(SWT.MouseWheel, event -> {
+			// Cancel the event to prevent default scrolling
+			event.doit = false;
+		});
 		fAppCombo.getControl().setEnabled(isEditable());
 	}
 


### PR DESCRIPTION
combo

Disables mouse wheel scrolling on the product and application selection combo to avoid
accidental selection changes when the user scrolls over the control.

This improves usability when the combo is hovered during scroll operations, especially in scrollable containers.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/1854