### PR TITLE
Extract ClasspathContainerState from ClasspathComputer

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationPreferenceListener.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationPreferenceListener.java
@@ -30,7 +30,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.pde.internal.core.ClasspathComputer;
+import org.eclipse.pde.internal.core.ClasspathContainerState;
 import org.eclipse.pde.internal.core.PluginModelManager;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
@@ -66,7 +66,7 @@ public class DSAnnotationPreferenceListener implements IPreferenceChangeListener
 				SubMonitor progress = SubMonitor.convert(monitor, Messages.DSAnnotationPreferenceListener_taskName,
 						managedProjects.size() * 2);
 				if (requiresClasspathUpdate) {
-					ClasspathComputer.requestClasspathUpdate(managedProjects);
+					ClasspathContainerState.requestClasspathUpdate(managedProjects);
 					try {
 						Job.getJobManager().join(PluginModelManager.class, monitor);
 					} catch (OperationCanceledException | InterruptedException e) {

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSLibPluginModelListener.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSLibPluginModelListener.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.pde.core.plugin.ModelEntry;
-import org.eclipse.pde.internal.core.ClasspathComputer;
+import org.eclipse.pde.internal.core.ClasspathContainerState;
 import org.eclipse.pde.internal.core.IPluginModelListener;
 import org.eclipse.pde.internal.core.PluginModelDelta;
 import org.eclipse.pde.internal.core.PluginModelManager;
@@ -116,7 +116,7 @@ public class DSLibPluginModelListener implements IPluginModelListener {
 					}
 				}
 			}
-			ClasspathComputer.requestClasspathUpdate(toUpdate);
+			ClasspathContainerState.requestClasspathUpdate(toUpdate);
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathComputer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathComputer.java
@@ -13,15 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -29,9 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,17 +29,8 @@ import java.util.stream.Stream;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IResourceChangeEvent;
-import org.eclipse.core.resources.IResourceChangeListener;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -69,10 +50,8 @@ import org.eclipse.pde.core.build.IBuildModel;
 import org.eclipse.pde.core.plugin.IPluginLibrary;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.build.WorkspaceBuildModel;
-import org.eclipse.pde.internal.core.natures.PluginProject;
 import org.eclipse.pde.internal.core.project.PDEProject;
 import org.eclipse.pde.internal.core.util.CoreUtility;
