### PR TITLE
Make sure new states assign unique ID to bundles

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/BundleValidationOperation.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/BundleValidationOperation.java
@@ -57,10 +57,11 @@ public class BundleValidationOperation implements IWorkspaceRunnable {
 		}
 		SubMonitor subMonitor = SubMonitor.convert(monitor, fModels.size() + 1);
 		fState = FACTORY.createState(true);
+		long id = 1;
 		for (IPluginModelBase fModel : fModels) {
 			BundleDescription bundle = fModel.getBundleDescription();
 			if (bundle != null) {
-				fState.addBundle(FACTORY.createBundleDescription(bundle));
+				fState.addBundle(FACTORY.createBundleDescription(id++, bundle));
 			}
 			subMonitor.split(1);
 		}


### PR DESCRIPTION
Currently it can happen that a bundle has an ID clash and then it is missing from a resolve operation afterwards.

This now uses the new API to copy a bundledescription with a specific id to circumvent the problem.

Requires the I-Build to compile:

- https://ci.eclipse.org/releng/job/Builds/job/I-build-4.38/81/

FYI @trancexpress 

This should solve the validation dialog issues we have seen.

For selection the proper provider / junit bundles there is this PR (that was closed by the version bump!?!):

- https://github.com/eclipse-pde/eclipse.pde/pull/2037
