### PR TITLE
Fix split package between swt.spies and swt.tools

### DIFF
--- a/ui/org.eclipse.swt.tools.spies/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.swt.tools.spies/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools.spies;singleton:=true
 Bundle-Version: 3.109.700.qualifier
 Bundle-ManifestVersion: 2
-Export-Package: org.eclipse.swt.tools.internal,
+Export-Package: org.eclipse.swt.internal.tools.views;x-internal:=true,
  org.eclipse.swt.tools.views
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/ui/org.eclipse.swt.tools.spies/src/org/eclipse/swt/internal/tools/views/Sleak.java
+++ b/ui/org.eclipse.swt.tools.spies/src/org/eclipse/swt/internal/tools/views/Sleak.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2020 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.tools.internal;
+package org.eclipse.swt.internal.tools.views;
 
 import java.io.*;
 import java.util.*;

--- a/ui/org.eclipse.swt.tools.spies/src/org/eclipse/swt/tools/views/SleakView.java
+++ b/ui/org.eclipse.swt.tools.spies/src/org/eclipse/swt/tools/views/SleakView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@
 package org.eclipse.swt.tools.views;
 
 import org.eclipse.e4.ui.di.*;
-import org.eclipse.swt.tools.internal.*;
+import org.eclipse.swt.internal.tools.views.*;
 import org.eclipse.swt.widgets.*;
 
 import jakarta.annotation.*;


### PR DESCRIPTION
Move Sleak class to o.e.swt.internal.tools.views. It's more correct (or at least less wrong as per
https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Naming_Conventions.md ).
Removes the nasty problem of split packages signed with different certificates.