-import org.eclipse.pde.internal.core.util.PDEClasspathContainerSaveHelper;
 import org.eclipse.team.core.RepositoryProvider;
 
 public class ClasspathComputer {
@@ -86,26 +65,6 @@ public class ClasspathComputer {
 	private static final int SEVERITY_ERROR = 3;
 	private static final int SEVERITY_WARNING = 2;
 	private static final int SEVERITY_IGNORE = 1;
-
-	/**
-	 * Job used to update class path containers.
-	 */
-	private static final UpdateClasspathsJob fUpdateJob = new UpdateClasspathsJob();
-
-	static final IResourceChangeListener CHANGE_LISTENER = new IResourceChangeListener() {
-
-		@Override
-		public void resourceChanged(IResourceChangeEvent event) {
-			IResource resource = event.getResource();
-			if (resource instanceof IProject project) {
-				if (PDECore.DEBUG_STATE) {
-					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-							String.format("Project %s was deleted.", project.getName())); //$NON-NLS-1$
-				}
-				getStateFile(project).delete();
-			}
-		}
-	};
 
 	public static void setClasspath(IProject project, IPluginModelBase model) throws CoreException {
 		IClasspathEntry[] entries = getClasspath(project, model, null, false, true);
@@ -518,227 +477,6 @@ public class ClasspathComputer {
 	public static IClasspathEntry[] computeClasspathEntries(IPluginModelBase model, IProject project) {
 		IClasspathContainer container = new RequiredPluginsClasspathContainer(model, project);
 		return container.getClasspathEntries();
-	}
-
-	public static void requestClasspathUpdate(IProject project) {
-		if (project == null) {
-			return;
-		}
-		requestClasspathUpdate(List.of(project));
-	}
-
-	public static void requestClasspathUpdate(Collection<IProject> updateProjects) {
-		if (updateProjects == null || updateProjects.isEmpty()) {
-			return;
-		}
-		fUpdateJob.addAll(updateProjects);
-	}
-
-	static void requestClasspathUpdate(IProject project, IClasspathContainer savedState) {
-		fUpdateJob.add(project, savedState);
-	}
-
-	/**
-	 * Job to update class path containers asynchronously. Avoids blocking the
-	 * UI thread. The job is given a workspace lock so other jobs can't run on a
-	 * stale classpath.
-	 */
-	private static final class UpdateClasspathsJob extends Job {
-
-		private static final int WORK = 10_000;
-		private final Queue<UpdateRequest> workQueue = new ConcurrentLinkedQueue<>();
-
-		/**
-		 * Constructs a new job.
-		 */
-		public UpdateClasspathsJob() {
-			super(PDECoreMessages.PluginModelManager_1);
-			// The job is given a workspace lock so other jobs can't run on a
-			// stale classpath (bug 354993)
-			setRule(ResourcesPlugin.getWorkspace().getRoot());
-		}
-
-		@Override
-		public boolean belongsTo(Object family) {
-			return family == PluginModelManager.class || family == ClasspathComputer.class;
-		}
-
-		@Override
-		protected IStatus run(IProgressMonitor jobMonitor) {
-			SubMonitor monitor = SubMonitor.convert(jobMonitor, PDECoreMessages.PluginModelManager_1, WORK);
-			PluginModelManager.getInstance().initialize(monitor.split(10));
-			PluginModelManager modelManager = PluginModelManager.getInstance();
-			Map<IJavaProject, IClasspathContainer> updateProjects = new LinkedHashMap<>();
-			Map<IProject, IStatus> errorsPerProject = new LinkedHashMap<>();
-			UpdateRequest request;
-			while (!monitor.isCanceled() && (request = workQueue.poll()) != null) {
-				monitor.setWorkRemaining(WORK);
-				IProject project = request.project();
-				if (project.exists() && project.isOpen()) {
-					IPluginModelBase model = modelManager.findModel(project);
-					if (model != null && PluginProject.isJavaProject(project)) {
-						IJavaProject javaProject = JavaCore.create(project);
-						RequiredPluginsClasspathContainer classpathContainer = new RequiredPluginsClasspathContainer(
-								model, project);
-						try {
-							if (!isUpToDate(project, classpathContainer.computeEntries(), request.container())) {
-								updateProjects.put(javaProject, classpathContainer);
-								errorsPerProject.remove(project);
-								saveState(project, classpathContainer);
-							}
-						} catch (CoreException e) {
-							errorsPerProject.put(project, e.getStatus());
-						}
-						monitor.worked(1);
-					}
-				}
-			}
-			if (monitor.isCanceled()) {
-				return Status.CANCEL_STATUS;
-			}
-			if (!updateProjects.isEmpty()) {
-				int i = 0;
-				int n = updateProjects.size();
-				IJavaProject[] javaProjects = new IJavaProject[n];
-				IClasspathContainer[] container = new IClasspathContainer[n];
-				for (Entry<IJavaProject, IClasspathContainer> entry : updateProjects.entrySet()) {
-					javaProjects[i] = entry.getKey();
-					container[i] = entry.getValue();
-					i++;
-				}
-				try {
-					setProjectContainers(javaProjects, container, monitor);
-				} catch (JavaModelException e) {
-					return e.getStatus();
-				}
-			}
-			IStatus[] errors = errorsPerProject.values().toArray(IStatus[]::new);
-			if (errors.length == 0) {
-				return Status.OK_STATUS;
-			}
-			if (errors.length == 1) {
-				return errors[0];
-			}
-			MultiStatus overallStatus = new MultiStatus(ClasspathComputer.class, 0,
-					PDECoreMessages.ClasspathComputer_failed);
-			for (IStatus status : errors) {
-				overallStatus.add(status);
-			}
-			return overallStatus;
-		}
-
-		/**
-		 * Queues more projects/containers.
-		 */
-		void addAll(Collection<IProject> tocheck) {
-			for (IProject project : tocheck) {
-				workQueue.add(new UpdateRequest(project, null));
-			}
-			schedule();
-		}
-
-		void add(IProject project, IClasspathContainer classpathContainer) {
-			if (project == null) {
-				return;
-			}
-			workQueue.add(new UpdateRequest(project, classpathContainer));
-			schedule();
-		}
-
-	}
-
-	private static boolean isUpToDate(IProject project, IClasspathEntry[] currentEntries,
-			IClasspathContainer previousClasspathContainer) {
-		if (previousClasspathContainer == null) {
-			if (PDECore.DEBUG_STATE) {
-				PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-						String.format("%s need update because it has no state to compare", project.getName())); //$NON-NLS-1$
-			}
-			return false;
-		}
-		IClasspathEntry[] previousEntries = previousClasspathContainer.getClasspathEntries();
-		if (previousEntries == null || previousEntries.length != currentEntries.length) {
-			if (PDECore.DEBUG_STATE) {
-				PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-						String.format("%s need update because entries do not match in size!", //$NON-NLS-1$
-						project.getName()));
-			}
-			return false;
-		}
-		for (int i = 0; i < previousEntries.length; i++) {
-			IClasspathEntry previous = previousEntries[i];
-			IClasspathEntry current = currentEntries[i];
-			if (!Objects.equals(current, previous)) {
-				if (PDECore.DEBUG_STATE) {
-					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-							String.format("%s need update because entry at position %d is different:\n\t%s\n\t%s", //$NON-NLS-1$
-									project.getName(), i, current, previous));
-				}
-				return false;
-			}
-		}
-		return true;
-	}
-
-	private static void saveState(IProject project, RequiredPluginsClasspathContainer classpathContainer) {
-		synchronized (project) {
-			try {
-				File stateFile = getStateFile(project);
-				stateFile.getParentFile().mkdirs();
-				try (BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(stateFile))) {
-					PDEClasspathContainerSaveHelper.writeContainer(classpathContainer, stream);
-				}
-			} catch (Exception e) {
-				// can't write then...
-				if (PDECore.DEBUG_STATE) {
-					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-							String.format("Writing project state for %s failed!", project.getName()), //$NON-NLS-1$
-							e);
-				}
-			}
-		}
-	}
-
-	static IClasspathContainer readState(IProject project) {
-		synchronized (project) {
-			try {
-				File stateFile = getStateFile(project);
-				try (InputStream stream = new FileInputStream(stateFile)) {
-					IClasspathContainer container = Objects
-							.requireNonNull(PDEClasspathContainerSaveHelper.readContainer(stream));
-					if (PDECore.DEBUG_STATE) {
-						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-								String.format("%s is restored from previous state.", project.getName())); //$NON-NLS-1$
-					}
-					return container;
-				}
-			} catch (Exception e) {
-				if (PDECore.DEBUG_STATE) {
-					if (e instanceof FileNotFoundException) {
-						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-								String.format("%s has no saved state!", project.getName())); //$NON-NLS-1$
-					} else {
-						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
-								String.format("Restoring project state for %s failed!", project.getName()), e); //$NON-NLS-1$
-					}
-				}
-				return PDEClasspathContainerSaveHelper.emptyContainer();
-			}
-		}
-	}
-
-	static void setProjectContainers(IJavaProject[] javaProjects, IClasspathContainer[] container,
-			IProgressMonitor monitor) throws JavaModelException {
-		JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, javaProjects, container, monitor);
-	}
-
-	private static File getStateFile(IProject project) {
-		return PDECore.getDefault().getStateLocation().append("cpc").append(project.getName()) //$NON-NLS-1$
-				.toFile();
-	}
-
-	private static record UpdateRequest(IProject project, IClasspathContainer container) {
-
 	}
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - extracted code from ClasspathComputer
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.internal.core.natures.PluginProject;
+import org.eclipse.pde.internal.core.util.PDEClasspathContainerSaveHelper;
+
+public class ClasspathContainerState {
+
+	/**
+	 * Job used to update class path containers.
+	 */
+	private static final UpdateClasspathsJob fUpdateJob = new UpdateClasspathsJob();
+
+	static final IResourceChangeListener CHANGE_LISTENER = new IResourceChangeListener() {
+
+		@Override
+		public void resourceChanged(IResourceChangeEvent event) {
+			IResource resource = event.getResource();
+			if (resource instanceof IProject project) {
+				if (PDECore.DEBUG_STATE) {
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+							String.format("Project %s was deleted.", project.getName())); //$NON-NLS-1$
+				}
+				getStateFile(project).delete();
+			}
+		}
+	};
+
+	/**
+	 * Job to update class path containers asynchronously. Avoids blocking the
+	 * UI thread. The job is given a workspace lock so other jobs can't run on a
+	 * stale classpath.
+	 */
+	private static final class UpdateClasspathsJob extends Job {
+
+		private static final int WORK = 10_000;
+		private final Queue<UpdateRequest> workQueue = new ConcurrentLinkedQueue<>();
+
+		/**
+		 * Constructs a new job.
+		 */
+		public UpdateClasspathsJob() {
+			super(PDECoreMessages.PluginModelManager_1);
+			// The job is given a workspace lock so other jobs can't run on a
+			// stale classpath (bug 354993)
+			setRule(ResourcesPlugin.getWorkspace().getRoot());
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == PluginModelManager.class || family == ClasspathComputer.class;
+		}
+
+		@Override
+		protected IStatus run(IProgressMonitor jobMonitor) {
+			SubMonitor monitor = SubMonitor.convert(jobMonitor, PDECoreMessages.PluginModelManager_1, WORK);
+			PluginModelManager.getInstance().initialize(monitor.split(10));
+			PluginModelManager modelManager = PluginModelManager.getInstance();
+			Map<IJavaProject, IClasspathContainer> updateProjects = new LinkedHashMap<>();
+			Map<IProject, IStatus> errorsPerProject = new LinkedHashMap<>();
+			UpdateRequest request;
+			while (!monitor.isCanceled() && (request = workQueue.poll()) != null) {
+				monitor.setWorkRemaining(WORK);
+				IProject project = request.project();
+				if (project.exists() && project.isOpen()) {
+					IPluginModelBase model = modelManager.findModel(project);
+					if (model != null && PluginProject.isJavaProject(project)) {
+						IJavaProject javaProject = JavaCore.create(project);
+						RequiredPluginsClasspathContainer classpathContainer = new RequiredPluginsClasspathContainer(
+								model, project);
+						try {
+							if (!isUpToDate(project, classpathContainer.computeEntries(), request.container())) {
+								updateProjects.put(javaProject, classpathContainer);
+								errorsPerProject.remove(project);
+								saveState(project, classpathContainer);
+							}
+						} catch (CoreException e) {
+							errorsPerProject.put(project, e.getStatus());
+						}
+						monitor.worked(1);
+					}
+				}
+			}
+			if (monitor.isCanceled()) {
+				return Status.CANCEL_STATUS;
+			}
+			if (!updateProjects.isEmpty()) {
+				int i = 0;
+				int n = updateProjects.size();
+				IJavaProject[] javaProjects = new IJavaProject[n];
+				IClasspathContainer[] container = new IClasspathContainer[n];
+				for (Entry<IJavaProject, IClasspathContainer> entry : updateProjects.entrySet()) {
+					javaProjects[i] = entry.getKey();
+					container[i] = entry.getValue();
+					i++;
+				}
+				try {
+					setProjectContainers(javaProjects, container, monitor);
+				} catch (JavaModelException e) {
+					return e.getStatus();
+				}
+			}
+			IStatus[] errors = errorsPerProject.values().toArray(IStatus[]::new);
+			if (errors.length == 0) {
+				return Status.OK_STATUS;
+			}
+			if (errors.length == 1) {
+				return errors[0];
+			}
+			MultiStatus overallStatus = new MultiStatus(ClasspathComputer.class, 0,
+					PDECoreMessages.ClasspathComputer_failed);
+			for (IStatus status : errors) {
+				overallStatus.add(status);
+			}
+			return overallStatus;
+		}
+
+		/**
+		 * Queues more projects/containers.
+		 */
+		void addAll(Collection<IProject> tocheck) {
+			for (IProject project : tocheck) {
+				workQueue.add(new UpdateRequest(project, null));
+			}
+			schedule();
+		}
+
+		void add(IProject project, IClasspathContainer classpathContainer) {
+			if (project == null) {
+				return;
+			}
+			workQueue.add(new UpdateRequest(project, classpathContainer));
+			schedule();
+		}
+
+	}
+
+	private static boolean isUpToDate(IProject project, IClasspathEntry[] currentEntries,
+			IClasspathContainer previousClasspathContainer) {
+		if (previousClasspathContainer == null) {
+			if (PDECore.DEBUG_STATE) {
+				PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+						String.format("%s need update because it has no state to compare", project.getName())); //$NON-NLS-1$
+			}
+			return false;
+		}
+		IClasspathEntry[] previousEntries = previousClasspathContainer.getClasspathEntries();
+		if (previousEntries == null || previousEntries.length != currentEntries.length) {
+			if (PDECore.DEBUG_STATE) {
+				PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+						String.format("%s need update because entries do not match in size!", //$NON-NLS-1$
+								project.getName()));
+			}
+			return false;
+		}
+		for (int i = 0; i < previousEntries.length; i++) {
+			IClasspathEntry previous = previousEntries[i];
+			IClasspathEntry current = currentEntries[i];
+			if (!Objects.equals(current, previous)) {
+				if (PDECore.DEBUG_STATE) {
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+							String.format("%s need update because entry at position %d is different:\n\t%s\n\t%s", //$NON-NLS-1$
+									project.getName(), i, current, previous));
+				}
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static void saveState(IProject project, RequiredPluginsClasspathContainer classpathContainer) {
+		synchronized (project) {
+			try {
+				File stateFile = getStateFile(project);
+				stateFile.getParentFile().mkdirs();
+				try (BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(stateFile))) {
+					PDEClasspathContainerSaveHelper.writeContainer(classpathContainer, stream);
+				}
+			} catch (Exception e) {
+				// can't write then...
+				if (PDECore.DEBUG_STATE) {
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+							String.format("Writing project state for %s failed!", project.getName()), //$NON-NLS-1$
+							e);
+				}
+			}
+		}
+	}
+
+	static IClasspathContainer readState(IProject project) {
+		synchronized (project) {
+			try {
+				File stateFile = getStateFile(project);
+				try (InputStream stream = new FileInputStream(stateFile)) {
+					IClasspathContainer container = Objects
+							.requireNonNull(PDEClasspathContainerSaveHelper.readContainer(stream));
+					if (PDECore.DEBUG_STATE) {
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+								String.format("%s is restored from previous state.", project.getName())); //$NON-NLS-1$
+					}
+					return container;
+				}
+			} catch (Exception e) {
+				if (PDECore.DEBUG_STATE) {
+					if (e instanceof FileNotFoundException) {
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+								String.format("%s has no saved state!", project.getName())); //$NON-NLS-1$
+					} else {
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+								String.format("Restoring project state for %s failed!", project.getName()), e); //$NON-NLS-1$
+					}
+				}
+				return PDEClasspathContainerSaveHelper.emptyContainer();
+			}
+		}
+	}
+
+	static void setProjectContainers(IJavaProject[] javaProjects, IClasspathContainer[] container,
+			IProgressMonitor monitor) throws JavaModelException {
+		JavaCore.setClasspathContainer(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH, javaProjects, container, monitor);
+	}
+
+	private static File getStateFile(IProject project) {
+		return PDECore.getDefault().getStateLocation().append("cpc").append(project.getName()) //$NON-NLS-1$
+				.toFile();
+	}
+
+	public static void requestClasspathUpdate(IProject project) {
+		if (project == null) {
+			return;
+		}
+		requestClasspathUpdate(List.of(project));
+	}
+
+	public static void requestClasspathUpdate(Collection<IProject> updateProjects) {
+		if (updateProjects == null || updateProjects.isEmpty()) {
+			return;
+		}
+		fUpdateJob.addAll(updateProjects);
+	}
+
+	static void requestClasspathUpdate(IProject project, IClasspathContainer savedState) {
+		fUpdateJob.add(project, savedState);
+	}
+
+	private static record UpdateRequest(IProject project, IClasspathContainer container) {
+
+	}
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -377,7 +377,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		});
 		bndResourceChangeListener = new BndResourceChangeListener();
 		workspace.addResourceChangeListener(bndResourceChangeListener);
