### PR TITLE
Improve assert message in ApiBuilderTest

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.api.tools.tests
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.pde.api.tools;bundle-version="1.0.600",

--- a/apitools/org.eclipse.pde.api.tools.tests/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools.tests/pom.xml
@@ -18,7 +18,7 @@
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.pde.api.tools.tests</artifactId>
-	<version>1.4.100-SNAPSHOT</version>
+	<version>1.4.200-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/ApiBuilderTest.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -434,11 +436,18 @@ public abstract class ApiBuilderTest extends BuilderTests {
 		int[] expectedProblemIds = getExpectedProblemIds();
 		int length = problems.length;
 		if (expectedProblemIds.length != length) {
-			for (int i = 0; i < length; i++) {
-				System.err.println(problems[i]);
+			Set<Integer> set = Arrays.stream(expectedProblemIds).boxed().collect(Collectors.toSet());
+			StringBuilder sb = new StringBuilder(String.format("Wrong number of problems: expected = %d, actual = %d", //$NON-NLS-1$
+					expectedProblemIds.length, problems.length));
+			for (ApiProblem problem : problems) {
+				sb.append(System.lineSeparator());
+				sb.append("\t- "); //$NON-NLS-1$
+				sb.append(problem);
+				sb.append(" expected: "); //$NON-NLS-1$
+				sb.append(set.contains(problem.getProblemId()));
 			}
+			fail(sb.toString());
 		}
-		assertEquals("Wrong number of problems", expectedProblemIds.length, length); //$NON-NLS-1$
 		String[][] args = getExpectedMessageArgs();
 		if (args != null) {
 			// compare messages


### PR DESCRIPTION
Currently the assertion only tell that there is a difference and print the problems to the system out. Instead it should better mention all details in the message itself.