### PR TITLE
Handle test projects that are using the default output location

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/PdeProjectAnalyzer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/PdeProjectAnalyzer.java
@@ -37,7 +37,7 @@ public class PdeProjectAnalyzer extends Analyzer {
 			IJavaProject javaProject = JavaCore.create(project);
 			IClasspathEntry[] classpath = javaProject.getResolvedClasspath(true);
 			for (IClasspathEntry cp : classpath) {
-				if (cp.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+				if (cp.getEntryKind() == IClasspathEntry.CPE_LIBRARY && (includeTest || !cp.isTest())) {
 					IPath path = cp.getPath();
 					File file = path.toFile();
 					if (file != null && file.getName().endsWith(".jar") && !file.getName().equals("jrt-fs.jar") //$NON-NLS-1$ //$NON-NLS-2$

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/PdeTestProjectJar.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/PdeTestProjectJar.java
@@ -38,7 +38,10 @@ public class PdeTestProjectJar extends PdeProjectJar {
 			for (IClasspathEntry cp : classpath) {
 				if (cp.getEntryKind() == IClasspathEntry.CPE_SOURCE && cp.isTest()) {
 					IPath location = cp.getOutputLocation();
-					if (location != null) {
+					if (location == null) {
+						IPath defaultOutputLocation = javaProject.getOutputLocation();
+						FileResource.addResources(this, workspaceRoot.getFolder(defaultOutputLocation), null);
+					} else {
 						IFolder otherOutputFolder = workspaceRoot.getFolder(location);
 						FileResource.addResources(this, otherOutputFolder, null);
 					}


### PR DESCRIPTION
If the only source folder in a project is a test folder it is allowed by JDT to use the standard output location. In such case currently nothing is added to the project jar.

This now checks for this case and also includes compile classfiles from there. It also makes sure that test-only classpath entries are not added if not include test is given.