### PR TITLE
New and Noteworthy for 4.37 (PDE changes)

### DIFF
--- a/org.eclipse.pde.doc.user/toc.xml
+++ b/org.eclipse.pde.doc.user/toc.xml
@@ -46,7 +46,8 @@
 	<!-- Tips and Tricks -->
 	<topic label="Tips and Tricks" href="tips/pde_tips.htm"/>
 
-	<!-- What's New -->	<topic label="What's new" href="whatsNew/pde_whatsnew.html">
+	<!-- What's New -->	
+	<topic label="What's new" href="whatsNew/pde_whatsnew.html">
 		<link toc="topics_WhatsNew.xml"/>
 	</topic>
 

--- a/org.eclipse.pde.doc.user/topics_WhatsNew.xml
+++ b/org.eclipse.pde.doc.user/topics_WhatsNew.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?NLS TYPE="org.eclipse.help.toc"?>
 <!--
-     Copyright (c) 2011, 2013 IBM Corporation and others.
+     Copyright (c) 2011, 2025 IBM Corporation and others.
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
      which accompanies this distribution, and is available at
@@ -15,5 +15,5 @@
 <!-- Define topics for the What's New -->
 <!-- ================================ -->
 <toc label="What's new">
-	<topic href="whatsNew/pde_whatsnew.html#editors"                 label="Editors"/>
+	
 </toc>

--- a/org.eclipse.pde.doc.user/whatsNew/pde_whatsnew.html
+++ b/org.eclipse.pde.doc.user/whatsNew/pde_whatsnew.html
@@ -1,113 +1,20 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta name="copyright" content="Copyright (c) Eclipse contributors and others 2020. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page."/>
+<meta name="copyright" content="Copyright (c) Eclipse contributors and others 2025. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page."/>
 <meta http-equiv="Content-Language" content="en-us"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css"/>
+<link rel="STYLESHEET" href="../book.css" type="text/css"/>
 <style type="text/css">
-body {max-width: 900px;}
-table.news col.title {width: 30%;}
-/*img {max-width: 520px;}*/
-table.news {table-layout: fixed; border-collapse: collapse; width: 100%;}
-table.news td {border-top: solid thin black; padding: 10px; overflow: visible;}
-table.news tr {vertical-align: top;}
-table.news tr td.section {font-size: 20px; font-weight: bold;}
-table.news tr td.title {vertical-align: top; font-weight: bold;}
-table.news tr td.content {vertical-align: top;}
-ul {padding-left: 13px;}
-</style>
-<title>What's New in 4.30 (PDE)</title>
+body { max-width: 900px; font-family: sans-serif; }
+  </style>
+  <title>Eclipse PDE What's New</title>
 </head>
-
 <body>
