### PR TITLE
Let ManifestConsistencyChecker use the DebugTrace instead of System.out

### DIFF
--- a/ui/org.eclipse.pde.core/.options
+++ b/ui/org.eclipse.pde.core/.options
@@ -6,6 +6,6 @@ org.eclipse.pde.core/model=false
 # trace for creating targets using a p2 profile
 org.eclipse.pde.core/target/profile=false
 # trace when validating plugin.xml contents
-org.eclipse.pde.core/validation=false
+org.eclipse.pde.core/debug/validation=false
 # trace when read/save the current state of the plugin resolution
 org.eclipse.pde.core/debug/state=false

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -89,11 +89,12 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 	private static final String DEBUG = "/debug"; //$NON-NLS-1$
 
 	public static final String KEY_DEBUG_STATE = DEBUG + "/state"; //$NON-NLS-1$
+	public static final String KEY_DEBUG_VALIDATION = DEBUG + "/validation"; //$NON-NLS-1$
 	private static final String DEBUG_FLAG = PLUGIN_ID + DEBUG;
 	private static final String CLASSPATH_DEBUG = PLUGIN_ID + "/classpath"; //$NON-NLS-1$
 	private static final String MODEL_DEBUG = PLUGIN_ID + "/model"; //$NON-NLS-1$
 	private static final String TARGET_PROFILE_DEBUG = PLUGIN_ID + "/target/profile"; //$NON-NLS-1$
-	private static final String VALIDATION_DEBUG = PLUGIN_ID + "/validation"; //$NON-NLS-1$
+	private static final String VALIDATION_DEBUG = PLUGIN_ID + KEY_DEBUG_VALIDATION;
 	private static final String STATE_DEBUG = PLUGIN_ID + KEY_DEBUG_STATE;
 
 	// Shared instance

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestConsistencyChecker.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/ManifestConsistencyChecker.java
@@ -118,10 +118,14 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 				if (kind == IResourceDelta.ADDED || kind == IResourceDelta.REMOVED) {
 					type = MANIFEST | EXTENSIONS | BUILD | STRUCTURE;
 					if (PDECore.DEBUG_VALIDATION) {
-						System.out.print("Needs to rebuild project [" + getProject().getName() + "]: "); //$NON-NLS-1$ //$NON-NLS-2$
-						System.out.print(delta.getResource().getProjectRelativePath().toString());
-						System.out.print(" - "); //$NON-NLS-1$
-						System.out.println(kind == IResourceDelta.ADDED ? "added" : "removed"); //$NON-NLS-1$ //$NON-NLS-2$
+						StringBuilder sb = new StringBuilder();
+						sb.append("Needs to rebuild project ["); //$NON-NLS-1$
+						sb.append(getProject().getName());
+						sb.append("]: "); //$NON-NLS-1$
+						sb.append(delta.getResource().getProjectRelativePath().toString());
+						sb.append(" - "); //$NON-NLS-1$
+						sb.append(kind == IResourceDelta.ADDED ? "added" : "removed"); //$NON-NLS-1$ //$NON-NLS-2$
+						PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION, sb.toString());
 					}
 					return false;
 				}
