### PR TITLE
TestPDETemplates.createProjectWithTemplate use only supported EE

### DIFF
--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for PDE templates
 Bundle-SymbolicName: org.eclipse.pde.ui.templates.tests
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: tests.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -16,7 +16,9 @@ Require-Bundle: org.eclipse.pde.ui;bundle-version="3.10.0",
  org.eclipse.pde.ui.tests
 Automatic-Module-Name: org.eclipse.pde.ui.templates.tests
 Eclipse-BundleShape: dir
-Import-Package: org.hamcrest,
+Import-Package: org.eclipse.jdt.launching,
+ org.eclipse.jdt.launching.environments,
+ org.hamcrest,
  org.junit,
  org.junit.runner,
  org.junit.runners

--- a/ui/org.eclipse.pde.ui.templates.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.templates.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.templates.tests</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.eclipse.jdt.launching.environments.IExecutionEnvironmentsManager;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.ds.internal.annotations.Messages;
 import org.eclipse.pde.internal.core.ICoreConstants;
@@ -117,7 +121,15 @@ public class TestPDETemplates {
 		data.setHasBundleStructure(true);
 		data.setSourceFolderName("src");
 		data.setOutputFolderName("bin");
-		data.setExecutionEnvironment("JavaSE-" + Runtime.version().feature());
+		IExecutionEnvironmentsManager executionEnvironmentsManager = JavaRuntime.getExecutionEnvironmentsManager();
+		IExecutionEnvironment environment = executionEnvironmentsManager
+				.getEnvironment("JavaSE-" + Runtime.version().feature());
+		SortedSet<IExecutionEnvironment> supportedExecutionEnvironments = executionEnvironmentsManager
+				.getSupportedExecutionEnvironments();
+		if (!supportedExecutionEnvironments.contains(environment)) {
+			environment = supportedExecutionEnvironments.last();
+		}
+		data.setExecutionEnvironment(environment.getId());
 		data.setTargetVersion(ICoreConstants.TARGET_VERSION_LATEST);
 		data.setDoGenerateClass(true);
 		String pureOSGi = template.getConfigurationElement().getAttribute("pureOSGi");


### PR DESCRIPTION
- The tests fail when running on Java 25 because that's not currently a supported execution environment.