### PR TITLE
[Work in Progress] Issue #1858 [manifest editor] Show uses of exported packages in a tree. 

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/TreeSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/TreeSection.java
@@ -114,6 +114,7 @@ public abstract class TreeSection extends StructuredViewerSection {
 		if (tree == null) {
 			return;
 		}
+
 		tree.selectAll();
 		selectionChanged(viewer.getStructuredSelection());
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ExportPackageVisibilitySection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/ExportPackageVisibilitySection.java
@@ -24,9 +24,9 @@ import java.util.List;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
@@ -74,9 +74,9 @@ public class ExportPackageVisibilitySection extends TableSection implements IPar
 	private Image fImage;
 	private Button fVisibleButton;
 
-	static class TableContentProvider implements IStructuredContentProvider {
+	static class TreeContentProvider implements ITreeContentProvider {
 		@Override
-		public Object[] getElements(Object parent) {
+		public Object[] getChildren(Object parent) {
 			ExportPackageObject object = (ExportPackageObject) parent;
 			if (object == null || !object.isInternal()) {
 				return new Object[0];


### PR DESCRIPTION

The following pull request addresses [Issue #1858](https://github.com/eclipse-pde/eclipse.pde/issues/1858) - [manifest editor] Show uses of exported packages in a tree. 

Changes: 
- Imported the tree viewer and tree content provider needed to start adding the tree to the ExportPackageVisibility.java file since this file along with the ExportPackageSection.java contains the code for displaying the export packages. 
- Worked on replacing some of the "table" functions with tree functions. 
- Added code that starts to build the tree for displaying export packages. **I had technical difficulties committing this to this branch but will be add it to the code file**

   **treeViewer = new TreeViewer(parent);
		treeViewer.setContentProvider(new TreeContentProvider());
		treeViewer.setLabelProvider(new TreeContentLabelProvider());

*_*I added this code where the main table display is coded in the ExportPackageVisibility.java file. I plan on adding more code to create the overall size of the tree later on._ **

Questions: 
Is there a specific tree display needed for this issue to show each "child of the package" or "used packages" as mentioned in the [issue's description](https://github.com/eclipse-pde/eclipse.pde/issues/1858)? For instance, creating a tree to display the parent package and a list of the child packages underneath it with checkboxes to see which packages are currently used: 

<img width="223" height="121" alt="Example of Export Package Display" src="https://github.com/user-attachments/assets/fa39fc6f-1bd0-4082-a8d6-287f93cdcdd8" />

I noticed that there is a file called "TreeSection.java" is it best practice to use this file and its code to help build the tree or is it specifically used for another feature in the Eclipse PDE project?




