### PR TITLE
Print a stack dump if initialize is called outside of Initializing Java

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
@@ -129,9 +129,19 @@ public class ClasspathContainerState {
 			if (monitor.isCanceled()) {
 				return Status.CANCEL_STATUS;
 			}
-			if (!updateProjects.isEmpty()) {
+			if (updateProjects.isEmpty()) {
+				if (PDECore.DEBUG_STATE) {
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE,
+							"UpdateClasspathsJob finished, but no project needs an update!"); //$NON-NLS-1$
+				}
+			} else {
 				int i = 0;
 				int n = updateProjects.size();
+				if (PDECore.DEBUG_STATE) {
+					PDECore.TRACE.trace(PDECore.KEY_DEBUG_STATE, String
+							.format("UpdateClasspathsJob finished, there are %d project that need a classpath container update.", //$NON-NLS-1$
+									n));
+				}
 				IJavaProject[] javaProjects = new IJavaProject[n];
 				IClasspathContainer[] container = new IClasspathContainer[n];
 				for (Entry<IJavaProject, IClasspathContainer> entry : updateProjects.entrySet()) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsInitializer.java
@@ -30,6 +30,15 @@ public class RequiredPluginsInitializer extends ClasspathContainerInitializer {
 	public void initialize(IPath containerPath, IJavaProject javaProject) throws CoreException {
 		IProject project = javaProject.getProject();
 		IClasspathContainer savedState = ClasspathContainerState.readState(project);
+		if (PDECore.DEBUG_STATE) {
+			// This should at best only ever be called from the "Initializing
+			// Java Tooling" job, if that is not the case something might be
+			// wrong and we add a stackdump to give more information about the
+			// source
+			if (!Thread.currentThread().getName().contains("Initializing Java Tooling")) { //$NON-NLS-1$
+				PDECore.TRACE.traceDumpStack(PDECore.KEY_DEBUG_STATE);
+			}
+		}
 		ClasspathContainerState.setProjectContainers(new IJavaProject[] { javaProject },
 				new IClasspathContainer[] { savedState }, null);
 		// The saved state might be stale, request a classpath update here, this


### PR DESCRIPTION
Currently one would expect that all calls to initialize the classpath originate from the "Initializing Java Tooling" job, but it happens to be not always the case. If that happens early access to the classpath might lead to unexpected rebuilds or other issues.

This now enhance the tracing to provide a stacktrace in this case to make it more clear where the call is coming from to allow analysis and possible mitigation.