### PR TITLE
Catch NoClassDefFoundError while locating sources

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/SourceLocationManager.java
@@ -323,7 +323,7 @@ public class SourceLocationManager implements ICoreConstants {
 		return getExtensions().locators.stream().map(locator -> {
 			try {
 				return locator.locator.locateSource(plugin);
-			} catch (RuntimeException e) {
+			} catch (RuntimeException | NoClassDefFoundError e) {
 				return null;
 			}
 		}).filter(Objects::nonNull).findFirst().orElse(null);


### PR DESCRIPTION
If the locator is unable to locate some sources due to a classlaoding problem this currently leads to an ugly exception window showing up.

This now adds NoClassDefFoundError to the catch clause to prevent annoy the user in such case.