### PR TITLE
Save and restore the current plugin classpath container state from disk

### DIFF
--- a/ui/org.eclipse.pde.core/.options
+++ b/ui/org.eclipse.pde.core/.options
@@ -7,3 +7,5 @@ org.eclipse.pde.core/model=false
 org.eclipse.pde.core/target/profile=false
 # trace when validating plugin.xml contents
 org.eclipse.pde.core/validation=false
+# trace when read/save the current state of the plugin resolution
+org.eclipse.pde.core/state=false

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEClasspathContainer.java
@@ -49,7 +49,7 @@ public class PDEClasspathContainer {
 
 	private static final IAccessRule EXCLUDE_ALL_RULE = JavaCore.newAccessRule(IPath.fromOSString("**/*"), IAccessRule.K_NON_ACCESSIBLE | IAccessRule.IGNORE_IF_BETTER); //$NON-NLS-1$
 
-	protected void addProjectEntry(IProject project, List<Rule> rules, boolean exportsExternalAnnotations,
+	protected static void addProjectEntry(IProject project, List<Rule> rules, boolean exportsExternalAnnotations,
 			List<IClasspathEntry> entries) throws CoreException {
 		if (project.hasNature(JavaCore.NATURE_ID)) {
 			IAccessRule[] accessRules = rules != null ? getAccessRules(rules) : null;
@@ -61,7 +61,8 @@ public class PDEClasspathContainer {
 		}
 	}
 
-	private IClasspathAttribute[] getClasspathAttributesForProject(IProject project, boolean exportsExternalAnnotations)
+	private static IClasspathAttribute[] getClasspathAttributesForProject(IProject project,
+			boolean exportsExternalAnnotations)
 			throws JavaModelException {
 		if (exportsExternalAnnotations) {
 			String annotationPath = JavaCore.create(project).getOutputLocation().toString();

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -21,6 +21,7 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.ISaveContext;
 import org.eclipse.core.resources.ISaveParticipant;
 import org.eclipse.core.resources.IWorkspace;
@@ -81,11 +82,13 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 	public static boolean DEBUG_MODEL = false;
 	public static boolean DEBUG_TARGET_PROFILE = false;
 	public static boolean DEBUG_VALIDATION = false;
+	public static boolean DEBUG_STATE = false;
 	private static final String DEBUG_FLAG = PLUGIN_ID + "/debug"; //$NON-NLS-1$
 	private static final String CLASSPATH_DEBUG = PLUGIN_ID + "/classpath"; //$NON-NLS-1$
 	private static final String MODEL_DEBUG = PLUGIN_ID + "/model"; //$NON-NLS-1$
 	private static final String TARGET_PROFILE_DEBUG = PLUGIN_ID + "/target/profile"; //$NON-NLS-1$
 	private static final String VALIDATION_DEBUG = PLUGIN_ID + "/validation"; //$NON-NLS-1$
+	private static final String STATE_DEBUG = PLUGIN_ID + "/state"; //$NON-NLS-1$
 
 	// Shared instance
 	private static PDECore inst;
@@ -368,6 +371,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		});
 		bndResourceChangeListener = new BndResourceChangeListener();
 		workspace.addResourceChangeListener(bndResourceChangeListener);
+		workspace.addResourceChangeListener(ClasspathComputer.CHANGE_LISTENER, IResourceChangeEvent.PRE_DELETE);
 		fBundleContext.registerService(Workspace.class, new BndWorkspaceServiceFactory(),
 				FrameworkUtil.asDictionary(Map.of(Constants.SERVICE_RANKING, -10)));
 	}
@@ -424,6 +428,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		workspace.removeSaveParticipant(PLUGIN_ID);
 		workspace.removeResourceChangeListener(bndResourceChangeListener);
+		workspace.removeResourceChangeListener(ClasspathComputer.CHANGE_LISTENER);
 
 		MinimalState.shutdown();
 	}
@@ -454,6 +459,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		DEBUG_MODEL = DEBUG && options.getBooleanOption(MODEL_DEBUG, false);
 		DEBUG_TARGET_PROFILE = DEBUG && options.getBooleanOption(TARGET_PROFILE_DEBUG, false);
 		DEBUG_VALIDATION = DEBUG && options.getBooleanOption(VALIDATION_DEBUG, false);
+		DEBUG_STATE = DEBUG & options.getBooleanOption(STATE_DEBUG, false);
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
@@ -437,6 +437,12 @@ public class PluginModelManager implements IModelProviderListener {
 		return fEntries;
 	}
 
+	void initialize(IProgressMonitor monitor) {
+		synchronized (fEntriesSynchronizer) {
+			initializeTable(monitor);
+		}
+	}
+
 	/** Has to be called synchronized with fEntriesSynchronizer **/
 	private void initializeTable(IProgressMonitor monitor) {
 		if (fEntries != null) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -61,6 +61,7 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.target.NameVersionDescriptor;
 import org.eclipse.pde.internal.build.BundleHelper;
 import org.eclipse.pde.internal.build.IBuildPropertiesConstants;
+import org.eclipse.pde.internal.core.PDEClasspathContainer.Rule;
 import org.eclipse.pde.internal.core.bnd.BndProjectManager;
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
 import org.eclipse.pde.internal.core.natures.BndProject;
@@ -71,7 +72,7 @@ import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Constants;
 
-class RequiredPluginsClasspathContainer extends PDEClasspathContainer implements IClasspathContainer {
+class RequiredPluginsClasspathContainer implements IClasspathContainer {
 
 	@SuppressWarnings("nls")
 	private static final Set<String> JUNIT5_RUNTIME_PLUGINS = Set.of("org.junit", //
@@ -459,9 +460,10 @@ class RequiredPluginsClasspathContainer extends PDEClasspathContainer implements
 		getClasspathContributors().map(cc -> cc.getEntriesForDependency(hostBundle, desc)).flatMap(Collection::stream)
 				.forEach(entries::add);
 		if (resource != null) {
-			addProjectEntry(resource.getProject(), rules, model.getPluginBase().exportsExternalAnnotations(), entries);
+			PDEClasspathContainer.addProjectEntry(resource.getProject(), rules,
+					model.getPluginBase().exportsExternalAnnotations(), entries);
 		} else {
-			addExternalPlugin(model, rules, entries);
+			PDEClasspathContainer.addExternalPlugin(model, rules, entries);
 		}
 		return true;
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -13,36 +13,18 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.pde.core.plugin.IPluginModelBase;
 
 public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
-
-	private static final Job initPDEJob = Job.create(PDECoreMessages.PluginModelManager_InitializingPluginModels,
-			monitor -> {
-				if (!PDECore.getDefault().getModelManager().isInitialized()) {
-					PDECore.getDefault().getModelManager().targetReloaded(monitor);
-				}
-			});
-
-	private static final DeferredClasspathContainerInitializerJob deferredClasspathContainerInitializerJob = new DeferredClasspathContainerInitializerJob();
 
 	private static final IClasspathContainer EMPTY_CLASSPATH_CONTAINER = new IClasspathContainer() {
 
@@ -68,95 +50,27 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 		}
 	};
 
-	private static class DeferredClasspathContainerInitializerJob extends Job {
-
-		private final Set<IJavaProject> projects = new LinkedHashSet<>();
-
-		public DeferredClasspathContainerInitializerJob() {
-			// This name is not displayed to a user.
-			super("DeferredClasspathContainerInitializerJob"); //$NON-NLS-1$
-			setSystem(true);
-		}
-
-		public synchronized void initialize(IJavaProject project) {
-			if (projects.add(project)) {
-				schedule();
-			}
-		}
-
-		private synchronized IJavaProject[] consumeProjects() {
-			try {
-				return projects.toArray(IJavaProject[]::new);
-			} finally {
-				projects.clear();
-			}
-		}
-
-		@Override
-		protected IStatus run(IProgressMonitor monitor) {
-			try {
-				setupClasspath(consumeProjects());
-			} catch (JavaModelException e) {
-				PDECore.log(e);
-			}
-			return Status.OK_STATUS;
-		}
-
-		@Override
-		public boolean belongsTo(Object family) {
-			return family == PluginModelManager.class || family == ClasspathContainerInitializer.class;
-		}
-	}
-
 	@Override
 	public void initialize(IPath containerPath, IJavaProject javaProject) throws CoreException {
-		if (Job.getJobManager().isSuspended()) {
-			// If the jobmanager is currently suspended we can't use the
-			// schedule/join pattern here, instead we must retry the requested
-			// action once jobs are enabled again, this will the possibly
-			// trigger a rebuild if required or notify other listeners.
-			//
-			// Second as JDT is caching the container state, it might happens
-			// that the final results are the same and if PDE is too fast, it
-			// then happens that there is no delta event send to the model
-			// listeners leading to odd results.
-			// We explicitly set an empty classpath container here, so JDT will
-			// always see a delta when we later update the container to its
-			// final entries.
+		IProject project = javaProject.getProject();
+		IClasspathContainer savedState = ClasspathComputer.readState(project);
+		if (savedState == null) {
+			if (PDECore.DEBUG_STATE) {
+				System.out.println(String.format("%s has no saved state!", javaProject.getProject().getName())); //$NON-NLS-1$
+			}
 			JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, new IJavaProject[] { javaProject },
 					new IClasspathContainer[] { EMPTY_CLASSPATH_CONTAINER }, null);
-			deferredClasspathContainerInitializerJob.initialize(javaProject);
 		} else {
-			setupClasspath(javaProject);
-		}
-	}
-
-	protected static void setupClasspath(IJavaProject... javaProjects) throws JavaModelException {
-		// The first project to be built may initialize the PDE models,
-		// potentially long running, so allow cancellation
-		PluginModelManager manager = PDECore.getDefault().getModelManager();
-		if (!manager.isInitialized()) {
-			initPDEJob.schedule();
-			try {
-				initPDEJob.join();
-			} catch (InterruptedException e) {
+			if (PDECore.DEBUG_STATE) {
+				System.out.println(
+						String.format("%s is restored from previous state.", javaProject.getProject().getName())); //$NON-NLS-1$
 			}
+			JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, new IJavaProject[] { javaProject },
+					new IClasspathContainer[] { savedState }, null);
 		}
-
-		Map<IJavaProject, RequiredPluginsClasspathContainer> classPathContainers = new LinkedHashMap<>();
-		for (IJavaProject javaProject : javaProjects) {
-			IProject project = javaProject.getProject();
-			if (project.exists() && project.isOpen()) {
-				IPluginModelBase model = manager.findModel(project);
-				RequiredPluginsClasspathContainer requiredPluginsClasspathContainer = new RequiredPluginsClasspathContainer(
-						model, project);
-				classPathContainers.put(javaProject, requiredPluginsClasspathContainer);
-			}
-		}
-
-		JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH,
-				classPathContainers.keySet().toArray(IJavaProject[]::new),
-				classPathContainers.values().toArray(IClasspathContainer[]::new), null);
+		// The saved state might be stale, request a classpath update here, this
+		// will run in a background job and update the classpath if needed.
+		ClasspathComputer.requestClasspathUpdate(project, savedState);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDEClasspathContainerSaveHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDEClasspathContainerSaveHelper.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2025 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Sonatype, Inc. - initial API and implementation
+ *      Christoph Läubrich adapted from m2e to PDE
+ *******************************************************************************/
+
+package org.eclipse.pde.internal.core.util;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IAccessRule;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.JavaCore;
+
+/**
+ * BuildPath save helper
+ *
+ * Adapted from org.eclipse.m2e.jdt.internal.MavenClasspathContainerSaveHelper
+ */
+public class PDEClasspathContainerSaveHelper {
+
+	public static IClasspathContainer readContainer(InputStream input) throws IOException, ClassNotFoundException {
+		ObjectInputStream is = new ObjectInputStream(new BufferedInputStream(input)) {
+			{
+				enableResolveObject(true);
+			}
+
+			@Override
+			protected Object resolveObject(Object o) throws IOException {
+				if (o instanceof ProjectEntryReplace project) {
+					return project.getEntry();
+				} else if (o instanceof LibraryEntryReplace library) {
+					return library.getEntry();
+				} else if (o instanceof ClasspathAttributeReplace classpathAttribute) {
+					return classpathAttribute.getAttribute();
+				} else if (o instanceof AccessRuleReplace accessRule) {
+					return accessRule.getAccessRule();
+				} else if (o instanceof PathReplace path) {
+					return path.getPath();
+				}
+				return super.resolveObject(o);
+			}
+		};
+		return (IClasspathContainer) is.readObject();
+	}
+
+	public static void writeContainer(IClasspathContainer container, OutputStream output) throws IOException {
+		ObjectOutputStream os = new ObjectOutputStream(new BufferedOutputStream(output)) {
+			{
+				enableReplaceObject(true);
+			}
+
+			@Override
+			protected Object replaceObject(Object o) throws IOException {
+				if (o instanceof IClasspathEntry e) {
+					if (e.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
+						return new ProjectEntryReplace(e);
+					} else if (e.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+						return new LibraryEntryReplace(e);
+					}
+				} else if (o instanceof IClasspathAttribute classpthAttribute) {
+					return new ClasspathAttributeReplace(classpthAttribute);
+				} else if (o instanceof IAccessRule accessRule) {
+					return new AccessRuleReplace(accessRule);
+				} else if (o instanceof IPath path) {
+					return new PathReplace(path);
+				}
+				return super.replaceObject(o);
+			}
+		};
+		os.writeObject(new SerializableClasspathContainer(container.getClasspathEntries()));
+		os.flush();
+	}
+
+	/**
+	 * A library IClasspathEntry replacement used for object serialization
+	 */
+	static final class LibraryEntryReplace implements Serializable {
+		private static final long serialVersionUID = 3901667379326978799L;
+
+		private final IPath path;
+
+		private final IPath sourceAttachmentPath;
+
+		private final IPath sourceAttachmentRootPath;
+
+		private final IClasspathAttribute[] extraAttributes;
+
+		private final boolean exported;
+
+		private final IAccessRule[] accessRules;
+
+		LibraryEntryReplace(IClasspathEntry entry) {
+			this.path = entry.getPath();
+			this.sourceAttachmentPath = entry.getSourceAttachmentPath();
+			this.sourceAttachmentRootPath = entry.getSourceAttachmentRootPath();
+			this.accessRules = entry.getAccessRules();
+			this.extraAttributes = entry.getExtraAttributes();
+			this.exported = entry.isExported();
+		}
+
+		IClasspathEntry getEntry() {
+			return JavaCore.newLibraryEntry(path, sourceAttachmentPath, sourceAttachmentRootPath, //
+					accessRules, extraAttributes, exported);
+		}
+	}
+
+	/**
+	 * A project IClasspathEntry replacement used for object serialization
+	 */
+	static final class ProjectEntryReplace implements Serializable {
+		private static final long serialVersionUID = -2397483865904288762L;
+
+		private final IPath path;
+
+		private final IClasspathAttribute[] extraAttributes;
+
+		private final IAccessRule[] accessRules;
+
+		private final boolean exported;
+
+		private final boolean combineAccessRules;
+
+		ProjectEntryReplace(IClasspathEntry entry) {
+			this.path = entry.getPath();
+			this.accessRules = entry.getAccessRules();
+			this.extraAttributes = entry.getExtraAttributes();
+			this.exported = entry.isExported();
+			this.combineAccessRules = entry.combineAccessRules();
+		}
+
+		IClasspathEntry getEntry() {
+			return JavaCore.newProjectEntry(path, accessRules, //
+					combineAccessRules, extraAttributes, exported);
+		}
+	}
+
+	/**
+	 * An IClasspathAttribute replacement used for object serialization
+	 */
+	static final class ClasspathAttributeReplace implements Serializable {
+		private static final long serialVersionUID = 6370039352012628029L;
+
+		private final String name;
+
+		private final String value;
+
+		ClasspathAttributeReplace(IClasspathAttribute attribute) {
+			this.name = attribute.getName();
+			this.value = attribute.getValue();
+		}
+
+		IClasspathAttribute getAttribute() {
+			return JavaCore.newClasspathAttribute(name, value);
+		}
+	}
+
+	/**
+	 * An IAccessRule replacement used for object serialization
+	 */
+	static final class AccessRuleReplace implements Serializable {
+		private static final long serialVersionUID = 7315582893941374715L;
+
+		private final IPath pattern;
+
+		private final int kind;
+
+		private final boolean ignoreIfBetter;
+
+		AccessRuleReplace(IAccessRule accessRule) {
+			pattern = accessRule.getPattern();
+			kind = accessRule.getKind();
+			ignoreIfBetter = accessRule.ignoreIfBetter();
+		}
+
+		IAccessRule getAccessRule() {
+			if (ignoreIfBetter) {
+				return JavaCore.newAccessRule(pattern, kind | IAccessRule.IGNORE_IF_BETTER);
+			}
+			return JavaCore.newAccessRule(pattern, kind);
+		}
+	}
+
+	/**
+	 * An IPath replacement used for object serialization
+	 */
+	static final class PathReplace implements Serializable {
+		private static final long serialVersionUID = -2361259525684491181L;
+
+		private final String path;
+
+		PathReplace(IPath path) {
+			this.path = path.toPortableString();
+		}
+
+		IPath getPath() {
+			return IPath.fromPortableString(path);
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SerializableClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SerializableClasspathContainer.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *  Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.util;
+
+import java.io.Serializable;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.PDECoreMessages;
+
+class SerializableClasspathContainer implements IClasspathContainer, Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private final IClasspathEntry[] entries;
+
+	public SerializableClasspathContainer(IClasspathEntry[] entries) {
+		this.entries = entries;
+	}
+
+	@Override
+	public IClasspathEntry[] getClasspathEntries() {
+		return entries;
+	}
+
+	@Override
+	public int getKind() {
+		return K_APPLICATION;
+	}
+
+	@Override
+	public IPath getPath() {
+		return PDECore.REQUIRED_PLUGINS_CONTAINER_PATH;
+	}
+
+	@Override
+	public String getDescription() {
+		return PDECoreMessages.RequiredPluginsClasspathContainer_description;
+	}
+
+}


### PR DESCRIPTION
Computing the bundle plugin classpath can be an expensive operation for different reasons. In many cases these computation even yields the same results as before especially on workspace restart without target changes.

This now stores the last successful computed state per project and read it back on initialization of the classpath container, scheduling a check for actual changes in the background. Only if this check yields a different result or the update is requested as part of a change to the manifest or target state for example the current values are updated.

This yields faster startup times without the risk of blocking (other than file I/O) until PDE can deliver the classpath to consumers delaying the heavy work to a later time.