### PR TITLE
Do not implement IClasspathContainer

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathComputer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathComputer.java
@@ -32,7 +32,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathAttribute;
-import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaModelStatus;
 import org.eclipse.jdt.core.IJavaProject;
@@ -474,9 +473,10 @@ public class ClasspathComputer {
 		return JavaCore.newContainerEntry(PDECore.REQUIRED_PLUGINS_CONTAINER_PATH);
 	}
 
-	public static IClasspathEntry[] computeClasspathEntries(IPluginModelBase model, IProject project) {
-		IClasspathContainer container = new RequiredPluginsClasspathContainer(model, project);
-		return container.getClasspathEntries();
+	public static IClasspathEntry[] computeClasspathEntries(IPluginModelBase model, IProject project)
+			throws CoreException {
+		RequiredPluginsClasspathContainer container = new RequiredPluginsClasspathContainer(model, project);
+		return container.computeEntries();
 	}
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
@@ -111,13 +111,13 @@ public class ClasspathContainerState {
 					IPluginModelBase model = modelManager.findModel(project);
 					if (model != null && PluginProject.isJavaProject(project)) {
 						IJavaProject javaProject = JavaCore.create(project);
-						RequiredPluginsClasspathContainer classpathContainer = new RequiredPluginsClasspathContainer(
-								model, project);
 						try {
-							if (!isUpToDate(project, classpathContainer.computeEntries(), request.container())) {
-								updateProjects.put(javaProject, classpathContainer);
+							IClasspathEntry[] entries = ClasspathComputer.computeClasspathEntries(model,
+									javaProject.getProject());
+							if (!isUpToDate(project, entries, request.container())) {
+								updateProjects.put(javaProject, PDEClasspathContainerSaveHelper.containerOf(entries));
 								errorsPerProject.remove(project);
-								saveState(project, classpathContainer);
+								saveState(project, entries);
 							}
 						} catch (CoreException e) {
 							errorsPerProject.put(project, e.getStatus());
@@ -213,13 +213,13 @@ public class ClasspathContainerState {
 		return true;
 	}
 
-	private static void saveState(IProject project, RequiredPluginsClasspathContainer classpathContainer) {
+	private static void saveState(IProject project, IClasspathEntry[] entries) {
 		synchronized (project) {
 			try {
 				File stateFile = getStateFile(project);
 				stateFile.getParentFile().mkdirs();
 				try (BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(stateFile))) {
-					PDEClasspathContainerSaveHelper.writeContainer(classpathContainer, stream);
+					PDEClasspathContainerSaveHelper.writeContainerEntries(entries, stream);
 				}
 			} catch (Exception e) {
 				// can't write then...

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -42,7 +42,6 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.IClasspathAttribute;
-import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.osgi.service.resolver.BaseDescription;
@@ -72,7 +71,7 @@ import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Constants;
 
-class RequiredPluginsClasspathContainer implements IClasspathContainer {
+class RequiredPluginsClasspathContainer {
 
 	@SuppressWarnings("nls")
 	private static final Set<String> JUNIT5_RUNTIME_PLUGINS = Set.of("org.junit", //
@@ -112,30 +111,6 @@ class RequiredPluginsClasspathContainer implements IClasspathContainer {
 		}
 		fBuild = buildModel != null ? buildModel.getBuild() : null;
 		this.project = project;
-	}
-
-	@Override
-	public int getKind() {
-		return K_APPLICATION;
-	}
-
-	@Override
-	public IPath getPath() {
-		return PDECore.REQUIRED_PLUGINS_CONTAINER_PATH;
-	}
-
-	@Override
-	public String getDescription() {
-		return PDECoreMessages.RequiredPluginsClasspathContainer_description;
-	}
-
-	@Override
-	public IClasspathEntry[] getClasspathEntries() {
-		try {
-			return computeEntries();
-		} catch (CoreException e) {
-			return new IClasspathEntry[0];
-		}
 	}
 
 	IClasspathEntry[] computeEntries() throws CoreException {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDEClasspathContainerSaveHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/PDEClasspathContainerSaveHelper.java
@@ -66,7 +66,11 @@ public class PDEClasspathContainerSaveHelper {
 		return new SerializableClasspathContainer();
 	}
 
-	public static void writeContainer(IClasspathContainer container, OutputStream output) throws IOException {
+	public static IClasspathContainer containerOf(IClasspathEntry[] entries) {
+		return new SerializableClasspathContainer(entries);
+	}
+
+	public static void writeContainerEntries(IClasspathEntry[] entries, OutputStream output) throws IOException {
 		ObjectOutputStream os = new ObjectOutputStream(new BufferedOutputStream(output)) {
 			{
 				enableReplaceObject(true);
@@ -90,7 +94,7 @@ public class PDEClasspathContainerSaveHelper {
 				return super.replaceObject(o);
 			}
 		};
-		os.writeObject(new SerializableClasspathContainer(container.getClasspathEntries()));
+		os.writeObject(new SerializableClasspathContainer(entries));
 		os.flush();
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SerializableClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SerializableClasspathContainer.java
@@ -57,10 +57,7 @@ class SerializableClasspathContainer implements IClasspathContainer, Serializabl
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + Arrays.hashCode(entries);
-		return result;
+		return Arrays.hashCode(entries);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/RequiredPluginsContainerPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/RequiredPluginsContainerPage.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.wizards;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -199,7 +200,10 @@ public class RequiredPluginsContainerPage extends WizardPage implements IClasspa
 			entry = ClasspathComputer.createContainerEntry();
 			IPluginModelBase model = PluginRegistry.findModel(javaProject.getProject());
 			if (model != null) {
-				realEntries = ClasspathComputer.computeClasspathEntries(model, javaProject.getProject());
+				try {
+					realEntries = ClasspathComputer.computeClasspathEntries(model, javaProject.getProject());
+				} catch (CoreException e) {
+				}
 			}
 		} else {
 			try {


### PR DESCRIPTION
Currently `RequiredPluginsClasspathContainer` itself implements `IClasspathContainer` but we actually only need that instance to compute the entries.

As the `RequiredPluginsClasspathContainer` retains some objects in its instance and to make handling more uniform (e.g. regarding equals and hashcode of container instances) this now removes the actual implementation of the interface and simply wraps the resulting entries in a `SerializableClasspathContainer` that only holds a reference to the entries produced itself.