### PR TITLE
Write trace messages to the trace log for ClasspathComputer

### DIFF
--- a/ui/org.eclipse.pde.core/.options
+++ b/ui/org.eclipse.pde.core/.options
@@ -8,4 +8,4 @@ org.eclipse.pde.core/target/profile=false
 # trace when validating plugin.xml contents
 org.eclipse.pde.core/validation=false
 # trace when read/save the current state of the plugin resolution
-org.eclipse.pde.core/state=false
+org.eclipse.pde.core/debug/state=false

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathComputer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathComputer.java
@@ -99,7 +99,8 @@ public class ClasspathComputer {
 			IResource resource = event.getResource();
 			if (resource instanceof IProject project) {
 				if (PDECore.DEBUG_STATE) {
-					System.out.println(String.format("Project %s was deleted.", project.getName())); //$NON-NLS-1$
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+							String.format("Project %s was deleted.", project.getName())); //$NON-NLS-1$
 				}
 				getStateFile(project).delete();
 			}
@@ -650,15 +651,16 @@ public class ClasspathComputer {
 			IClasspathContainer previousClasspathContainer) {
 		if (previousClasspathContainer == null) {
 			if (PDECore.DEBUG_STATE) {
-				System.out
-						.println(String.format("%s need update because it has no state to compare", project.getName())); //$NON-NLS-1$
+				PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+						String.format("%s need update because it has no state to compare", project.getName())); //$NON-NLS-1$
 			}
 			return false;
 		}
 		IClasspathEntry[] previousEntries = previousClasspathContainer.getClasspathEntries();
 		if (previousEntries == null || previousEntries.length != currentEntries.length) {
 			if (PDECore.DEBUG_STATE) {
-				System.out.println(String.format("%s need update because entries do not match in size!", //$NON-NLS-1$
+				PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+						String.format("%s need update because entries do not match in size!", //$NON-NLS-1$
 						project.getName()));
 			}
 			return false;
@@ -668,7 +670,7 @@ public class ClasspathComputer {
 			IClasspathEntry current = currentEntries[i];
 			if (!Objects.equals(current, previous)) {
 				if (PDECore.DEBUG_STATE) {
-					System.out.println(
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
 							String.format("%s need update because entry at position %d is different:\n\t%s\n\t%s", //$NON-NLS-1$
 									project.getName(), i, current, previous));
 				}
@@ -689,8 +691,9 @@ public class ClasspathComputer {
 			} catch (Exception e) {
 				// can't write then...
 				if (PDECore.DEBUG_STATE) {
-					System.err.println(String.format("Writing project state for %s failed!", project.getName())); //$NON-NLS-1$
-					e.printStackTrace();
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+							String.format("Writing project state for %s failed!", project.getName()), //$NON-NLS-1$
+							e);
 				}
 			}
 		}
@@ -704,17 +707,19 @@ public class ClasspathComputer {
 					IClasspathContainer container = Objects
 							.requireNonNull(PDEClasspathContainerSaveHelper.readContainer(stream));
 					if (PDECore.DEBUG_STATE) {
-						System.out.println(String.format("%s is restored from previous state.", project.getName())); //$NON-NLS-1$
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+								String.format("%s is restored from previous state.", project.getName())); //$NON-NLS-1$
 					}
 					return container;
 				}
 			} catch (Exception e) {
 				if (PDECore.DEBUG_STATE) {
 					if (e instanceof FileNotFoundException) {
-						System.out.println(String.format("%s has no saved state!", project.getName())); //$NON-NLS-1$
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+								String.format("%s has no saved state!", project.getName())); //$NON-NLS-1$
 					} else {
-						System.err.println(String.format("Restoring project state for %s failed!", project.getName())); //$NON-NLS-1$
-						e.printStackTrace();
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+								String.format("Restoring project state for %s failed!", project.getName()), e); //$NON-NLS-1$
 					}
 				}
 				return PDEClasspathContainerSaveHelper.emptyContainer();

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -36,6 +36,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
+import org.eclipse.osgi.service.debug.DebugTrace;
 import org.eclipse.pde.core.IBundleClasspathResolver;
 import org.eclipse.pde.core.IClasspathContributor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -62,6 +63,7 @@ import aQute.bnd.service.RepositoryListenerPlugin;
 import aQute.bnd.service.clipboard.Clipboard;
 
 public class PDECore extends Plugin implements DebugOptionsListener {
+
 	public static final String PLUGIN_ID = "org.eclipse.pde.core"; //$NON-NLS-1$
 
 	public static final IPath REQUIRED_PLUGINS_CONTAINER_PATH = IPath.fromOSString(PLUGIN_ID + ".requiredPlugins"); //$NON-NLS-1$
@@ -83,12 +85,16 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 	public static boolean DEBUG_TARGET_PROFILE = false;
 	public static boolean DEBUG_VALIDATION = false;
 	public static boolean DEBUG_STATE = false;
-	private static final String DEBUG_FLAG = PLUGIN_ID + "/debug"; //$NON-NLS-1$
+	public static DebugTrace TRACE;
+	private static final String DEBUG = "/debug"; //$NON-NLS-1$
+
+	public static final String KEY_DEBUG_STATE = DEBUG + "/state"; //$NON-NLS-1$
+	private static final String DEBUG_FLAG = PLUGIN_ID + DEBUG;
 	private static final String CLASSPATH_DEBUG = PLUGIN_ID + "/classpath"; //$NON-NLS-1$
 	private static final String MODEL_DEBUG = PLUGIN_ID + "/model"; //$NON-NLS-1$
 	private static final String TARGET_PROFILE_DEBUG = PLUGIN_ID + "/target/profile"; //$NON-NLS-1$
 	private static final String VALIDATION_DEBUG = PLUGIN_ID + "/validation"; //$NON-NLS-1$
-	private static final String STATE_DEBUG = PLUGIN_ID + "/state"; //$NON-NLS-1$
+	private static final String STATE_DEBUG = PLUGIN_ID + KEY_DEBUG_STATE;
 
 	// Shared instance
 	private static PDECore inst;
@@ -455,6 +461,9 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 	@Override
 	public void optionsChanged(DebugOptions options) {
 		boolean DEBUG = options.getBooleanOption(DEBUG_FLAG, false);
+		if (DEBUG) {
+			TRACE = options.newDebugTrace(PLUGIN_ID);
+		}
 		DEBUG_CLASSPATH = DEBUG && options.getBooleanOption(CLASSPATH_DEBUG, false);
 		DEBUG_MODEL = DEBUG && options.getBooleanOption(MODEL_DEBUG, false);
 		DEBUG_TARGET_PROFILE = DEBUG && options.getBooleanOption(TARGET_PROFILE_DEBUG, false);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -34,7 +34,7 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 				new IClasspathContainer[] { savedState }, null);
 		// The saved state might be stale, request a classpath update here, this
 		// will run in a background job and update the classpath if needed.
-		ClasspathComputer.requestClasspathUpdate(project);
+		ClasspathComputer.requestClasspathUpdate(project, savedState);
 	}
 
 	@Override


### PR DESCRIPTION
Currently PDE uses System.out to print trace messages, that has the problem that id the user has configured a trace file it does not show up there.

This now acquire a DebugTrace instance that can be used and use that in the ClasspathComputer.