### PR TITLE
Add null check when getting fragment host wire provider

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -206,7 +206,9 @@ public class DependencyManager {
 					// to ensure it's added again below. In the subsequent
 					// processing this fragment's requirements will then also be
 					// considered (before it was discarded).
-					closure.remove(hostWire.getProvider());
+					if (hostWire.getProviderWiring() != null) {
+						closure.remove(hostWire.getProvider());
+					}
 				}
 			}
 


### PR DESCRIPTION
If the host is missing or does not build an NPE occurred (issue #1819)