### PR TITLE
UI support for setting filter attribute in feature editor

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/IPluginImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/plugin/IPluginImport.java
@@ -35,6 +35,11 @@ public interface IPluginImport extends IPluginObject, IPluginReference {
 	String P_OPTIONAL = "optional"; //$NON-NLS-1$
 
 	/**
+	 * @since 3.21
+	 */
+	String P_FILTER = "filter"; //$NON-NLS-1$
+
+	/**
 	 * Tests whether the imported plug-in is reexported for
 	 * plug-ins that will use this plug-in.
 	 *
@@ -69,5 +74,26 @@ public interface IPluginImport extends IPluginObject, IPluginReference {
 	 * @throws CoreException if the model is not editable
 	 */
 	void setOptional(boolean value) throws CoreException;
+
+	/**
+	 * Sets the filter string applied to this import when resolving the required
+	 * plug-in.
+	 *
+	 * @param filter
+	 *            the filter string to associate with this import, or
+	 *            {@code null} to clear it
+	 * @throws CoreException
+	 *             if the model is not editable
+	 * @since 3.21
+	 */
+	void setFilter(String filter) throws CoreException;
+
+	/**
+	 * Returns the filter string for this plugin reference.
+	 *
+	 * @return the filter string, or null if not set
+	 * @since 3.21
+	 */
+	String getFilter();
 
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/plugin/PluginImport.java
@@ -46,6 +46,7 @@ public class PluginImport extends IdentifiablePluginObject implements IPluginImp
 	private boolean reexported = false;
 	private boolean optional = false;
 	private String version;
+	private String filter;
 
 	public PluginImport() {
 	}
@@ -72,6 +73,11 @@ public class PluginImport extends IdentifiablePluginObject implements IPluginImp
 	@Override
 	public String getVersion() {
 		return version;
+	}
+
+	@Override
+	public String getFilter() {
+		return filter;
 	}
 
 	@Override
@@ -201,6 +207,14 @@ public class PluginImport extends IdentifiablePluginObject implements IPluginImp
 		String oldValue = this.version;
 		this.version = version;
 		firePropertyChanged(P_VERSION, oldValue, version);
+	}
+
+	@Override
+	public void setFilter(String filter) throws CoreException {
+		ensureModelEditable();
+		String oldValue = this.filter;
+		this.filter = filter;
+		firePropertyChanged(P_FILTER, oldValue, filter);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginImportNode.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/plugin/PluginImportNode.java
@@ -21,6 +21,16 @@ public class PluginImportNode extends PluginObjectNode implements IPluginImport 
 
 	private static final long serialVersionUID = 1L;
 
+	@Override
+	public void setFilter(String filter) {
+		setXMLAttribute(P_FILTER, filter);
+	}
+
+	@Override
+	public String getFilter() {
+		return getXMLAttributeValue(P_FILTER);
+	}
+
 	public PluginImportNode(String id) {
 		super();
 		String name = "plugin"; //$NON-NLS-1$

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -247,6 +247,7 @@ public class PDEUIMessages extends NLS {
 	public static String ContainerRenameParticipant_renameBundleId;
 
 	public static String ControlValidationUtility_errorMsgFilterInvalidSyntax;
+	public static String ControlValidationUtility_errorMsgFeatureFilterInvalidSyntax;
 	public static String ControlValidationUtility_errorMsgKeyNotFound;
 	public static String ControlValidationUtility_errorMsgNotOnClasspath;
 	public static String ControlValidationUtility_errorMsgPluginUnresolved;
@@ -977,6 +978,7 @@ public class PDEUIMessages extends NLS {
 	public static String ManifestEditor_MatchSection_equivalent;
 	public static String ManifestEditor_MatchSection_compatible;
 	public static String ManifestEditor_MatchSection_greater;
+	public static String ManifestEditor_MatchSection_filter;
 
 	public static String ManifestEditor_PluginSpecSection_title;
 	public static String ManifestEditor_PluginSpecSection_desc;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/MatchSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/MatchSection.java
@@ -25,6 +25,7 @@ import org.eclipse.pde.core.IModelChangedEvent;
 import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginImport;
 import org.eclipse.pde.core.plugin.IPluginReference;
+import org.eclipse.pde.internal.core.ifeature.IFeatureImport;
 import org.eclipse.pde.internal.core.plugin.ImportObject;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
@@ -32,6 +33,8 @@ import org.eclipse.pde.internal.ui.editor.FormEntryAdapter;
 import org.eclipse.pde.internal.ui.editor.FormLayoutFactory;
 import org.eclipse.pde.internal.ui.editor.PDEFormPage;
 import org.eclipse.pde.internal.ui.editor.PDESection;
+import org.eclipse.pde.internal.ui.editor.validation.ControlValidationUtility;
+import org.eclipse.pde.internal.ui.editor.validation.TextValidator;
 import org.eclipse.pde.internal.ui.parts.ComboPart;
 import org.eclipse.pde.internal.ui.parts.FormEntry;
 import org.eclipse.swt.SWT;
@@ -44,6 +47,8 @@ import org.eclipse.ui.forms.IFormPart;
 import org.eclipse.ui.forms.IPartSelectionListener;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
 
 public class MatchSection extends PDESection implements IPartSelectionListener {
 
@@ -51,6 +56,8 @@ public class MatchSection extends PDESection implements IPartSelectionListener {
 	private Button fOptionalButton;
 
 	private FormEntry fVersionText;
+	private FormEntry fFilterText;
+	private TextValidator fFilterEntryValidator;
 
 	private ComboPart fMatchCombo;
 	protected IPluginReference fCurrentImport;
@@ -134,6 +141,32 @@ public class MatchSection extends PDESection implements IPartSelectionListener {
 		}));
 		toolkit.paintBordersFor(container);
 		initialize();
+
+		fFilterText = new FormEntry(container, toolkit, PDEUIMessages.ManifestEditor_MatchSection_filter, null, false);
+		fFilterText.setFormEntryListener(
+				new FormEntryAdapter(this, getPage().getEditor().getEditorSite().getActionBars()) {
+					@Override
+					public void textValueChanged(FormEntry text) {
+						applyFilter(text.getValue());
+					}
+
+					@Override
+					public void textDirty(FormEntry text) {
+						if (fBlockChanges) {
+							return;
+						}
+						markDirty();
+						fBlockChanges = true;
+						resetMatchCombo(fCurrentImport);
+						fBlockChanges = false;
+					}
+				});
+		fFilterEntryValidator = new TextValidator(getManagedForm(), fFilterText.getText(), getProject(), true) {
+			@Override
+			protected boolean validateControl() {
+				return validateFilter();
+			}
+		};
 		update((IPluginReference) null);
 
 		section.setClient(container);
@@ -141,6 +174,14 @@ public class MatchSection extends PDESection implements IPartSelectionListener {
 		section.setDescription(PDEUIMessages.MatchSection_desc);
 		section.setLayout(FormLayoutFactory.createClearGridLayout(false, 1));
 		section.setLayoutData(new GridData(GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_BEGINNING));
+	}
+
+	private boolean validateFilter() {
+		if (fFilterText.getText().getText().length() == 0) {
+			return true;
+		}
+		return ControlValidationUtility.validateFilterField(fFilterText.getText().getText(),
+				fFilterEntryValidator);
 	}
 
 	private void createReexportButton(FormToolkit toolkit, Composite container) {
@@ -197,6 +238,34 @@ public class MatchSection extends PDESection implements IPartSelectionListener {
 			}
 		} catch (CoreException ex) {
 			PDEPlugin.logException(ex);
+		}
+	}
+
+	private void applyFilter(String filter) {
+		try {
+			if (fCurrentImport == null)
+				return;
+			if (fCurrentImport instanceof IFeatureImport) {
+				IFeatureImport featureImport = (IFeatureImport) fCurrentImport;
+				if (filter == null || filter.isEmpty())
+					featureImport.setFilter(null);
+				else {
+					FrameworkUtil.createFilter(filter);
+					featureImport.setFilter(filter);
+				}
+			} else if (fCurrentImport instanceof IPluginImport) {
+				IPluginImport pluginImport = (IPluginImport) fCurrentImport;
+				if (filter == null || filter.isEmpty())
+					pluginImport.setFilter(null);
+				else {
+					FrameworkUtil.createFilter(filter);
+					pluginImport.setFilter(filter);
+				}
+			}
+		} catch (InvalidSyntaxException e) {
+			PDEPlugin.logException(e);
+		} catch (CoreException e) {
+			PDEPlugin.logException(e);
 		}
 	}
 
@@ -272,8 +341,11 @@ public class MatchSection extends PDESection implements IPartSelectionListener {
 			}
 			fVersionText.setValue(null, true);
 			fVersionText.setEditable(false);
+
 			fMatchCombo.getControl().setEnabled(false);
 			fMatchCombo.setText(""); //$NON-NLS-1$
+			fFilterText.setValue(null, true);
+			fFilterText.setEditable(false);
 			fCurrentImport = null;
 			fBlockChanges = false;
 			return;
@@ -292,7 +364,16 @@ public class MatchSection extends PDESection implements IPartSelectionListener {
 		}
 		fVersionText.setEditable(isEditable());
 		fVersionText.setValue(fCurrentImport.getVersion());
+
 		resetMatchCombo(fCurrentImport);
+		fFilterText.setEditable(isEditable());
+		if (fCurrentImport instanceof IFeatureImport featureImport) {
+			fFilterText.setValue(featureImport.getFilter());
+		} else if (fCurrentImport instanceof IPluginImport pluginImport) {
+			fFilterText.setValue(pluginImport.getFilter());
+		} else {
+			fFilterText.setValue(null);
+		}
 		fBlockChanges = false;
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/validation/ControlValidationUtility.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/validation/ControlValidationUtility.java
@@ -95,6 +95,19 @@ public class ControlValidationUtility {
 		return true;
 	}
 
+	public static boolean validateFilterField(String value, IValidatorMessageHandler validator) {
+		// Check to see if the platform filter syntax is valid
+		try {
+			PDECore.getDefault().getBundleContext().createFilter(value);
+		} catch (InvalidSyntaxException ise) {
+			validator.addMessage(PDEUIMessages.ControlValidationUtility_errorMsgFeatureFilterInvalidSyntax,
+					IMessageProvider.ERROR);
+			return false;
+		}
+
+		return true;
+	}
+
 	public static boolean validateActivatorField(String value, IValidatorMessageHandler validator, IProject project) {
 
 		// Check the compiler flag and translate it into a message type

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -388,6 +388,7 @@ ManifestEditor_MatchSection_perfect = Perfect
 ManifestEditor_MatchSection_equivalent = Equivalent
 ManifestEditor_MatchSection_compatible = Compatible
 ManifestEditor_MatchSection_greater = Greater or Equal
+ManifestEditor_MatchSection_filter = Filter:
 
 ManifestEditor_PluginSpecSection_title = General Information
 ManifestEditor_PluginSpecSection_desc = This section describes general information about this plug-in.
@@ -2523,6 +2524,7 @@ ControlValidationUtility_errorMsgValueMustBeSpecified=A value must be specified
 ControlValidationUtility_errorMsgValueNotExternalized=The specified value is not externalized
 ControlValidationUtility_errorMsgKeyNotFound=The specified key is not present in the plug-in's properties file
 ControlValidationUtility_errorMsgFilterInvalidSyntax=The specified platform filter contains invalid syntax
+ControlValidationUtility_errorMsgFeatureFilterInvalidSyntax=The specified feature filter contains invalid syntax
 PackageFinder_taskName=Searching class files for package references
 
 UpdateSingleton_dir_label=Update ''{0}'' to 'singleton' directive true


### PR DESCRIPTION
### Summary

Continuation of closed PR #1931 

**Issue**
Add support for setting the filter attribute in the feature editor under the dependencies tab #1808, 

**Solution**
- Added a filter textfield
- Textfield contents are validated by parsing as an OSGi filter
- Textfield contents are also verified to have valid syntax
- User input is processed by setFilter into an XML write function, which directly imports it into the corresponding XML file. 
- tested for multiple features and existing Eclipse PDE features
<img width="1070" height="656" alt="image" src="https://github.com/user-attachments/assets/3b907fb5-281c-4e76-b675-0e745b3107e5" />

<img width="1067" height="674" alt="image" src="https://github.com/user-attachments/assets/f4f76f93-7f07-4673-8f51-66f93264fbb0" />






@KN0987 @BAlgarra
