### PR TITLE
Docs: Include PDE Usage Scenarios in Developer Resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ more.
 
 * https://projects.eclipse.org/projects/eclipse.pde/developer
 
+PDE Usage Scenarios (testing builds)
+
+* https://eclipse.dev/pde/pde-ui/scenarios/PDEScenarios3_0.html
+
 The project maintains the following source code repositories
 
 * https://github.com/eclipse-pde/eclipse.pde/


### PR DESCRIPTION
This PR adds a link in the CONTRIBUTING.md under Developer resources to https://eclipse.dev/pde/pde-ui/scenarios/PDEScenarios3_0.html.
This resource provides guidance for testing builds in specific scenarios. Adding it to the documentation will help contributors verify their changes in existing situations that are not fully covered by the existing docs.

Thank you to @JTRBG123 and @wannidapolchan for helping with this.