### PR TITLE
Unify logging and setting the classpath container

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - refactor to restore from saved state
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
@@ -20,57 +21,20 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IClasspathContainer;
-import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
 public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 
-	private static final IClasspathContainer EMPTY_CLASSPATH_CONTAINER = new IClasspathContainer() {
-
-		@Override
-		public IPath getPath() {
-			return PDECore.REQUIRED_PLUGINS_CONTAINER_PATH;
-		}
-
-		@Override
-		public int getKind() {
-			return K_APPLICATION;
-		}
-
-		@Override
-		public String getDescription() {
-			return PDECoreMessages.RequiredPluginsClasspathContainer_description;
-		}
-
-		@Override
-		public IClasspathEntry[] getClasspathEntries() {
-			// nothing yet, will be updated soon
-			return new IClasspathEntry[0];
-		}
-	};
-
 	@Override
 	public void initialize(IPath containerPath, IJavaProject javaProject) throws CoreException {
 		IProject project = javaProject.getProject();
 		IClasspathContainer savedState = ClasspathComputer.readState(project);
-		if (savedState == null) {
-			if (PDECore.DEBUG_STATE) {
-				System.out.println(String.format("%s has no saved state!", javaProject.getProject().getName())); //$NON-NLS-1$
-			}
-			JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, new IJavaProject[] { javaProject },
-					new IClasspathContainer[] { EMPTY_CLASSPATH_CONTAINER }, null);
-		} else {
-			if (PDECore.DEBUG_STATE) {
-				System.out.println(
-						String.format("%s is restored from previous state.", javaProject.getProject().getName())); //$NON-NLS-1$
-			}
-			JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, new IJavaProject[] { javaProject },
-					new IClasspathContainer[] { savedState }, null);
-		}
+		ClasspathComputer.setProjectContainers(new IJavaProject[] { javaProject },
+				new IClasspathContainer[] { savedState }, null);
 		// The saved state might be stale, request a classpath update here, this
 		// will run in a background job and update the classpath if needed.
-		ClasspathComputer.requestClasspathUpdate(project, savedState);
+		ClasspathComputer.requestClasspathUpdate(project);
 	}
 
 	@Override
@@ -78,7 +42,6 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 		if (containerPath == null || project == null) {
 			return null;
 		}
-
 		return containerPath.segment(0) + "/" + project.getPath().segment(0); //$NON-NLS-1$
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDEClasspathContainerSaveHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDEClasspathContainerSaveHelper.java
@@ -62,6 +62,10 @@ public class PDEClasspathContainerSaveHelper {
 		return (IClasspathContainer) is.readObject();
 	}
 
+	public static IClasspathContainer emptyContainer() {
+		return new SerializableClasspathContainer();
+	}
+
 	public static void writeContainer(IClasspathContainer container, OutputStream output) throws IOException {
 		ObjectOutputStream os = new ObjectOutputStream(new BufferedOutputStream(output)) {
 			{

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SerializableClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SerializableClasspathContainer.java
@@ -14,6 +14,7 @@
 package org.eclipse.pde.internal.core.util;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathContainer;
@@ -26,13 +27,17 @@ class SerializableClasspathContainer implements IClasspathContainer, Serializabl
 	private static final long serialVersionUID = 1L;
 	private final IClasspathEntry[] entries;
 
+	public SerializableClasspathContainer() {
+		this(new IClasspathEntry[0]);
+	}
+
 	public SerializableClasspathContainer(IClasspathEntry[] entries) {
 		this.entries = entries;
 	}
 
 	@Override
 	public IClasspathEntry[] getClasspathEntries() {
-		return entries;
+		return entries.clone();
 	}
 
 	@Override
@@ -48,6 +53,29 @@ class SerializableClasspathContainer implements IClasspathContainer, Serializabl
 	@Override
 	public String getDescription() {
 		return PDECoreMessages.RequiredPluginsClasspathContainer_description;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(entries);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		SerializableClasspathContainer other = (SerializableClasspathContainer) obj;
+		return Arrays.equals(entries, other.entries);
 	}
 
 }


### PR DESCRIPTION
Currently some messages about the state is logged in the initializer and some in the computer, also setting an empty classpath required an own inner class while it is actually equal to an empty state.

This now unifies the logging and handling of classpath containers.