### PR TITLE
Improve DeferredClasspathContainerInitializerJob.belongsTo

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -104,7 +104,7 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 
 		@Override
 		public boolean belongsTo(Object family) {
-			return family == PluginModelManager.class;
+			return family == PluginModelManager.class || family == ClasspathContainerInitializer.class;
 		}
 	}
 


### PR DESCRIPTION
- Add ClasspathContainerInitializer.class to the test for families in belongsTo to allow a client to wait for classpath container initialization without knowing or caring about PDE specifically.