### PR TITLE
Unify access to RequiredPluginsClasspathContainer and classpath updates

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.annotations/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.ds.annotations;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Activator: org.eclipse.pde.ds.internal.annotations.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.105.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSLibPluginModelListener.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSLibPluginModelListener.java
@@ -14,25 +14,17 @@
 package org.eclipse.pde.ds.internal.annotations;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import org.eclipse.core.resources.WorkspaceJob;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.jobs.ISchedulingRule;
-import org.eclipse.core.runtime.jobs.MultiRule;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.pde.core.plugin.ModelEntry;
+import org.eclipse.pde.internal.core.ClasspathComputer;
 import org.eclipse.pde.internal.core.IPluginModelListener;
 import org.eclipse.pde.internal.core.PluginModelDelta;
 import org.eclipse.pde.internal.core.PluginModelManager;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
 
 @SuppressWarnings("restriction")
 public class DSLibPluginModelListener implements IPluginModelListener {
@@ -114,50 +106,20 @@ public class DSLibPluginModelListener implements IPluginModelListener {
 			}
 		}
 
-			ArrayList<IJavaProject> toUpdate = new ArrayList<>(projects.size());
+		ArrayList<IProject> toUpdate = new ArrayList<>(projects.size());
 			if (!modelIds.isEmpty()) {
 				for (Map.Entry<IJavaProject, String> entry : projects.entrySet()) {
 					IJavaProject project = entry.getKey();
 					String modelId = entry.getValue();
 					if (modelIds.contains(modelId)) {
-						toUpdate.add(project);
+						toUpdate.add(project.getProject());
 					}
 				}
 			}
-
-			if (!toUpdate.isEmpty()) {
-				requestClasspathUpdate(toUpdate);
-			}
+			ClasspathComputer.requestClasspathUpdate(toUpdate);
 		}
 	}
 
-	private void requestClasspathUpdate(final Collection<IJavaProject> changedProjects) {
-		WorkspaceJob job = new WorkspaceJob(Messages.ProjectClasspathPreferenceChangeListener_jobName) {
-			@Override
-			public IStatus runInWorkspace(IProgressMonitor monitor) {
-				SubMonitor progress = SubMonitor.convert(monitor, Messages.DSAnnotationPreferenceListener_taskName,
-						changedProjects.size());
-				for (IJavaProject project : changedProjects) {
-					ProjectClasspathPreferenceChangeListener.updateClasspathContainer(project, progress.newChild(1));
-				}
-
-				return Status.OK_STATUS;
-			}
-		};
-
-		job.setSystem(true);
-
-		ISchedulingRule[] rules = changedProjects.stream().map(IJavaProject::getProject)
-				.toArray(size -> new ISchedulingRule[size]);
-		job.setRule(new MultiRule(rules));
-
-		Display display = Display.getCurrent();
-		if (display != null) {
-			PlatformUI.getWorkbench().getProgressService().showInDialog(display.getActiveShell(), job);
-		}
-
-		job.schedule();
-	}
 
 	public static void dispose() {
 		DSLibPluginModelListener instance = getInstance(false);

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ProjectClasspathPreferenceChangeListener.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ProjectClasspathPreferenceChangeListener.java
@@ -17,21 +17,10 @@ import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
-import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.pde.core.plugin.IPluginModelBase;
-import org.eclipse.pde.core.plugin.PluginRegistry;
-import org.eclipse.pde.internal.core.ClasspathUtilCore;
-import org.eclipse.pde.internal.core.PDECore;
-import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer;
 
-@SuppressWarnings("restriction")
 public class ProjectClasspathPreferenceChangeListener implements IPreferenceChangeListener, IResourceChangeListener {
 
 	private final IJavaProject project;
@@ -49,40 +38,6 @@ public class ProjectClasspathPreferenceChangeListener implements IPreferenceChan
 	public void preferenceChange(PreferenceChangeEvent event) {
 	}
 
-
-	static void updateClasspathContainer(IJavaProject project, IProgressMonitor monitor) {
-		if (monitor != null) {
-			monitor.beginTask(project.getElementName(), 1);
-		}
-
-		try {
-			if (monitor != null && monitor.isCanceled()) {
-				throw new OperationCanceledException();
-			}
-
-			ClasspathContainerInitializer initializer = JavaCore.getClasspathContainerInitializer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH.segment(0));
-			if (initializer != null && initializer.canUpdateClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, project)) {
-				IPluginModelBase model = PluginRegistry.findModel(project.getProject());
-				if (model != null) {
-					try {
-						initializer.requestClasspathContainerUpdate(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, project,
-								new RequiredPluginsClasspathContainer(model, ClasspathUtilCore.getBuild(model),
-										project.getProject()));
-					} catch (CoreException e) {
-						Activator.log(e);
-					}
-				}
-			}
-
-			if (monitor != null) {
-				monitor.worked(1);
-			}
-		} finally {
-			if (monitor != null) {
-				monitor.done();
-			}
-		}
-	}
 
 	@Override
 	public void resourceChanged(IResourceChangeEvent event) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core.bnd;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,15 +24,8 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.ICoreRunnable;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jdt.core.ClasspathContainerInitializer;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.pde.internal.core.ClasspathComputer;
 import org.eclipse.pde.internal.core.PDECore;
