### PR TITLE
Do checks inside the job and compute the classpath entries

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECoreMessages.java
@@ -281,6 +281,8 @@ public class PDECoreMessages extends NLS {
 
 	public static String BuildErrorReporter_SourceCompatibility;
 
+	public static String ClasspathComputer_failed;
+
 	public static String ClasspathHelper_BadFileLocation;
 
 	public static String ConvertSchemaToHTML_CannotFindIncludedSchema;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/pderesources.properties
@@ -222,6 +222,7 @@ FeatureExportOperation_runningPackagerScript=Running packager script
 FeatureExportOperation_workspaceBuildErrorsFoundDuringExport=Export completed successfully, but build problems were detected in the following required projects: {0}
 FeatureModelManager_initializingFeatureTargetPlatform=Initializing feature from target platform
 BaseExportTask_pdeExport=PDE Export
+ClasspathComputer_failed=Classpath Update failed
 ClasspathHelper_BadFileLocation=Could not determine absolute location of file: {0}
 ConvertSchemaToHTML_CannotFindIncludedSchema=Cannot find included schema ''{0}'' required by parent schema ''{1}''
 ConvertSchemaToHTML_InvalidAdditionalSearchPath=Invalid path found in additional search paths: {0}


### PR DESCRIPTION
Currently some checks are performed outside the update job, for example the model is fetched and the javanature. These values can change between submit the data to the job and it actually pick it up.

This now moves these check into the job itself and uses a concurrent queue to prevent the need for synchronized. Also results are collected inside a Map so if new update request are received in the meanwhile we discard the previous computed values.

Beside that, entries are now eagerly computed as they are required anyways when we set the classpath and we can catch problems that occur here instead of just swallow them.

Also the job now react to cancel request much better than before.