### PR TITLE
Fix NPE in TargetContentsGroup

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
@@ -1166,14 +1166,7 @@ public class TargetContentsGroup {
 				if (fMissing == null || fMissing.isEmpty()) {
 					fMissing = new HashSet<>(); // A set is used to remove copies of problem bundles
 					TargetBundle[] bundles = fTargetDefinition.getBundles();
-					for (int i = 0; i < bundles.length; i++) {
-						if (!bundles[i].getStatus().isOK()) {
-							// We only display error bundles that have symbolic names
-							if (bundles[i].getBundleInfo().getSymbolicName() != null) {
-								fMissing.add(bundles[i]);
-							}
-						}
-					}
+					addMissing(bundles);
 					result.addAll(fMissing);
 				} else {
 					// As missing bundles are unchecked, we want to keep them in the table, only if locations change does fMissing become null
@@ -1206,6 +1199,20 @@ public class TargetContentsGroup {
 				return result.toArray();
 			}
 			return new Object[] {inputElement};
+		}
+
+		private void addMissing(TargetBundle[] bundles) {
+			if (bundles == null)
+				return;
+
+			for (TargetBundle bundle : bundles) {
+				if (!bundle.getStatus().isOK()) {
+					// We only display error bundles that have symbolic names
+					if (bundle.getBundleInfo().getSymbolicName() != null) {
+						fMissing.add(bundle);
+					}
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
The result of calling `fTargetDefinition.getBundles();` was not being checked for `null` and this exception occurred.

<details><summary>NPE</summary>
<p>

```java
[ERROR] An internal error has occurred.
java.lang.NullPointerException: Cannot read the array length because "bundles" is null
	at org.eclipse.pde.internal.ui.shared.target.TargetContentsGroup$TreeContentProvider.getElements(TargetContentsGroup.java:1169)
	at org.eclipse.jface.viewers.StructuredViewer.getRawChildren(StructuredViewer.java:940)
	at org.eclipse.jface.viewers.ColumnViewer.getRawChildren(ColumnViewer.java:701)
	at org.eclipse.jface.viewers.AbstractTreeViewer.getRawChildren(AbstractTreeViewer.java:1454)
	at org.eclipse.jface.viewers.TreeViewer.getRawChildren(TreeViewer.java:352)
	at org.eclipse.jface.viewers.StructuredViewer.getFilteredChildren(StructuredViewer.java:848)
	at org.eclipse.jface.viewers.StructuredViewer.getSortedChildren(StructuredViewer.java:1024)
	at org.eclipse.jface.viewers.ColumnViewer.getSortedChildren(ColumnViewer.java:818)
	at org.eclipse.jface.viewers.AbstractTreeViewer.getSortedChildren(AbstractTreeViewer.java:688)
	at org.eclipse.jface.viewers.AbstractTreeViewer.updateChildren(AbstractTreeViewer.java:2902)
	at org.eclipse.jface.viewers.AbstractTreeViewer.internalRefreshStruct(AbstractTreeViewer.java:2030)
	at org.eclipse.jface.viewers.TreeViewer.internalRefreshStruct(TreeViewer.java:684)
	at org.eclipse.jface.viewers.AbstractTreeViewer.internalRefresh(AbstractTreeViewer.java:2003)
	at org.eclipse.jface.viewers.AbstractTreeViewer.internalRefresh(AbstractTreeViewer.java:1960)
	at org.eclipse.jface.viewers.StructuredViewer.lambda$3(StructuredViewer.java:1485)
	at org.eclipse.jface.viewers.StructuredViewer.preservingSelection(StructuredViewer.java:1391)
	at org.eclipse.jface.viewers.TreeViewer.preservingSelection(TreeViewer.java:367)
	at org.eclipse.jface.viewers.StructuredViewer.preservingSelection(StructuredViewer.java:1352)
	at org.eclipse.jface.viewers.CheckboxTreeViewer.preservingSelection(CheckboxTreeViewer.java:407)
	at org.eclipse.pde.internal.ui.shared.CachedCheckboxTreeViewer.preservingSelection(CachedCheckboxTreeViewer.java:109)
	at org.eclipse.jface.viewers.StructuredViewer.refresh(StructuredViewer.java:1485)
	at org.eclipse.jface.viewers.ColumnViewer.refresh(ColumnViewer.java:532)
	at org.eclipse.jface.viewers.StructuredViewer.refresh(StructuredViewer.java:1446)
	at org.eclipse.ui.dialogs.FilteredTree$1.runInUIThread(FilteredTree.java:418)
	at org.eclipse.ui.progress.UIJob.lambda$0(UIJob.java:148)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4111)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3727)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:678)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:185)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:627)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:575)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1431)
```

</p>
</details> 

Eclipse version: **4.36**