-import org.eclipse.pde.internal.core.PDECoreMessages;
-import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer;
 
 public class BndResourceChangeListener implements IResourceChangeListener {
 
@@ -62,35 +54,11 @@ public class BndResourceChangeListener implements IResourceChangeListener {
 						return true;
 					}
 				});
-				if (updateProjects.size() > 0) {
-					performClasspathUpdate(updateProjects);
-				}
+				ClasspathComputer.requestClasspathUpdate(updateProjects);
 			} catch (CoreException e) {
 				// can't do anything then...
 			}
 		}
-	}
-
-	private static void performClasspathUpdate(Collection<IProject> updateProjects) {
-		Job.create(PDECoreMessages.PluginModelManager_1, new ICoreRunnable() {
-
-			@Override
-			public void run(IProgressMonitor monitor) throws CoreException {
-				ClasspathContainerInitializer initializer = JavaCore
-						.getClasspathContainerInitializer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH.segment(0));
-				if (initializer == null) {
-					return;
-				}
-				for (IProject project : updateProjects) {
-					IJavaProject javaProject = JavaCore.create(project);
-					if (initializer.canUpdateClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, javaProject)) {
-							initializer.requestClasspathContainerUpdate(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH,
-								javaProject, new RequiredPluginsClasspathContainer(null, null, project));
-					}
-				}
-
-			}
-		}).schedule();
 	}
 
 }

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest.java
@@ -30,16 +30,15 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.internal.core.ClasspathComputer;
 import org.eclipse.pde.internal.core.MinimalState;
 import org.eclipse.pde.internal.core.PDECore;
-import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.ui.tests.util.ProjectUtils;
 import org.eclipse.pde.ui.tests.util.TargetPlatformUtil;
@@ -76,9 +75,9 @@ public class ClasspathResolutionTest {
 		IProject project = ProjectUtils.importTestProject("tests/projects/demoMissedSystemModulePackage");
 		project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
 		IJavaProject javaProject = JavaCore.create(project);
-		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(
-				PDECore.getDefault().getModelManager().findModel(project), project);
-		for (IClasspathEntry entry : container.getClasspathEntries()) {
+		IClasspathEntry[] classpathEntries = ClasspathComputer
+				.computeClasspathEntries(PDECore.getDefault().getModelManager().findModel(project), project);
+		for (IClasspathEntry entry : classpathEntries) {
 			if (entry.getPath().lastSegment().contains("org.w3c.dom.events")) {
 				fail(entry.getPath() + " erronesously present in container");
 			}
@@ -152,8 +151,7 @@ public class ClasspathResolutionTest {
 	private List<String> getRequiredPluginContainerEntries(IProject project) throws CoreException {
 		project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
 		IPluginModelBase model = PDECore.getDefault().getModelManager().findModel(project);
-		IClasspathContainer requiredPluginsClasspathContainer = new RequiredPluginsClasspathContainer(model, project);
-		return Arrays.stream(requiredPluginsClasspathContainer.getClasspathEntries()).map(IClasspathEntry::getPath)
+		return Arrays.stream(ClasspathComputer.computeClasspathEntries(model, project)).map(IClasspathEntry::getPath)
 				.map(IPath::lastSegment).toList();
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/RequiredPluginsContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/RequiredPluginsContainerPage.java
@@ -33,7 +33,6 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ClasspathComputer;
-import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
@@ -200,8 +199,7 @@ public class RequiredPluginsContainerPage extends WizardPage implements IClasspa
 			entry = ClasspathComputer.createContainerEntry();
 			IPluginModelBase model = PluginRegistry.findModel(javaProject.getProject());
 			if (model != null) {
-				IClasspathContainer container = new RequiredPluginsClasspathContainer(model, javaProject.getProject());
-				realEntries = container.getClasspathEntries();
+				realEntries = ClasspathComputer.computeClasspathEntries(model, javaProject.getProject());
 			}
 		} else {
 			try {


### PR DESCRIPTION
Currently there a many slightly different access to the RequiredPluginsClasspathContainer when performing an update for the classpath, this makes it quite hard to control what happens when. Also then different jobs are fired to update the classpath and this also creates a lot of boilerplate code.

This now do the following:
- make RequiredPluginsClasspathContainer package protected to limit its visibility and scope
- let all code use ClasspathComputer for its access and to request an update to the container.