### PR TITLE
Restrict more versions of JUnit-dependencies in pde.unit.runtime.tests

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
@@ -17,7 +17,10 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.debug.ui;bundle-version="3.14.200",
  org.eclipse.ui;bundle-version="3.114.0",
  org.eclipse.pde.ui.tests;bundle-version="3.11.500",
- junit-jupiter-api;bundle-version="[5.14.0,6.0.0)"
+ junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
+ org.eclipse.jdt.junit4.runtime;bundle-version="[1.3.0,2.0.0)",
+ org.eclipse.jdt.junit5.runtime;bundle-version="[1.1.0,2.0.0)",
+ org.eclipse.pde.junit.runtime;bundle-version="[3.8.0,4.0.0)"
 Import-Package: org.assertj.core.api;version="3.14.0",
  org.junit,
  org.junit.rules,

--- a/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
+++ b/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
@@ -49,26 +49,6 @@
 								<id>org.eclipse.osgi.compatibility.state</id>
 								<versionRange>0.0.0</versionRange>
 							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>junit-jupiter-api</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>org.eclipse.jdt.junit4.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>org.eclipse.jdt.junit5.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>org.eclipse.pde.junit.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
 						</extraRequirements>
 					</dependency-resolution>
 				</configuration>

--- a/ui/org.eclipse.pde.junit.runtime.tests/test-bundles/verification.tests.junit4.platform/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/test-bundles/verification.tests.junit4.platform/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: verification.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
- junit-platform-runner;bundle-version="1.4.0",
- junit-jupiter-api;bundle-version="5.4.0"
+ junit-platform-runner;bundle-version="[1.4.0,2.0.0)",
+ junit-jupiter-api;bundle-version="[5.4.0,6.0.0)"
 Export-Package: verification.tests.junit4.platform

--- a/ui/org.eclipse.pde.junit.runtime.tests/test-bundles/verification.tests.junit5.suite/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/test-bundles/verification.tests.junit5.suite/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: verification.tests.junit5.suite
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: verification.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: junit-platform-suite-api;bundle-version="1.8.1",
+Require-Bundle: junit-platform-suite-api;bundle-version="[1.8.1,2.0.0)",
  verification.tests.junit5
 Export-Package: verification.tests.junit5.suite

--- a/ui/org.eclipse.pde.junit.runtime.tests/test-bundles/verification.tests.junit5/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/test-bundles/verification.tests.junit5/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: verification.tests.junit5
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: verification.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: junit-jupiter-api;bundle-version="5.4.0"
+Require-Bundle: junit-jupiter-api;bundle-version="[5.4.0,6.0.0)"
 Export-Package: verification.tests.junit5


### PR DESCRIPTION
and define runtime requirements in the MANIFEST.MF with proper version-ranges instead of in the pom.xml with unbound versions.

Required for
- https://github.com/eclipse-pde/eclipse.pde/pull/2013