-		workspace.addResourceChangeListener(ClasspathComputer.CHANGE_LISTENER, IResourceChangeEvent.PRE_DELETE);
+		workspace.addResourceChangeListener(ClasspathContainerState.CHANGE_LISTENER, IResourceChangeEvent.PRE_DELETE);
 		fBundleContext.registerService(Workspace.class, new BndWorkspaceServiceFactory(),
 				FrameworkUtil.asDictionary(Map.of(Constants.SERVICE_RANKING, -10)));
 	}
@@ -434,7 +434,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		workspace.removeSaveParticipant(PLUGIN_ID);
 		workspace.removeResourceChangeListener(bndResourceChangeListener);
-		workspace.removeResourceChangeListener(ClasspathComputer.CHANGE_LISTENER);
+		workspace.removeResourceChangeListener(ClasspathContainerState.CHANGE_LISTENER);
 
 		MinimalState.shutdown();
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
@@ -282,7 +282,7 @@ public class PluginModelManager implements IModelProviderListener {
 				}
 			}
 		}
-		ClasspathComputer.requestClasspathUpdate(updates);
+		ClasspathContainerState.requestClasspathUpdate(updates);
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -29,12 +29,12 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 	@Override
 	public void initialize(IPath containerPath, IJavaProject javaProject) throws CoreException {
 		IProject project = javaProject.getProject();
-		IClasspathContainer savedState = ClasspathComputer.readState(project);
-		ClasspathComputer.setProjectContainers(new IJavaProject[] { javaProject },
+		IClasspathContainer savedState = ClasspathContainerState.readState(project);
+		ClasspathContainerState.setProjectContainers(new IJavaProject[] { javaProject },
 				new IClasspathContainer[] { savedState }, null);
 		// The saved state might be stale, request a classpath update here, this
 		// will run in a background job and update the classpath if needed.
-		ClasspathComputer.requestClasspathUpdate(project, savedState);
+		ClasspathContainerState.requestClasspathUpdate(project, savedState);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/BndResourceChangeListener.java
@@ -24,7 +24,7 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.pde.internal.core.ClasspathComputer;
+import org.eclipse.pde.internal.core.ClasspathContainerState;
 import org.eclipse.pde.internal.core.PDECore;
 
 public class BndResourceChangeListener implements IResourceChangeListener {
@@ -54,7 +54,7 @@ public class BndResourceChangeListener implements IResourceChangeListener {
 						return true;
 					}
 				});
-				ClasspathComputer.requestClasspathUpdate(updateProjects);
+				ClasspathContainerState.requestClasspathUpdate(updateProjects);
 			} catch (CoreException e) {
 				// can't do anything then...
 			}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/osgitest/OSGiTestClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/osgitest/OSGiTestClasspathContributor.java
