### PR TITLE
Fix PDEFormEditor.dispose() calling super.dispose() first

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/PDEFormEditor.java
@@ -593,9 +593,9 @@ public abstract class PDEFormEditor extends FormEditor implements IInputContextL
 			clipboard.dispose();
 			clipboard = null;
 		}
-		super.dispose();
 		fInputContextManager.dispose();
 		fInputContextManager = null;
+		super.dispose();
 	}
 
 	@Override


### PR DESCRIPTION
Common pattern for init/dispose, setup/teardown is that on init, super is called first and on dispose last.

This is always done this way to allow super class initialize whatever needed first and subclass work on that, and the dispose should always perform cleanup in the opposite direction. Otherwise super code might cleanup things that are still needed for the subclass to properly cleanup.

Probably related to
https://github.com/eclipse-pde/eclipse.pde/issues/1963