-<h2>What's New in 4.30 (PDE)</h2>
-<p>Here are descriptions of some of the more interesting or significant changes made to the Plug-in Development Environment (PDE)
-for the 4.30 release of Eclipse. They are grouped into:</p>
-<ul> <!-- NOTE: Sync ../topics_WhatsNew.xml with this! -->
-	<!--li><a href="#dialogs-wizards-views">Dialogs, Wizards and Views</a></li-->
-	<li><a href="#editors">Editors</a></li>
-	<!--li><a href="#APITools">API Tools</a></li-->
-	<!--li><a href="#pde-launching">PDE Launching</a></li-->
-	<!--li><a href="#pde-compiler">PDE Compiler</a></li-->
-	<!--li><a href="#security">Security</a></li-->
-	<!--li><a href="#GeneralUpdates">General Updates</a></li-->
-</ul>
-
-<!-- ****************** START OF N&N TABLE****************** -->
-<table class="news">
-<colgroup>
-  <col class="title" />
-  <col />
-</colgroup>
-<tbody>
-  <!-- ******************** Dialogs, Wizard and Views ********************** -->
-  <!--tr>
-    <td id="dialogs-wizards-views" class="section" colspan="2"><h2>Dialogs, Wizards and Views</h2></td>
-  </tr-->
-  <!-- ******************** End ofDialogs, Wizard and Views ********************** -->
-  
-  <!-- ******************** Editors ********************** -->
-  <tr>
-    <td id="editors" class="section" colspan="2"><h2>Editors</h2></td>
-  </tr>
-
-  <tr id="product-update-repository-name">
-    <!-- https://github.com/eclipse-equinox/p2/issues/345 -->
-    <!-- https://github.com/eclipse-equinox/p2/pull/353 -->
-    <!-- https://github.com/eclipse-pde/eclipse.pde/pull/824 -->
-    <td class="title">Support for names of product update repositories</td>
-    <td class="content">
-      The PDE Product Editor now supports in its <code>Updates</code> section to specify the <code>Name</code> of each update repository.
-      In the assembled product the names will be presented to a user in the preferences under <code>Available Software Sites</code>.
-      <p><img src="images/product_updates_names.png" alt="Product Updates with Name"/></p>
-    </td>
-  </tr>
-
-  <tr id="unnecessary-attributes-removal">
-    <!-- https://github.com/eclipse-pde/eclipse.pde/issues/730 -->
-    <!-- https://github.com/eclipse-pde/eclipse.pde/pull/770 -->
-    <!-- https://github.com/eclipse-equinox/p2/pull/378 -->
-    <!-- https://github.com/eclipse-pde/eclipse.pde/pull/882 -->
-    <td class="title">Removed support for unnecessary attributes in Features and Products</td>
-    <td class="content">
-      The <code>Feature</code> editor has its support for the following attributes of <code>plugin</code> elements removed:
-      <ul>
-        <li><code>download-size</code></li>
-        <li><code>install-size</code></li>
-        <li><code>unpack</code></li>
-        <li><code>fragment</code></li>
-      </ul>
-      These attributes are unused and without effect for a long time and unnecessarily increase the complexity of the editor and the size of a <code>feature.xml</code> file.
-      They are ignored when present in an existing Feature and removed by the editor upon the next modification through the editor.
-      <p>
-      The <code>Product Configuration</code> editor has its support for the following attribute of <code>plugin</code> elements removed:
-      <ul>
-        <li><code>fragment</code></li>
-      </ul>
-      This attribute is unused and without effect for a long time and unnecessarily increase the size of a <code>.product</code> file.
-      They are ignored when present in an existing Product and removed by the editor upon the next modification through the editor.
-      </p>
-    </td>
-  </tr>
-
-  <!-- ******************** End of Editors ********************** -->
-
-  <!-- ******************** APITools ********************** -->
-  <!--tr>
-    <td id="APITools" class="section" colspan="2"><h2>API Tools</h2></td>
-  </tr-->
-  <!-- ******************** End of APITools ********************** -->
-  
-   <!-- ******************** PDE Compiler ********************** -->
-  <!--tr>
-    <td id="pde-compiler" class="section" colspan="2"><h2>PDE Compiler</h2></td>
-  </tr-->
-   <!-- ******************** End of PDE Compiler ********************** --> 
-  <!--tr><td colspan="2"/></tr-->
-</tbody>
-</table>
-<!-- ****************** END OF N&N TABLE ****************** -->
-
+  <h2>Plug-in Development Environment</h2>
+  <p>
+    The new and noteworthy updates for Eclipse 4.37 can be found
+    <a href="https://eclipse.dev/eclipse/news/4.37/pde.html" target="_blank">here</a>.
+  </p>
 </body>
 </html>


### PR DESCRIPTION
Fixes: [#3243](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3243)  

Refs : See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3232#issuecomment-3219123658

The New and Noteworthy for Eclipse 4.37 in PDE still points to 4.30 and needs to be updated to 4.37. It hasn’t been revised since the migration of PDE from Platform Common 

This is the remaining work of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3244

[@MohananRahul](https://github.com/MohananRahul)
 [@merks](https://github.com/merks)