### PR TITLE
Include Test Source folders when gathering unused dependencies

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
@@ -86,7 +86,7 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 			return;
 		}
 		Set<String> computedPackages;
-		try (PdeProjectAnalyzer analyzer = new PdeProjectAnalyzer(fModel.getUnderlyingResource().getProject(), false)) {
+		try (PdeProjectAnalyzer analyzer = new PdeProjectAnalyzer(fModel.getUnderlyingResource().getProject(), true)) {
 			analyzer.setImportPackage("*"); //$NON-NLS-1$
 			analyzer.calcManifest();
 			Packages imports = analyzer.getImports();


### PR DESCRIPTION
Currently if there are only test folders all dependencies are considered unused. While this is technically correct, the usage of test-fragments often is used to import additional requirements, so it seem more safe to not remove them.