### PR TITLE
Applications list is filtered using the plugins from the product

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -297,13 +297,15 @@ public class TargetPlatformHelper {
 	}
 
 	public static Set<String> getApplicationNameSet() {
-		return getApplicationNameSet((Set<String>) null);
+		return getApplicationNameSet(java.util.Collections.emptySet());
 	}
 
 	public static Set<String> getApplicationNameSet(Set<String> productBundleNames) {
 		TreeSet<String> result = new TreeSet<>();
 		IExtension[] extensions = PDECore.getDefault().getExtensionsRegistry()
 				.findExtensions("org.eclipse.core.runtime.applications", true); //$NON-NLS-1$
+
+		final boolean toFilter = !productBundleNames.isEmpty();
 
 		for (IExtension extension : extensions) {
 			String id = extension.getUniqueIdentifier();
@@ -313,8 +315,10 @@ public class TargetPlatformHelper {
 			}
 			String contributorId = elements[0].getContributor().getName();
 
-			if (!productBundleNames.contains(contributorId)) {
-				continue;
+			if (toFilter) {
+				if (!productBundleNames.contains(contributorId)) {
+					continue;
+				}
 			}
 
 			String visiblity = elements[0].getAttribute("visible"); //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
@@ -273,10 +273,15 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
+
+		if (models == null) {
+			models = java.util.Collections.emptySet(); // <-- tiny null guard
+		}
+
 		Set<String> productBundleSymbolicNames = new HashSet<>();
 		for (IPluginModelBase model : models) {
 			BundleDescription desc = model.getBundleDescription();
-			if (desc != null) {
+			if (desc != null && desc.getSymbolicName() != null) {
 				String symbolicName = desc.getSymbolicName();
 				productBundleSymbolicNames.add(symbolicName);
 			}


### PR DESCRIPTION
Fixed the issue where the list of applications included all applications, even invalid ones like "org.eclipse.equinox.p2.director" , which caused the product to fail when launched with those invalid applications.

Was fixed it collaboration with my teammates: @krishneetRAJ and @vihuynh72. 

We implemented a way of filtering the list of applications by getting the plugins/dependencies from the product and filtering the list using the plugins. The more plugins you add the more applications will be available.

Fixes issue : [#1052](https://github.com/eclipse-pde/eclipse.pde/issues/1052)

Before: 

<img width="1061" height="835" alt="Screenshot 2025-08-19 at 1 28 17 PM" src="https://github.com/user-attachments/assets/4df1430c-b76e-43c2-a68b-774c7c56d874" />

After: 

<img width="944" height="628" alt="Screenshot 2025-08-19 at 1 29 22 PM" src="https://github.com/user-attachments/assets/2be61362-30ed-42e9-a29d-a782fb526dfb" />

The list above was filtered using these plugins: 

<img width="1087" height="440" alt="Screenshot 2025-08-19 at 1 28 33 PM" src="https://github.com/user-attachments/assets/b09bc5a7-53ab-4bbd-ab3f-391fb8e2b1f1" />
