### PR TITLE
Showing a preview of the target state in the editor

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.16.200.qualifier
+Bundle-Version: 3.16.300.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -26,6 +26,8 @@ import org.eclipse.osgi.util.NLS;
 public class PDEUIMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.pde.internal.ui.pderesources";//$NON-NLS-1$
 
+	public static String StatePage_title;
+
 	public static String AbstractLauncherToolbar_noProblems;
 
 	public static String AbstractLauncherToolbar_noSelection;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ManifestEditor.java
@@ -16,6 +16,8 @@ package org.eclipse.pde.internal.ui.editor.plugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.zip.ZipFile;
 
@@ -173,6 +175,14 @@ public class ManifestEditor extends PDELauncherFormEditor implements IShowEditor
 			for (IPluginModelBase model : models) {
 				if (version.equals(model.getPluginBase().getVersion())) {
 					return open(model.getPluginBase(), true);
+				}
+			}
+			String location = desc.getLocation();
+			if (location != null && location.toLowerCase().startsWith("file:")) { //$NON-NLS-1$
+				try {
+					File file = new File(new URI(location));
+					return openExternalPlugin(file, ICoreConstants.BUNDLE_FILENAME_DESCRIPTOR);
+				} catch (URISyntaxException e) {
 				}
 			}
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/StatePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/StatePage.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.targetdefinition;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.equinox.frameworkadmin.BundleInfo;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
+import org.eclipse.osgi.util.ManifestElement;
+import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.TargetBundle;
+import org.eclipse.pde.internal.build.BundleHelper;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.eclipse.pde.internal.ui.views.target.StateTree;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.forms.editor.FormPage;
+import org.osgi.framework.FrameworkUtil;
+
+public class StatePage extends FormPage {
+
+	public static final String PAGE_ID = "state"; //$NON-NLS-1$
+
+	private State state;
+
+	private StateTree stateTree;
+
+	private ITargetDefinition target;
+
+	private Job job;
+
+	private boolean active;
+
+	public StatePage(TargetEditor editor) {
+		super(editor, PAGE_ID, PDEUIMessages.StatePage_title);
+	}
+
+	@Override
+	public void createPartControl(Composite parent) {
+		stateTree = new StateTree(parent);
+		stateTree.setInput(state);
+	}
+
+	@Override
+	public Control getPartControl() {
+		return stateTree;
+	}
+
+	@Override
+	public void setActive(boolean active) {
+		this.active = active;
+		super.setActive(active);
+		loadState();
+	}
+
+	private void loadState() {
+		if (!active || state != null || target == null) {
+			return;
+		}
+		TargetBundle[] targetBundles = target.getBundles();
+		if (targetBundles == null || targetBundles.length == 0) {
+			return;
+		}
+		job = Job.create("Compute Target State", monitor -> { //$NON-NLS-1$
+			try {
+				State targetState = BundleHelper.getPlatformAdmin().getFactory().createState(true);
+				targetState.setPlatformProperties(
+						PDECore.getDefault().getModelManager().getState().getState().getPlatformProperties());
+				StateObjectFactory factory = targetState.getFactory();
+				long id = 1;
+				for (TargetBundle targetBundle : targetBundles) {
+					if (targetBundle.isSourceBundle()) {
+						continue;
+					}
+					BundleInfo bundleInfo = targetBundle.getBundleInfo();
+					String manifest = bundleInfo.getManifest();
+					if (manifest != null) {
+						Map<String, String> bundleManifest;
+						try (ByteArrayInputStream stream = new ByteArrayInputStream(
+								manifest.getBytes(StandardCharsets.UTF_8))) {
+							bundleManifest = ManifestElement.parseBundleManifest(stream);
+						}
+						BundleDescription bundleDescription = factory.createBundleDescription(targetState,
+								FrameworkUtil.asDictionary(bundleManifest),
+								String.valueOf(targetBundle.getBundleInfo().getLocation()), id++);
+						targetState.addBundle(bundleDescription);
+					}
+					if (monitor.isCanceled()) {
+						return Status.CANCEL_STATUS;
+					}
+				}
+				targetState.resolve(false);
+				if (monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
+				}
+				PlatformUI.getWorkbench().getDisplay().execute(() -> {
+					state = targetState;
+					if (stateTree != null) {
+						stateTree.setInput(targetState);
+					}
+				});
+			} catch (Exception e) {
+				ILog.get().error("Computing target state failed!", e); //$NON-NLS-1$
+			}
+			return Status.OK_STATUS;
+		});
+		job.schedule();
+	}
+
+	public void reset() {
+		PlatformUI.getWorkbench().getDisplay().execute(() -> {
+			update(null);
+			if (stateTree != null) {
+				stateTree.setInput(null);
+			}
+		});
+	}
+
+	protected void update(ITargetDefinition target) {
+		if (job != null) {
+			job.cancel();
+			job = null;
+		}
+		this.state = null;
+		this.target = target;
+	}
+
+	public void updateTarget(ITargetDefinition target) {
+		PlatformUI.getWorkbench().getDisplay().execute(() -> {
+			update(target);
+			loadState();
+		});
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -132,6 +132,7 @@ public class TargetEditor extends FormEditor {
 	private ImageHyperlink fLoadHyperlink;
 
 	private final EventHandler fEventHandler = this::handleBrokerEvent;
+	private StatePage statePage;
 
 	@Override
 	protected FormToolkit createToolkit(Display display) {
@@ -145,6 +146,8 @@ public class TargetEditor extends FormEditor {
 			addPage(new DefinitionPage(this));
 			addPage(new ContentPage(this));
 			addPage(new EnvironmentPage(this));
+			statePage = new StatePage(this);
+			addPage(statePage);
 			addTextualEditorPage();
 		} catch (CoreException e) {
 			PDEPlugin.log(e);
@@ -650,6 +653,7 @@ public class TargetEditor extends FormEditor {
 					// Check to see if we are resolved, resolving, or cancelled
 					if (target != null && target.isResolved()) {
 						fContentTree.setInput(getTarget());
+						statePage.updateTarget(getTarget());
 					} else if (Job.getJobManager().find(getJobFamily()).length > 0) {
 						fContentTree.setInput(null);
 					} else {
@@ -674,6 +678,7 @@ public class TargetEditor extends FormEditor {
 				if (name == null) {
 					name = ""; //$NON-NLS-1$
 				}
+				statePage.reset();
 				Job resolveJob = new Job(NLS.bind(PDEUIMessages.TargetEditor_1, name)) {
 					@Override
 					protected IStatus run(IProgressMonitor monitor) {
@@ -688,6 +693,7 @@ public class TargetEditor extends FormEditor {
 						if (monitor.isCanceled()) {
 							return Status.CANCEL_STATUS;
 						}
+						statePage.updateTarget(getTarget());
 						// Don't return any problems because we don't want an error dialog
 						return Status.OK_STATUS;
 					}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -2727,3 +2727,4 @@ ProjectUpdateChange_configure_nature_and_builder=Update natures and builder
 ProjectUpdateChange_convert_manifest_to_bnd=Convert MANIFEST.MF to bnd instructions
 ProjectUpdateChange_convert_build_to_bnd=Convert build.properties to bnd instructions
 ProjectUpdateChange_set_pde_preference=Set {0} in preferences
+StatePage_title=Target State

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/target/StateTree.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/target/StateTree.java
@@ -1,0 +1,285 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     EclipseSource Corporation - ongoing enhancements
+ *     Anyware Technologies - ongoing enhancements
+ *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 487943
+ *     Christoph Läubrich - extracted from {@link StateViewPage}
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.views.target;
+
+import java.util.ArrayList;
+
+import org.eclipse.jdt.ui.ISharedImages;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.StyledCellLabelProvider;
+import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.ViewerCell;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.BundleSpecification;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
+import org.eclipse.osgi.service.resolver.ImportPackageSpecification;
+import org.eclipse.osgi.service.resolver.ResolverError;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.VersionConstraint;
+import org.eclipse.pde.internal.ui.PDELabelProvider;
+import org.eclipse.pde.internal.ui.PDEPlugin;
+import org.eclipse.pde.internal.ui.PDEPluginImages;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.eclipse.pde.internal.ui.editor.plugin.ManifestEditor;
+import org.eclipse.pde.internal.ui.util.SharedLabelProvider;
+import org.eclipse.pde.internal.ui.views.dependencies.DependenciesViewComparator;
+import org.eclipse.pde.internal.ui.views.target.StateViewPage.DependencyGroup;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.dialogs.FilteredTree;
+import org.eclipse.ui.dialogs.PatternFilter;
+import org.osgi.framework.Version;
+
+public class StateTree extends FilteredTree {
+
+	@SuppressWarnings("deprecation")
+	public StateTree(Composite parent) {
+		super(parent, SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL | SWT.SINGLE, new PatternFilter(), true);
+		TreeViewer fTreeViewer = getViewer();
+		fTreeViewer.setContentProvider(new StateContentProvider());
+		fTreeViewer.setLabelProvider(new StateLabelProvider());
+		fTreeViewer.setComparator(DependenciesViewComparator.getViewerComparator());
+		fTreeViewer.addDoubleClickListener(event -> handleDoubleClick());
+	}
+
+	@Override
+	protected void createControl(Composite parent, int treeStyle) {
+		super.createControl(parent, treeStyle);
+
+		// add 2px margin around filter text
+
+		FormLayout layout = new FormLayout();
+		layout.marginHeight = 0;
+		layout.marginWidth = 0;
+		setLayout(layout);
+
+		FormData data = new FormData();
+		data.left = new FormAttachment(0, 0);
+		data.right = new FormAttachment(100, 0);
+		data.bottom = new FormAttachment(100, 0);
+		if (showFilterControls) {
+			FormData filterData = new FormData();
+			filterData.top = new FormAttachment(0, 2);
+			filterData.left = new FormAttachment(0, 2);
+			filterData.right = new FormAttachment(100, -2);
+			filterComposite.setLayoutData(filterData);
+			data.top = new FormAttachment(filterComposite, 2);
+		} else {
+			data.top = new FormAttachment(0, 0);
+		}
+		treeComposite.setLayoutData(data);
+	}
+
+	private static class StateContentProvider implements ITreeContentProvider {
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			if (parentElement instanceof BundleDescription desc) {
+				if (desc.isResolved()) {
+					Object[] required = getResolvedDependencies(desc.getRequiredBundles());
+					Object[] imported = getResolvedDependencies(desc.getImportPackages());
+					ArrayList<DependencyGroup> list = new ArrayList<>(2);
+					if (required.length > 0) {
+						list.add(new DependencyGroup(required));
+					}
+					if (imported.length > 0) {
+						list.add(new DependencyGroup(imported));
+					}
+					return list.toArray();
+				}
+				return desc.getContainingState().getResolverErrors(desc);
+			} else if (parentElement instanceof DependencyGroup) {
+				return ((DependencyGroup) parentElement).getChildren();
+			}
+			return new Object[0];
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			return getChildren(element).length > 0;
+		}
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			if (inputElement instanceof State) {
+				return ((State) inputElement).getBundles();
+			}
+			return new Object[0];
+		}
+
+		private Object[] getResolvedDependencies(VersionConstraint[] constraints) {
+			ArrayList<VersionConstraint> list = new ArrayList<>(constraints.length);
+			for (VersionConstraint constraint : constraints) {
+				if (constraint.isResolved()) {
+					list.add(constraint);
+				}
+			}
+			return list.toArray();
+		}
+
+	}
+
+	private static class StateLabelProvider extends StyledCellLabelProvider implements ILabelProvider {
+		private final PDELabelProvider fSharedProvider;
+
+		public StateLabelProvider() {
+			fSharedProvider = PDEPlugin.getDefault().getLabelProvider();
+			fSharedProvider.connect(this);
+		}
+
+		@Override
+		public void dispose() {
+			fSharedProvider.disconnect(this);
+			super.dispose();
+		}
+
+		@Override
+		public void update(ViewerCell cell) {
+			Object element = cell.getElement();
+			StyledString styledString = new StyledString();
+			if (element instanceof ImportPackageSpecification spec) {
+				styledString.append(spec.getName());
+				ExportPackageDescription supplier = (ExportPackageDescription) spec.getSupplier();
+				if (isJREPackage(supplier)) {
+					styledString.append(PDEUIMessages.StateViewPage_suppliedByJRE);
+				} else {
+					styledString.append(PDEUIMessages.StateViewPage_suppliedBy);
+					getElementString(supplier.getSupplier(), styledString, false);
+				}
+			} else {
+				getElementString(element, styledString, true);
+			}
+
+			cell.setText(styledString.toString());
+			cell.setStyleRanges(styledString.getStyleRanges());
+			cell.setImage(getImage(element));
+			super.update(cell);
+		}
+
+		private void getElementString(Object element, StyledString styledString, boolean showLocation) {
+			if (element instanceof BundleSpecification) {
+				styledString.append(((BundleSpecification) element).getSupplier().toString());
+			} else if (element instanceof BundleDescription description) {
+				styledString.append(fSharedProvider.getObjectText(description));
+				Version version = description.getVersion();
+				// Bug 183417 - Bidi3.3: Elements' labels in the extensions page
+				// in the fragment manifest characters order is incorrect
+				// Use the PDELabelProvider.formatVersion function to properly
+				// format the version for all languages including bidi
+				styledString.append(' ').append(PDELabelProvider.formatVersion(version.toString())).toString();
+				if (showLocation && description.getLocation() != null) {
+					styledString.append(" - " + description.getLocation(), StyledString.DECORATIONS_STYLER); //$NON-NLS-1$
+				}
+			} else {
+				styledString.append(element.toString());
+			}
+		}
+
+		@Override
+		public Image getImage(Object element) {
+			if (element instanceof DependencyGroup) {
+				element = ((DependencyGroup) element).getChildren()[0];
+			}
+			if (element instanceof BundleSpecification) {
+				element = ((BundleSpecification) element).getSupplier();
+			}
+			if (element instanceof BundleDescription) {
+				int flags = ((BundleDescription) element).isResolved() ? 0 : SharedLabelProvider.F_ERROR;
+				return (((BundleDescription) element).getHost() == null)
+						? fSharedProvider.get(PDEPluginImages.DESC_PLUGIN_OBJ, flags)
+						: fSharedProvider.get(PDEPluginImages.DESC_FRAGMENT_OBJ, flags);
+			}
+			if (element instanceof ImportPackageSpecification) {
+				return JavaUI.getSharedImages().getImage(ISharedImages.IMG_OBJS_PACKAGE);
+			}
+			if (element instanceof ResolverError) {
+				if (((ResolverError) element).getType() == ResolverError.PLATFORM_FILTER) {
+					return fSharedProvider.get(PDEPluginImages.DESC_OPERATING_SYSTEM_OBJ);
+				}
+				return fSharedProvider.getImage(element);
+			}
+			return null;
+		}
+
+		@Override
+		public String getText(Object element) {
+			String result = element.toString();
+			if (element instanceof ImportPackageSpecification spec) {
+				result = spec.getName();
+			} else if (element instanceof BundleSpecification) {
+				result = ((BundleSpecification) element).getSupplier().toString();
+			} else if (element instanceof BundleDescription description) {
+				result = fSharedProvider.getObjectText(description);
+			}
+			return result;
+		}
+	}
+
+	private static boolean isJREPackage(ExportPackageDescription supplier) {
+		// check for runtime's non-API directive. This may change in the future
+		return (((Integer) supplier.getDirective("x-equinox-ee")).intValue() > 0); //$NON-NLS-1$
+	}
+
+	protected void handleDoubleClick() {
+		IStructuredSelection selection = getViewer().getStructuredSelection();
+		if (selection.size() == 1) {
+			BundleDescription desc = getBundleDescription();
+			if (desc != null) {
+				ManifestEditor.open(desc, false);
+			}
+		}
+	}
+
+	public BundleDescription getBundleDescription() {
+		IStructuredSelection selection = getViewer().getStructuredSelection();
+		if (selection.size() == 1) {
+			Object obj = selection.getFirstElement();
+			if (obj instanceof BundleSpecification) {
+				obj = ((BundleSpecification) obj).getSupplier();
+			} else if (obj instanceof ImportPackageSpecification) {
+				obj = ((ImportPackageSpecification) obj).getSupplier().getSupplier();
+			}
+			if (obj instanceof BundleDescription) {
+				return (BundleDescription) obj;
+			}
+		}
+		return null;
+	}
+
+	public void setInput(State state) {
+		TreeViewer viewer = getViewer();
+		if (viewer.getControl().isDisposed()) {
+			return;
+		}
+		viewer.setInput(state);
+	}
+
+}


### PR DESCRIPTION
Currently if one loads a target not using the planner mode there is no guarantee setting it will actually lead to a satisfiable solution. And even with planner mode there are cases where P2 can get to a different result than a real OSGi resolution or there are location types that do not resolve at all. So currently one is forced to actually set the target platform, then look at the target platform state view, identify the problem, change something and start again.

This aims to add a new tab "Resolved State" that shows the resolved state of the bundles that would be set as a result of activate the current target platform.