### PR TITLE
Prevent NPE in case no provider wiring is available

### DIFF
--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -128,7 +128,7 @@ public class ClasspathUtilCore {
 		}
 
 		List<BundleWire> wires = wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE);
-		return wires.stream().map(wire -> {
+		return wires.stream().filter(wire -> wire.getProviderWiring() != null).map(wire -> {
 			return wire.getProvider();
 		}).distinct().flatMap(provider -> {
 			IPluginModelBase model = PluginRegistry.findModel(provider);


### PR DESCRIPTION
In some case when a provider wiring is not available there can be a NPE when setting the PDE classpath, this now checks if a provider wiring is available before access the provider.