### PR TITLE
Prevent mouse wheel from changing selection application

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
@@ -267,7 +267,7 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 		fAppCombo.add(""); //$NON-NLS-1$
 		fAppCombo.addSelectionListener(
 				widgetSelectedAdapter(e -> getProduct().setApplication(fAppCombo.getSelection())));
-		fProductCombo.getControl().addListener(SWT.MouseWheel, event -> {
+		fAppCombo.getControl().addListener(SWT.MouseWheel, event -> {
 			// Cancel the event to prevent default scrolling
 			event.doit = false;
 		});


### PR DESCRIPTION
Commit 863e7c4943731c776df56c88b75d4963effdd9c6 contained a copy and paste error (using fProductCombo instead of fAppCombo)