### PR TITLE
TestSuiteHelper: Include felix.scr if osgi.component is required

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.api.tools.tests
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.pde.api.tools;bundle-version="1.0.600",

--- a/apitools/org.eclipse.pde.api.tools.tests/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools.tests/pom.xml
@@ -18,7 +18,7 @@
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.pde.api.tools.tests</artifactId>
-	<version>1.4.200-SNAPSHOT</version>
+	<version>1.4.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: org.eclipse.pde.build.tests;singleton:=true
-Bundle-Version: 1.4.900.qualifier
+Bundle-Version: 1.4.1000.qualifier
 Bundle-Activator: org.eclipse.pde.build.tests.Activator
 Export-Package: org.eclipse.pde.build.internal.tests;x-internal:=true,
  org.eclipse.pde.build.internal.tests.ant;x-internal:=true,

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -10,7 +10,7 @@
 		<version>4.38.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.pde.build.tests</artifactId>
-	<version>1.4.900-SNAPSHOT</version>
+	<version>1.4.1000-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<profiles>

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
@@ -898,7 +898,8 @@ public class PublishingTests extends P2TestCase {
 		IFile productFile = buildFolder.getFile("headless.product");
 		String[] bundles = new String[] { "headless", "org.eclipse.core.contenttype", "org.eclipse.core.jobs",
 				"org.eclipse.core.runtime", "org.osgi.service.prefs", EQUINOX_APP, EQUINOX_COMMON, EQUINOX_PREFERENCES,
-				EQUINOX_REGISTRY, OSGI };
+				EQUINOX_REGISTRY, OSGI, "org.apache.felix.scr", "org.osgi.service.event", "org.osgi.service.component",
+				"org.osgi.util.promise", "org.osgi.util.function" };
 		Utils.generateProduct(productFile, "headless.product", "1.0.0.qualifier", "headless.application", "headless",
 				bundles, false, null);
 		Properties p2Inf = new Properties(); // bug 268223


### PR DESCRIPTION
Some test cases use 'org.eclipse.core.runtime' as dependency.

One of the runtime's dependencies (org.eclipse.core.contenttype) uses declarative services to provide a service component, but was missing the Require-Capability: header to require the osgi.extender=osgi.component.

In https://github.com/eclipse-platform/eclipse.platform/pull/2162 this was corrected.

But as a result, for the resolution of org.eclipse.core.runtime to succeed, a OSGI extender provider must now strictly be present.

This cannot be auto-resolved as the PDE API tooling tests, as these tests are quite special and the bundles available in the resolver state are hand-picked by

    TestSuiteHelper.addAllRequired(IApiBaseline, Set<String>, IApiComponent, List<IApiComponent>)

which currently does not support this kind of dependency.

To work around that, we check if we find a dependency on SCR and if so, add an implementation for it to the baseline fixture: org.apache.felix.scr and its dependencies.

See also: https://github.com/eclipse-equinox/equinox/issues/1146