### PR TITLE
Add all required bundles to the classpath

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -404,9 +404,7 @@ class RequiredPluginsClasspathContainer {
 
 		BundleSpecification[] required = desc.getRequiredBundles();
 		for (BundleSpecification element : required) {
-			if (element.isExported()) {
-				addDependency((BundleDescription) element.getSupplier(), added, map, entries, useInclusion);
-			}
+			addDependency((BundleDescription) element.getSupplier(), added, map, entries, useInclusion);
 		}
 
 		if (addImportedPackages) {


### PR DESCRIPTION
When building the classpath, don't skip over bundles that aren't re-exported; when using `javac`, `javac` requires that the classes referenced in `.class` files are present on the classpath.

Fixes eclipse-jdtls/eclipse-jdt-core-incubator#421