### PR TITLE
Equinox Framework is required for plugin-test launches

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -67,6 +67,7 @@ import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.plugin.TargetPlatform;
+import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.ClasspathHelper;
 import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.ICoreConstants;
@@ -109,9 +110,12 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 				application = TargetPlatform.getDefaultApplication();
 			}
 			if (!IPDEConstants.CORE_TEST_APPLICATION.equals(application)) {
-				return RequirementHelper.getApplicationRequirements(application);
+				List<String> applicationRequirements = RequirementHelper.getApplicationRequirements(application);
+				List<String> list = new ArrayList<>(applicationRequirements);
+				list.add(IPDEBuildConstants.BUNDLE_OSGI);
+				return list;
 			}
-			return Collections.emptyList();
+			return List.of(IPDEBuildConstants.BUNDLE_OSGI);
 		});
 	}
 


### PR DESCRIPTION
Currently with the new feature to only include what is minimally required this can lead to the strange situation that the test fails to startup, if one then adds the org.eclipse.osgi to the bundle list it works without a problem.

This now adds the "org.eclipse.osgi" as a requirement for plugin-test launches as it is mandatory anyways.