### PR TITLE
Support more fragment options in DependencyManager / unify LaunchHelper

### DIFF
--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.13.500.qualifier
+Bundle-Version: 3.13.600.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -168,9 +168,19 @@ public class BundleLauncherHelper {
 		List<String> appRequirements = RequirementHelper.getApplicationLaunchRequirements(configuration);
 		RequirementHelper.addApplicationLaunchRequirements(appRequirements, configuration, bundle2startLevel);
 
-		boolean includeOptional = configuration.getAttribute(IPDELauncherConstants.INCLUDE_OPTIONAL, true);
-		computeDependencies(bundle2startLevel.keySet(), includeOptional, true) //
+		Set<DependencyManager.Options> options = configurationToOptions(configuration, true);
+		computeDependencies(bundle2startLevel.keySet(), options, true) //
 				.forEach(p -> addDefaultStartingBundle(bundle2startLevel, p));
+	}
+
+	protected static Set<DependencyManager.Options> configurationToOptions(ILaunchConfiguration configuration, boolean optionalDefault) throws CoreException {
+		boolean includeOptional = configuration.getAttribute(IPDELauncherConstants.INCLUDE_OPTIONAL, optionalDefault);
+		Set<DependencyManager.Options> options = new HashSet<>();
+		options.add(DependencyManager.Options.INCLUDE_EXTENSIBLE_FRAGMENTS);
+		if (includeOptional) {
+			options.add(DependencyManager.Options.INCLUDE_OPTIONAL_DEPENDENCIES);
+		}
+		return options;
 	}
 
 	// --- feature based launches ---
@@ -221,12 +231,13 @@ public class BundleLauncherHelper {
 		launchPlugins.addAll(additionalPlugins.keySet());
 
 		if (addRequirements) {
+			Set<DependencyManager.Options> options = configurationToOptions(configuration, false);
 			// Add all missing plug-ins required by the application/product set in the config
 			List<String> appRequirements = RequirementHelper.getApplicationLaunchRequirements(configuration);
 			RequirementHelper.addApplicationLaunchRequirements(appRequirements, configuration, launchPlugins, launchPlugins::add);
 
 			// Get all required plugins
-			computeDependencies(launchPlugins, false, isWorkspace(defaultPluginResolution)).forEach(launchPlugins::add);
+			computeDependencies(launchPlugins, options, isWorkspace(defaultPluginResolution)).forEach(launchPlugins::add);
 		}
 
 		// Create the start levels for the selected plugins and add them to the map
@@ -542,7 +553,7 @@ public class BundleLauncherHelper {
 
 	// --- dependency resolution ---
 
-	private static Stream<IPluginModelBase> computeDependencies(Set<IPluginModelBase> includedPlugins, boolean includeOptional, boolean preferWorkspaceBundles) {
+	private static Stream<IPluginModelBase> computeDependencies(Set<IPluginModelBase> includedPlugins, Set<DependencyManager.Options> options, boolean preferWorkspaceBundles) {
 		if (includedPlugins.isEmpty()) {
 			return Stream.empty();
 		}
@@ -556,11 +567,7 @@ public class BundleLauncherHelper {
 			Version version = versionStr != null ? Version.parseVersion(versionStr) : null;
 			return launchState.getBundle(descriptor.getId(), version);
 		}).forEach(launchBundles::add);
-
-		DependencyManager.Options[] options = includeOptional //
-				? new DependencyManager.Options[] {DependencyManager.Options.INCLUDE_OPTIONAL_DEPENDENCIES}
-				: new DependencyManager.Options[] {};
-		Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(launchBundles, options);
+		Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(launchBundles, options.toArray(DependencyManager.Options[]::new));
 		return closure.stream().map(launchBundlePlugins::get).map(Objects::requireNonNull) //
 				.filter(p -> !includedPlugins.contains(p));
 	}

--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PDE JUnit Tests
 Bundle-SymbolicName: org.eclipse.pde.ui.tests; singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-ClassPath: tests.jar
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.pde.ui,

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.ui.tests</artifactId>
-  <version>3.13.200-SNAPSHOT</version>
+  <version>3.13.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
@@ -1351,7 +1351,8 @@ public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 				}));
 
 		// Gather requirements of the product used below
-		Map<BundleLocationDescriptor, String> requiredRPBundles = getEclipseAppRequirementClosureForRunningPlatform();
+		Map<BundleLocationDescriptor, String> requiredRPBundles = getEclipseAppRequirementClosureForRunningPlatform(
+				DependencyManager.Options.INCLUDE_EXTENSIBLE_FRAGMENTS);
 
 		TargetPlatformUtil.setRunningPlatformWithDummyBundlesAsTarget(null, targetBundles, targetFeatures,
 				tpJarDirectory);

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
@@ -821,11 +821,13 @@ public class PluginBasedLaunchTest extends AbstractLaunchTest {
 				bundle("plugin.c", "1.0.0"));
 
 		Map<BundleLocationDescriptor, String> requiredRPBundlesWithoutOptional = FeatureBasedLaunchTest
-				.getEclipseAppRequirementClosureForRunningPlatform();
+				.getEclipseAppRequirementClosureForRunningPlatform(
+						DependencyManager.Options.INCLUDE_EXTENSIBLE_FRAGMENTS);
 
 		Map<BundleLocationDescriptor, String> requiredRPBundlesWithOptional = FeatureBasedLaunchTest
 				.getEclipseAppRequirementClosureForRunningPlatform(
-						DependencyManager.Options.INCLUDE_OPTIONAL_DEPENDENCIES);
+						DependencyManager.Options.INCLUDE_OPTIONAL_DEPENDENCIES,
+						DependencyManager.Options.INCLUDE_EXTENSIBLE_FRAGMENTS);
 
 		TargetPlatformUtil.setRunningPlatformWithDummyBundlesAsTarget(null, targetPlatformBundles, List.of(),
 				tpJarDirectory);


### PR DESCRIPTION
Currently one can only choose to include all fragments or only non-test fragments. But we can already distinguish several other types of fragments, e.g. those that belong to extensible API or provide native code specialization.

This now enhances DependencyManager to support a new type (INCLUDE_PLATFORM_FRAGMENTS) and to make configurable the inclusion of extensible API (INCLUDE_EXTENSIBLE_FRAGMENTS). Also the BundleLauncherHelper was adjusted to be more uniform when handling plugin versus feature based launches reading and preparing for further customization through launch configs.