### PR TITLE
Quick fix to add available matching version for Imported packages

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/BundleErrorReporter.java
@@ -1517,7 +1517,11 @@ public class BundleErrorReporter extends JarManifestErrorReporter {
 		String version = element.getAttribute(Constants.VERSION_ATTRIBUTE);
 		int severity = CompilerFlags.getFlag(fProject, CompilerFlags.P_MISSING_VERSION_IMP_PKG);
 		if (severity != CompilerFlags.IGNORE && version == null) {
-			VirtualMarker marker = report(NLS.bind(PDECoreMessages.BundleErrorReporter_MissingVersion, element.getValue()), getPackageLine(header, element), severity, PDEMarkerFactory.CAT_OTHER);
+			VirtualMarker marker = report(
+					NLS.bind(PDECoreMessages.BundleErrorReporter_MissingVersion, element.getValue()),
+					getPackageLine(header, element), severity, PDEMarkerFactory.M_MISSINGVERSION_IMPORT_PACKAGE,
+					PDEMarkerFactory.CAT_OTHER);
+			marker.setAttribute("pkgName", element.getValue()); //$NON-NLS-1$
 			addMarkerAttribute(marker,PDEMarkerFactory.compilerKey,  CompilerFlags.P_MISSING_VERSION_IMP_PKG);
 		}
 		validateVersionAttribute(header, element, true);

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/PDEMarkerFactory.java
@@ -80,6 +80,8 @@ public class PDEMarkerFactory {
 	public static final int M_SINGLETON_DIR_CHANGE = 0x1033; // other problem
 	public static final int M_MISSINGVERSION_REQ_BUNDLE = 0x1034; // other
 																	// problem
+	public static final int M_MISSINGVERSION_IMPORT_PACKAGE = 0x1035; // other
+																		// problem
 
 	// build properties fixes
 	public static final int B_APPEND_SLASH_FOLDER_ENTRY = 0x2001;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/ManifestUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/ManifestUtils.java
@@ -28,7 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -67,8 +66,6 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.Version;
-import org.osgi.framework.VersionRange;
 import org.osgi.framework.namespace.ExecutionEnvironmentNamespace;
 import org.osgi.resource.Namespace;
 import org.osgi.resource.Requirement;
@@ -397,16 +394,6 @@ public class ManifestUtils {
 				throw new IllegalArgumentException("Invalid execution environment filter", e); //$NON-NLS-1$
 			}
 		}
-	}
-
-	public static Optional<VersionRange> createConsumerRequirementRange(Version version) {
-		if (version != null && !Version.emptyVersion.equals(version)) {
-			return Optional.ofNullable(new VersionRange(VersionRange.LEFT_CLOSED, //
-					new Version(version.getMajor(), version.getMinor(), 0), //
-					new Version(version.getMajor() + 1, 0, 0), //
-					VersionRange.RIGHT_OPEN));
-		}
-		return Optional.empty();
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/VersionUtil.java
@@ -15,6 +15,7 @@
 package org.eclipse.pde.internal.core.util;
 
 import java.util.Comparator;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -118,6 +119,16 @@ public class VersionUtil {
 			return pvi.getMajor() + "." + pvi.getMinor() + "." + pvi.getMicro(); //$NON-NLS-1$//$NON-NLS-2$
 		}
 		return version;
+	}
+
+	public static Optional<VersionRange> createConsumerRequirementRange(Version version) {
+		if (version != null && !Version.emptyVersion.equals(version)) {
+			return Optional.ofNullable(new VersionRange(VersionRange.LEFT_CLOSED, //
+					new Version(version.getMajor(), version.getMinor(), 0), //
+					new Version(version.getMajor() + 1, 0, 0), //
+					VersionRange.RIGHT_OPEN));
+		}
+		return Optional.empty();
 	}
 
 }

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
@@ -24,7 +24,7 @@ import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEState;
 import org.eclipse.pde.internal.core.bundle.BundlePluginBase;
 import org.eclipse.pde.internal.core.ibundle.IBundleModel;
-import org.eclipse.pde.internal.core.util.ManifestUtils;
+import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.osgi.framework.Constants;
 import org.osgi.framework.VersionRange;
 