@@ -137,30 +141,46 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 					if (isLocalizationFile(resource)) {
 						type |= MANIFEST | EXTENSIONS;
 						if (PDECore.DEBUG_VALIDATION) {
-							System.out.print("Needs to rebuild manifest and extensions in project [" + getProject().getName() + "]: "); //$NON-NLS-1$ //$NON-NLS-2$
-							System.out.print(delta.getResource().getProjectRelativePath().toString());
-							System.out.println(" - changed"); //$NON-NLS-1$
+							StringBuilder sb = new StringBuilder();
+							sb.append("Needs to rebuild manifest and extensions in project ["); //$NON-NLS-1$
+							sb.append(getProject().getName());
+							sb.append("]: "); //$NON-NLS-1$
+							sb.append(delta.getResource().getProjectRelativePath().toString());
+							sb.append(" - changed"); //$NON-NLS-1$
+							PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION, sb.toString());
 						}
 					} else if (file.equals(PDEProject.getManifest(project))) {
 						type |= MANIFEST | EXTENSIONS | BUILD;
 						if (PDECore.DEBUG_VALIDATION) {
-							System.out.print("Needs to rebuild project [" + getProject().getName() + "]: "); //$NON-NLS-1$ //$NON-NLS-2$
-							System.out.print(delta.getResource().getProjectRelativePath().toString());
-							System.out.println(" - changed"); //$NON-NLS-1$
+							StringBuilder sb = new StringBuilder();
+							sb.append("Needs to rebuild project ["); //$NON-NLS-1$
+							sb.append(getProject().getName());
+							sb.append("]: "); //$NON-NLS-1$
+							sb.append(delta.getResource().getProjectRelativePath().toString());
+							sb.append(" - changed"); //$NON-NLS-1$
+							PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION, sb.toString());
 						}
 					} else if (name.endsWith(".exsd") || file.equals(PDEProject.getPluginXml(project)) || file.equals(PDEProject.getFragmentXml(project))) { //$NON-NLS-1$
 						type |= EXTENSIONS | BUILD;
 						if (PDECore.DEBUG_VALIDATION) {
-							System.out.print("Needs to rebuild project [" + getProject().getName() + "]: "); //$NON-NLS-1$ //$NON-NLS-2$
-							System.out.print(delta.getResource().getProjectRelativePath().toString());
-							System.out.println(" - changed"); //$NON-NLS-1$
+							StringBuilder sb = new StringBuilder();
+							sb.append("Needs to rebuild project ["); //$NON-NLS-1$
+							sb.append(getProject().getName());
+							sb.append("]: "); //$NON-NLS-1$
+							sb.append(delta.getResource().getProjectRelativePath().toString());
+							sb.append(" - changed"); //$NON-NLS-1$
+							PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION, sb.toString());
 						}
 					} else if (file.equals(PDEProject.getBuildProperties(project))) {
 						type |= BUILD;
 						if (PDECore.DEBUG_VALIDATION) {
-							System.out.print("Needs to rebuild build.properties in project [" + getProject().getName() + "]: "); //$NON-NLS-1$ //$NON-NLS-2$
-							System.out.print(delta.getResource().getProjectRelativePath().toString());
-							System.out.println(" - changed"); //$NON-NLS-1$
+							StringBuilder sb = new StringBuilder();
+							sb.append("Needs to rebuild build.properties in project ["); //$NON-NLS-1$
+							sb.append(getProject().getName());
+							sb.append("]: "); //$NON-NLS-1$
+							sb.append(delta.getResource().getProjectRelativePath().toString());
+							sb.append(" - changed"); //$NON-NLS-1$
+							PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION, sb.toString());
 						}
 					}
 				}
@@ -203,7 +223,8 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 		// always do a build of the project if a full build or an unspecified change has occurred
 		if (delta == null) {
 			if (PDECore.DEBUG_VALIDATION) {
-				System.out.println("Project [" + getProject().getName() + "] - full build"); //$NON-NLS-1$ //$NON-NLS-2$
+				PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION,
+						"Project [" + getProject().getName() + "] - full build"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			return MANIFEST | EXTENSIONS | BUILD | STRUCTURE;
 		}
@@ -214,7 +235,8 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 		if (Boolean.TRUE.equals(project.getSessionProperty(PDECore.TOUCH_PROJECT))) {
 			project.setSessionProperty(PDECore.TOUCH_PROJECT, null);
 			if (PDECore.DEBUG_VALIDATION) {
-				System.out.println("Dependencies Changed: Project [" + getProject().getName() + "] - full build"); //$NON-NLS-1$ //$NON-NLS-2$
+				PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION,
+						"Dependencies Changed: Project [" + getProject().getName() + "] - full build"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			return MANIFEST | EXTENSIONS | BUILD;
 		}
@@ -238,7 +260,9 @@ public class ManifestConsistencyChecker extends IncrementalProjectBuilder {
 			if (fClassFileVisitor.hasChanged()) {
 				type |= MANIFEST | EXTENSIONS | BUILD;
 				if (PDECore.DEBUG_VALIDATION) {
-					System.out.println("Class files changed due to dependency changes: Project [" + getProject().getName() + "] - rebuild manifest and properties files"); //$NON-NLS-1$ //$NON-NLS-2$
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_VALIDATION,
+							"Class files changed due to dependency changes: Project [" + getProject().getName() //$NON-NLS-1$
+									+ "] - rebuild manifest and properties files"); //$NON-NLS-1$
 				}
 			}
 		}


### PR DESCRIPTION
Currently the ManifestConsistencyChecker prints directly to System.out, not only loosing valuable information like current thread and source this also prevents its messages to be redirected to the trace log if requested.

This now adjust the code to use the DebugTrace instead of System.out.