### PR TITLE
Add dependencies to the org.eclipse.pde.build.tests bundle

### DIFF
--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: org.eclipse.pde.build.tests;singleton:=true
-Bundle-Version: 1.4.900.qualifier
+Bundle-Version: 1.4.1000.qualifier
 Bundle-Activator: org.eclipse.pde.build.tests.Activator
 Export-Package: org.eclipse.pde.build.internal.tests;x-internal:=true,
  org.eclipse.pde.build.internal.tests.ant;x-internal:=true,

--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -17,6 +17,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.equinox.frameworkadmin;version="2.0.0",
+ org.apache.felix.scr.info,
+ org.osgi.service.event,
+ org.osgi.service.component,
+ org.osgi.util.promise,
+ org.osgi.util.function,
  org.eclipse.equinox.internal.p2.artifact.repository,
  org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.equinox.internal.p2.metadata,

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -10,7 +10,7 @@
 		<version>4.38.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.pde.build.tests</artifactId>
-	<version>1.4.900-SNAPSHOT</version>
+	<version>1.4.1000-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<profiles>


### PR DESCRIPTION
- This is similar to what was done for org.eclipse.core.tests.harness.