### PR TITLE
Add implicit dependencies from the target

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -58,6 +58,7 @@ import org.eclipse.pde.core.build.IBuild;
 import org.eclipse.pde.core.build.IBuildEntry;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.target.NameVersionDescriptor;
 import org.eclipse.pde.internal.build.BundleHelper;
 import org.eclipse.pde.internal.build.IBuildPropertiesConstants;
 import org.eclipse.pde.internal.core.bnd.BndProjectManager;
@@ -275,6 +276,7 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 			}
 
 			addJunit5RuntimeDependencies(added, entries);
+			addImplicitDependencies(desc, added, entries);
 
 		} catch (CoreException e) {
 		}
@@ -638,6 +640,16 @@ public class RequiredPluginsClasspathContainer extends PDEClasspathContainer imp
 			}
 		} catch (CoreException e) {
 			return;
+		}
+	}
+
+	private void addImplicitDependencies(BundleDescription desc, Set<BundleDescription> added,
+			List<IClasspathEntry> entries) throws CoreException {
+		for (NameVersionDescriptor entry : DependencyManager.getImplicitDependencies()) {
+			String id = entry.getId();
+			if (id != null) {
+				addExtraModel(desc, added, entries, id);
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently if one defines implicit dependencies in the target these only getting added to the launch but not the project, this makes these quite hard to use. The best would be to make this feature more flexible to let the user choose if it is a runtime requirement or a compile dependency.

Unless we have this, it seems the best way is to add it in both cases as indicated in the help:

> The Implicit Dependencies section is used to manage the implicit
> dependencies of the target. Any plug-in marked as an implicit
> dependency will always be added as a required plug-in when PDE
> determines requirements.