### PR TITLE
Sort JUnit bundles by name to ensure a consistent ordering

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -629,7 +629,8 @@ class RequiredPluginsClasspathContainer implements IClasspathContainer {
 		Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(roots,
 				INCLUDE_OPTIONAL_DEPENDENCIES);
 		String systemBundleBSN = TargetPlatformHelper.getPDEState().getSystemBundle();
-		return closure.stream().filter(b -> !b.getSymbolicName().equals(systemBundleBSN)).toList();
+		return closure.stream().filter(b -> !b.getSymbolicName().equals(systemBundleBSN))
+				.sorted(Comparator.comparing(BundleDescription::getSymbolicName)).toList();
 	}
 
 	private void addSecondaryDependencies(BundleDescription desc, Set<BundleDescription> added,


### PR DESCRIPTION
Currently Junit bundles and their closure is just returned in a quite random order. This leads to sometimes triggering a rebuild because classpath seems to have changed.

This now sort them by their bundle id to ensure to have always the same order.