@@ -48,7 +48,7 @@ import org.eclipse.osgi.service.resolver.StateDelta;
 import org.eclipse.pde.core.IClasspathContributor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
-import org.eclipse.pde.internal.core.ClasspathComputer;
+import org.eclipse.pde.internal.core.ClasspathContainerState;
 import org.eclipse.pde.internal.core.ClasspathUtilCore;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.IStateDeltaListener;
@@ -272,7 +272,7 @@ public class OSGiTestClasspathContributor
 				updates.add(project);
 			}
 		}
-		ClasspathComputer.requestClasspathUpdate(updates);
+		ClasspathContainerState.requestClasspathUpdate(updates);
 
 	}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateClasspathJob.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/UpdateClasspathJob.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.ClasspathComputer;
+import org.eclipse.pde.internal.core.ClasspathContainerState;
 import org.eclipse.pde.internal.core.builders.PDEMarkerFactory;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
@@ -51,7 +52,7 @@ public class UpdateClasspathJob {
 						toUpdate.add(project);
 					}
 				}
-				ClasspathComputer.requestClasspathUpdate(toUpdate);
+				ClasspathContainerState.requestClasspathUpdate(toUpdate);
 				return Status.OK_STATUS;
 			}
 		};


### PR DESCRIPTION
With the enhanced storage/save of the classpath container state now the ClasspathComputer becomes more and more complex and contains too much different tasks.

This extracts from the ClasspathComputer the parts that handle the state into new class ClasspathContainerState to make it more maintainable.