### PR TITLE
[Work in Progress] Issue #1881 - Add a button to remove unused dependencies to the toolbar

### DIFF
--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.16.200.qualifier
+Bundle-Version: 3.17.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -608,6 +608,11 @@
             id="org.eclipse.pde.ui.imagebrowser.saveToWorkspace"
             name="%command.saveImageToWorkspace.name">
       </command>
+      <command
+            defaultHandler="org.eclipse.pde.ui.RemoveUnusedDependenciesHandler"
+            id="org.eclipse.pde.ui.removeUnusedDependencies"
+            name="Remove Unused Dependencies">
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.popupMenus">
@@ -1777,6 +1782,9 @@
              </with>
              </enabledWhen>
           </handler>
+          <handler
+                commandId="org.eclipse.pde.ui.removeUnusedDependencies">
+          </handler>
        </extension>
        <extension
              point="org.eclipse.ui.menus">
@@ -1986,6 +1994,21 @@
                    </reference>
                 </visibleWhen>
              </command>
+          </menuContribution>
+          <menuContribution
+                allPopups="false"
+                locationURI="toolbar:org.eclipse.ui.main.toolbar">
+             <toolbar
+                   id="org.eclipse.pde.ui.main.toolbar"
+                   label="Remove Unused Dependencies">
+                <command
+                      commandId="org.eclipse.pde.ui.removeUnusedDependencies"
+                      icon="icons/obj16/eclipse.png"
+                      label="Remove Unused Dependencies"
+                      style="push"
+                      tooltip="Removes unused dependencies">
+                </command>
+             </toolbar>
           </menuContribution>
        </extension>
        <extension

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/RemoveUnusedDependenciesHandler.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/ui/RemoveUnusedDependenciesHandler.java
@@ -1,0 +1,73 @@
+package org.eclipse.pde.ui;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.internal.ui.editor.PDEFormEditor;
+import org.eclipse.pde.internal.ui.search.dependencies.GatherUnusedDependenciesOperation;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * @since 3.17
+ */
+public class RemoveUnusedDependenciesHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		try {
+			// retrieve the current plugin model
+			IPluginModelBase model = getCurrentPluginModel();
+			if (model == null) {
+				return null;
+			}
+
+
+			GatherUnusedDependenciesOperation operation = new GatherUnusedDependenciesOperation(model);
+
+			operation.run(new NullProgressMonitor());
+
+			// gather unused dependencies
+			List<Object> unusedDependencies = operation.getList();
+
+			// remove unused dependencies if found
+			if (!unusedDependencies.isEmpty()) {
+				Object[] unusedArray = unusedDependencies.toArray();
+	            GatherUnusedDependenciesOperation.removeDependencies(model, unusedArray);
+			}
+
+		} catch (InvocationTargetException e) {
+			throw new ExecutionException("Error analyzing dependencies", e.getCause());
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new ExecutionException("Operation was interrupted", e);
+		}
+
+		return null;
+	}
+
+
+	private IPluginModelBase getCurrentPluginModel() {
+
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (window != null) {
+			IWorkbenchPage page = window.getActivePage();
+			if (page != null) {
+				IEditorPart editor = page.getActiveEditor();
+				if (editor instanceof PDEFormEditor) {
+					PDEFormEditor pdeEditor = (PDEFormEditor) editor;
+					return (IPluginModelBase) pdeEditor.getAggregateModel();
+				}
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
This pull request addresses Issue #1881 , where I added a button for removing unused dependencies to the toolbar since the feature is quite hidden in the Dependencies Tab under Dependency Analysis. The button currently has a placeholder icon, which is the Eclipse logo. 

I have made the following changes:
- I created the `RemoveUnusedDependenciesHandler.java` file, which contains the logic to check if there are any unused dependencies and remove them if they exist. For getting the current plug-in model, I created the `getCurrentPluginModel()` function within the `RemoveUnusedDependenciesHandler` class. It retrieves the plug-in from the active editor. 
- [Work in Progress] The button currently has a placeholder icon. I am curious as how do icons get assigned to buttons and what the process is of creating it if the icon does not exist already.

Here is a picture of what the toolbar looks like with the button:
<img width="562" height="37" alt="Screenshot 2025-09-28 at 9 29 22 PM" src="https://github.com/user-attachments/assets/b9d217d9-06e0-4ba1-89b6-84f56ca02628" />

When I hover over the button, it shows "Removes unused dependencies". 