### PR TITLE
Make Platform-Filter available in Auxiliary State

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -224,6 +224,17 @@ public class ClasspathUtilCore {
 		return false;
 	}
 
+	public static String getPlatformFilter(IPluginModelBase model) {
+		IPluginBase pluginBase = model.getPluginBase();
+		if (pluginBase instanceof BundlePlugin plugin) {
+			return plugin.getPlatformFilter();
+		}
+		if (pluginBase instanceof BundleFragment fragment) {
+			return fragment.getPlatformFilter();
+		}
+		return null;
+	}
+
 	public static boolean isPatchFragment(Resource desc) {
 		IPluginModelBase model = PluginRegistry.findModel(desc);
 		return model instanceof IFragmentModel i ? isPatchFragment(i.getFragment()) : false;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEAuxiliaryState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDEAuxiliaryState.java
@@ -97,6 +97,7 @@ public class PDEAuxiliaryState {
 		String localization;
 		String bundleSourceEntry;
 		boolean exportsExternalAnnotations;
+		String platformFilter;
 	}
 
 	/**
@@ -379,6 +380,7 @@ public class PDEAuxiliaryState {
 		info.libraries = getClasspath(manifest);
 		info.hasExtensibleAPI = "true".equals(manifest.get(ICoreConstants.EXTENSIBLE_API)); //$NON-NLS-1$
 		info.isPatchFragment = "true".equals(manifest.get(ICoreConstants.PATCH_FRAGMENT)); //$NON-NLS-1$
+		info.platformFilter = manifest.get(ICoreConstants.PLATFORM_FILTER);
 		info.localization = manifest.get(Constants.BUNDLE_LOCALIZATION);
 		info.hasBundleStructure = hasBundleStructure;
 		info.bundleSourceEntry = manifest.get(ICoreConstants.ECLIPSE_SOURCE_BUNDLE);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundleFragment.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundleFragment.java
@@ -122,4 +122,8 @@ public class BundleFragment extends BundlePluginBase implements IBundleFragment 
 		return "true".equals(getValue(ICoreConstants.PATCH_FRAGMENT, false)); //$NON-NLS-1$
 	}
 
+	public String getPlatformFilter() {
+		return getValue(ICoreConstants.PLATFORM_FILTER, false);
+	}
+
 }

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundlePlugin.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bundle/BundlePlugin.java
@@ -57,4 +57,8 @@ public class BundlePlugin extends BundlePluginBase implements IBundlePlugin {
 		return "true".equals(getValue(ICoreConstants.ECLIPSE_EXPORT_EXTERNAL_ANNOTATIONS, false)); //$NON-NLS-1$
 	}
 
+	public String getPlatformFilter() {
+		return getValue(ICoreConstants.PLATFORM_FILTER, false);
+	}
+
 }


### PR DESCRIPTION
Currently we can already access some additional data for a bundle from the state but the Eclipse-PlatformFilter is not.

This now adds support to also read that information if needed.