### PR TITLE
Possible misspelling of function name for changesForModelModication()

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/nls/ExternalizeStringsOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/nls/ExternalizeStringsOperation.java
@@ -110,7 +110,7 @@ public class ExternalizeStringsOperation extends WorkspaceModifyOperation {
 
 	private void getChangeForBuild(IFile buildPropsFile, IProgressMonitor monitor, CompositeChange parent, final String localization) {
 		// Create change
-		TextFileChange[] changes = PDEModelUtility.changesForModelModication(new ModelModification(buildPropsFile) {
+		TextFileChange[] changes = PDEModelUtility.changesForModelModification(new ModelModification(buildPropsFile) {
 			@Override
 			protected void modifyModel(IBaseModel model, IProgressMonitor monitor) throws CoreException {
 
@@ -192,7 +192,7 @@ public class ExternalizeStringsOperation extends WorkspaceModifyOperation {
 			return;
 		}
 		final String localiz = change.getBundleLocalization();
-		TextFileChange[] result = PDEModelUtility.changesForModelModication(new ModelModification(manifest) {
+		TextFileChange[] result = PDEModelUtility.changesForModelModification(new ModelModification(manifest) {
 			@Override
 			protected void modifyModel(IBaseModel model, IProgressMonitor monitor) throws CoreException {
 				if (model instanceof IBundlePluginModelBase bundleModel) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/RenameExtensionPointProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/RenameExtensionPointProcessor.java
@@ -104,7 +104,8 @@ public class RenameExtensionPointProcessor extends RefactoringProcessor {
 	protected void changeExtensionPoint(CompositeChange compositeChange, IProgressMonitor monitor) {
 		IFile file = getModificationFile(fInfo.getBase());
 		if (file != null) {
-			compositeChange.addAll(PDEModelUtility.changesForModelModication(getExtensionPointModification(file), monitor));
+			compositeChange
+					.addAll(PDEModelUtility.changesForModelModification(getExtensionPointModification(file), monitor));
 		}
 	}
 
@@ -115,7 +116,8 @@ public class RenameExtensionPointProcessor extends RefactoringProcessor {
 		for (int i = 0; i < bases.length; i++) {
 			IFile file = getModificationFile(bases[i]);
 			if (file != null) {
-				compositeChange.addAll(PDEModelUtility.changesForModelModication(getExtensionModification(file), subMonitor.split(1)));
+				compositeChange.addAll(PDEModelUtility.changesForModelModification(getExtensionModification(file),
+						subMonitor.split(1)));
 			}
 			subMonitor.setWorkRemaining(bases.length - i);
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/PDEModelUtility.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/util/PDEModelUtility.java
@@ -305,7 +305,8 @@ public class PDEModelUtility {
 		}
 	}
 
-	public static TextFileChange[] changesForModelModication(final ModelModification modification, final IProgressMonitor monitor) {
+	public static TextFileChange[] changesForModelModification(final ModelModification modification,
+			final IProgressMonitor monitor) {
 		final PDEFormEditor editor = getOpenEditor(modification);
 		if (editor != null) {
 			Display.getDefault().syncExec(() -> {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifest.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifest.java
@@ -387,7 +387,7 @@ public class OrganizeManifest implements IOrganizeManifestsSettings {
 			return new TextFileChange[0];
 		}
 
-		return PDEModelUtility.changesForModelModication(new ModelModification(propertiesFile) {
+		return PDEModelUtility.changesForModelModification(new ModelModification(propertiesFile) {
 			@Override
 			protected void modifyModel(IBaseModel model, IProgressMonitor monitor) throws CoreException {
 				if (!(model instanceof IBuildModel)) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifestsProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/OrganizeManifestsProcessor.java
@@ -136,7 +136,7 @@ public class OrganizeManifestsProcessor extends RefactoringProcessor implements 
 				}
 			}
 		};
-		Change[] changes = PDEModelUtility.changesForModelModication(modification, subMonitor);
+		Change[] changes = PDEModelUtility.changesForModelModification(modification, subMonitor);
 		for (Change changeItem : changes) {
 			change.add(changeItem);
 		}


### PR DESCRIPTION
The change from changesForModelModication() to changesForModelModification() (originally declared in the PDEModelUtility.java file) is being made to improve the coding and debugging experience for developers. One of the parameters that this function takes in is final ModelModification modification, which makes me think that Modication should be Modification instead. This would help save time with debugging since when I was working on Issue 1813, I saw that there was an error message with the function and I could not figure out what was wrong until I saw that I misspelled the function by one letter.