### PR TITLE
[RelEng] Add individual release preparation script for PDE

### DIFF
--- a/prepareNextDevCycle.sh
+++ b/prepareNextDevCycle.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -xe
+
+#*******************************************************************************
+# Copyright (c) 2025, 2025 Hannes Wellmann and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Hannes Wellmann - initial API and implementation
+#*******************************************************************************
+
+# This script is called by the pipeline for preparing the next development cycle (this file's name is crucial!)
+# and applies the changes required individually for SWT.
+# The calling pipeline also defines environment variables usable in this script.
+
+echo "Qualifier update for ${NEXT_RELEASE_VERSION}" > 'org.eclipse.pde.doc.user/forceQualifierUpdate.txt'
+
+
+git commit --all --message "Qualifier update of doc bundles for ${NEXT_RELEASE_VERSION}"


### PR DESCRIPTION
It will be called by the pipeline to prepare a new development cycle and automates the enforced qualifier update and clean-up of the 'forceQualifierUpdate.txt' files of the PDE doc bundle.

This will avoid doing it manually as done for the current cycle in
- https://github.com/eclipse-pde/eclipse.pde/pull/1948#issuecomment-3238182237