@@ -33,7 +33,7 @@ public class ImportPackageObject extends PackageObject {
 	private static final long serialVersionUID = 1L;
 
 	private static String getVersion(ExportPackageDescription desc) {
-		return ManifestUtils.createConsumerRequirementRange(desc.getVersion()).map(VersionRange::toString).orElse(null);
+		return VersionUtil.createConsumerRequirementRange(desc.getVersion()).map(VersionRange::toString).orElse(null);
 	}
 
 	public ImportPackageObject(ManifestHeader header, ManifestElement element, String versionAttribute) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3453,6 +3453,7 @@ public class PDEUIMessages extends NLS {
 	public static String ProjectUpdateChange_convert_build_to_bnd;
 	public static String ProjectUpdateChange_set_pde_preference;
 
-	public static String AddMatchingVersion_RequireBundle;
+	public static String AddMatchingVersion;
+	public static String AddMatchingVersionDescription;
 
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/ResolutionGenerator.java
@@ -154,10 +154,13 @@ public class ResolutionGenerator implements IMarkerResolutionGenerator2 {
 					new UpdateCorrectHeaderName(AbstractPDEMarkerResolution.RENAME_TYPE, marker) };
 		case PDEMarkerFactory.M_MISSINGVERSION_REQ_BUNDLE:
 			return new IMarkerResolution[] {
-					new VersionMatchResolution(AbstractPDEMarkerResolution.CREATE_TYPE, marker) };
+					new VersionMatchRequireBundleResolution(AbstractPDEMarkerResolution.CREATE_TYPE, marker) };
 		case PDEMarkerFactory.M_NO_SPACE_AFTER_COLON:
 			return new IMarkerResolution[] {
 					new AddSpaceBeforeValue(AbstractPDEMarkerResolution.CREATE_TYPE, marker) };
+		case PDEMarkerFactory.M_MISSINGVERSION_IMPORT_PACKAGE:
+			return new IMarkerResolution[] {
+					new VersionMatchImportPackageResolution(AbstractPDEMarkerResolution.CREATE_TYPE, marker) };
 		}
 		return NO_RESOLUTIONS;
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/VersionMatchImportPackageResolution.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/VersionMatchImportPackageResolution.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ *  Copyright (c) 2025, 2025 IBM Corporation and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.pde.internal.ui.correction;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.core.text.bundle.Bundle;
+import org.eclipse.pde.internal.core.text.bundle.BundleModel;
+import org.eclipse.pde.internal.core.text.bundle.ImportPackageHeader;
+import org.eclipse.pde.internal.core.text.bundle.ImportPackageObject;
+import org.eclipse.pde.internal.core.util.VersionUtil;
+import org.eclipse.pde.internal.ui.PDEUIMessages;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+
+/**
+ * Resolution to add available matching version for Imported package in MANIFEST
+ */
+public class VersionMatchImportPackageResolution extends AbstractManifestMarkerResolution {
+
+	public VersionMatchImportPackageResolution(int type, IMarker marker) {
+		super(type, marker);
+	}
+
+	public Version getVersion(Object inputElement) {
+		IPluginModelBase[] models = PluginRegistry.getActiveModels();
+		Version highest = null;
+		for (IPluginModelBase pluginModel : models) {
+			BundleDescription desc = pluginModel.getBundleDescription();
+
+			String id = desc == null ? null : desc.getSymbolicName();
+			if (id == null) {
+				continue;
+			}
+			ExportPackageDescription[] exported = desc.getExportPackages();
+			for (ExportPackageDescription exportedPackage : exported) {
+				String name = exportedPackage.getName();
+				if (("java".equals(name) || name.startsWith("java."))) { //$NON-NLS-1$ //$NON-NLS-2$
+					// $NON-NLS-2$
+					continue;
+				}
+				if (name.equals(inputElement.toString())) {
+					Version ver = exportedPackage.getVersion();
+					if (ver != null) {
+						if (highest == null || ver.compareTo(highest) > 0) {
+							highest = ver;
+						}
+					}
+				}
+			}
+		}
+		return highest;
+	}
+
+	@Override
+	protected void createChange(BundleModel model) {
+		String pkgName = Objects.requireNonNull(marker.getAttribute("pkgName", (String) null)); //$NON-NLS-1$
+		Bundle bundle = (Bundle) model.getBundle();
+		ImportPackageHeader header = (ImportPackageHeader) bundle.getManifestHeader(Constants.IMPORT_PACKAGE);
+		if (header != null) {
+			for (ImportPackageObject importPackage : header.getPackages()) {
+				if (pkgName.equals(importPackage.getName())) {
+					Version version = getVersion(pkgName);
+					if (version == null) {
+						return;
+					}
+					// Sanitize version: Remove a potential qualifier
+					Optional<VersionRange> versionRange = VersionUtil.createConsumerRequirementRange(version);
+					importPackage.setVersion(versionRange.map(VersionRange::toString).orElse(null));
+				}
+			}
+		}
+	}
+
+	@Override
+	public String getLabel() {
+		return PDEUIMessages.AddMatchingVersion;
+	}
+
+	@Override
+	public String getDescription() {
+		return PDEUIMessages.AddMatchingVersionDescription;
+	}
+
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/VersionMatchRequireBundleResolution.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/VersionMatchRequireBundleResolution.java
@@ -15,6 +15,7 @@
 package org.eclipse.pde.internal.ui.correction;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -26,12 +27,14 @@ import org.eclipse.pde.internal.core.text.bundle.RequireBundleObject;
 import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Resolution to add available matching version for Required bundles in MANIFEST
  */
-public class VersionMatchResolution extends AbstractManifestMarkerResolution {
-	public VersionMatchResolution(int type, IMarker marker) {
+public class VersionMatchRequireBundleResolution extends AbstractManifestMarkerResolution {
+	public VersionMatchRequireBundleResolution(int type, IMarker marker) {
 		super(type, marker);
 	}
 
@@ -47,8 +50,9 @@ public class VersionMatchResolution extends AbstractManifestMarkerResolution {
 					if (modelBase != null) {
 						String version = modelBase.getPluginBase().getVersion();
 						// Sanitize version: Remove a potential qualifier
-						version = VersionUtil.computeInitialPluginVersion(version);
-						requiredBundle.setVersion(version);
+						Optional<VersionRange> versionRange = VersionUtil
+								.createConsumerRequirementRange(new Version(version));
+						requiredBundle.setVersion(versionRange.map(VersionRange::toString).orElse(null));
 					}
 				}
 			}
@@ -57,7 +61,12 @@ public class VersionMatchResolution extends AbstractManifestMarkerResolution {
 
 	@Override
 	public String getLabel() {
-		return PDEUIMessages.AddMatchingVersion_RequireBundle;
+		return PDEUIMessages.AddMatchingVersion;
+	}
+
+	@Override
+	public String getDescription() {
+		return PDEUIMessages.AddMatchingVersionDescription;
 	}
 
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
@@ -51,7 +51,7 @@ import org.eclipse.pde.internal.core.text.bundle.ExportPackageHeader;
 import org.eclipse.pde.internal.core.text.bundle.ExportPackageObject;
 import org.eclipse.pde.internal.core.text.bundle.ImportPackageHeader;
 import org.eclipse.pde.internal.core.text.bundle.ImportPackageObject;
-import org.eclipse.pde.internal.core.util.ManifestUtils;
+import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
@@ -195,7 +195,7 @@ public class JavaResolutionFactory {
 					}
 					BundleDescription requiredBundle = getChangeObject();
 					String pluginId = requiredBundle.getSymbolicName();
-					VersionRange versionRange = ManifestUtils
+					VersionRange versionRange = VersionUtil
 							.createConsumerRequirementRange(requiredBundle.getVersion()).orElse(null);
 					IPluginImport[] imports = base.getPluginBase().getImports();
 					if (!isUndo()) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1303,7 +1303,8 @@ UpdateClasspathResolution_label=Update the classpath and compliance settings
 UpdateExecutionEnvironment_label=Update the execution environment based on JRE on the classpath
 UpdateClasspathJob_task = Update classpaths...
 UpdateClasspathJob_title = Updating Plug-in Classpaths
-AddMatchingVersion_RequireBundle = Require latest available version
+AddMatchingVersion = Require latest available version range
+AddMatchingVersionDescription = Add a version range aligned with the latest compatible available version
 
 RuntimeWorkbenchShortcut_title=Select Configuration
 RuntimeWorkbenchShortcut_select_debug=Select a launch configuration to debug:


### PR DESCRIPTION
This is to provide a quick fix for adding the available matching version for Imported packages in MANIFEST.MF warning.
Similar to the fix: #1623 and as suggested in [here](https://github.com/eclipse-pde/eclipse.pde/pull/1791#issuecomment-3181261395)

Attaching screenshot for the quick fix:

<img width="895" height="542" alt="image" src="https://github.com/user-attachments/assets/50ed92e2-04f1-4ad5-a2de-ee2e92fbfb82" />


After applying:

<img width="895" height="542" alt="image" src="https://github.com/user-attachments/assets/f39cb951-4f86-4f0f-a7bc-a1347899a193" />
