### PR TITLE
Add more bundle to PublishingTests.testPublishAndRunSimpleProduct()

### DIFF
--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: org.eclipse.pde.build.tests;singleton:=true
-Bundle-Version: 1.4.900.qualifier
+Bundle-Version: 1.4.1000.qualifier
 Bundle-Activator: org.eclipse.pde.build.tests.Activator
 Export-Package: org.eclipse.pde.build.internal.tests;x-internal:=true,
  org.eclipse.pde.build.internal.tests.ant;x-internal:=true,

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -10,7 +10,7 @@
 		<version>4.38.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.pde.build.tests</artifactId>
-	<version>1.4.900-SNAPSHOT</version>
+	<version>1.4.1000-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<profiles>

--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
@@ -898,7 +898,8 @@ public class PublishingTests extends P2TestCase {
 		IFile productFile = buildFolder.getFile("headless.product");
 		String[] bundles = new String[] { "headless", "org.eclipse.core.contenttype", "org.eclipse.core.jobs",
 				"org.eclipse.core.runtime", "org.osgi.service.prefs", EQUINOX_APP, EQUINOX_COMMON, EQUINOX_PREFERENCES,
-				EQUINOX_REGISTRY, OSGI };
+				EQUINOX_REGISTRY, OSGI, "org.apache.felix.scr", "org.osgi.service.component", "org.osgi.util.promise",
+				"org.osgi.util.function" };
 		Utils.generateProduct(productFile, "headless.product", "1.0.0.qualifier", "headless.application", "headless",
 				bundles, false, null);
 		Properties p2Inf = new Properties(); // bug 268223


### PR DESCRIPTION
- Add bundles that are transitively required by org.eclipse.core.contenttype's new required capability.

https://github.com/eclipse-platform/eclipse.platform/pull/2162