### PR TITLE
Properly encode filter string in feature editor

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeatureImport.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/feature/FeatureImport.java
@@ -33,6 +33,7 @@ import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.ifeature.IFeature;
 import org.eclipse.pde.internal.core.ifeature.IFeatureImport;
 import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
+import org.eclipse.pde.internal.core.util.PDEXMLHelper;
 import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.w3c.dom.Node;
 
@@ -188,8 +189,9 @@ public class FeatureImport extends VersionableObject implements IFeatureImport {
 		if (fPatch) {
 			writer.print(" patch=\"true\""); //$NON-NLS-1$
 		}
-		if (fFilter != null) {
-			writer.print(" filter=\"" + fFilter + "\""); //$NON-NLS-1$ //$NON-NLS-2$
+		String writableString = PDEXMLHelper.getWritableAttributeString(fFilter);
+		if (!writableString.isBlank()) {
+			writer.print(" filter=\"" + writableString + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		writer.println("/>"); //$NON-NLS-1$
 	}


### PR DESCRIPTION
Currently if one uses a filter in a feature import that happens to use special characters like '&' that require encoding as an entity saving the feature will break the XML as it will write out the literal value but not the encoded entity. One then has to manually fix up the results.

This now uses the PDEXMLHelper.getWritableAttributeString to properly encode this as and attribute value before writing.