### PR TITLE
Centralize code used in two places to compute JUnit requirements

### DIFF
--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Javadoc generation options have changed for 4.38
+Removed non reference method from public API class

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.launching;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.core.DependencyManager;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
+
+public class JUnitLaunchRequirements {
+
+	public static final String JUNIT4_JDT_RUNTIME_PLUGIN = "org.eclipse.jdt.junit4.runtime"; //$NON-NLS-1$
+	public static final String JUNIT5_JDT_RUNTIME_PLUGIN = "org.eclipse.jdt.junit5.runtime"; //$NON-NLS-1$
+
+	public static void addRequiredJunitRuntimePlugins(ILaunchConfiguration configuration, Map<String, List<IPluginModelBase>> allBundles, Map<IPluginModelBase, String> allModels) throws CoreException {
+		Set<String> requiredPlugins = new LinkedHashSet<>(getRequiredJunitRuntimeEclipsePlugins(configuration));
+
+		if (allBundles.containsKey("junit-platform-runner")) { //$NON-NLS-1$
+			// add launcher and jupiter.engine to support @RunWith(JUnitPlatform.class)
+			requiredPlugins.add("junit-platform-launcher"); //$NON-NLS-1$
+			requiredPlugins.add("junit-jupiter-engine"); //$NON-NLS-1$
+		}
+
+		Set<BundleDescription> addedRequirements = new HashSet<>();
+		addAbsentRequirements(requiredPlugins, addedRequirements, allBundles, allModels);
+
+		Set<BundleDescription> requirementsOfRequirements = DependencyManager.findRequirementsClosure(addedRequirements);
+		Set<String> rorIds = requirementsOfRequirements.stream().map(BundleDescription::getSymbolicName).collect(Collectors.toSet());
+		addAbsentRequirements(rorIds, null, allBundles, allModels);
+	}
+
+	@SuppressWarnings("restriction")
+	public static Collection<String> getRequiredJunitRuntimeEclipsePlugins(ILaunchConfiguration configuration) {
+		org.eclipse.jdt.internal.junit.launcher.ITestKind testKind = org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants.getTestRunnerKind(configuration);
+		if (testKind.isNull()) {
+			return Collections.emptyList();
+		}
+		List<String> plugins = new ArrayList<>();
+		plugins.add("org.eclipse.pde.junit.runtime"); //$NON-NLS-1$
+
+		if (org.eclipse.jdt.internal.junit.launcher.TestKindRegistry.JUNIT4_TEST_KIND_ID.equals(testKind.getId())) {
+			plugins.add("org.eclipse.jdt.junit4.runtime"); //$NON-NLS-1$
+		} else if (org.eclipse.jdt.internal.junit.launcher.TestKindRegistry.JUNIT5_TEST_KIND_ID.equals(testKind.getId())) {
+			plugins.add("org.eclipse.jdt.junit5.runtime"); //$NON-NLS-1$
+		}
+		return plugins;
+	}
+
+	private static void addAbsentRequirements(Collection<String> requirements, Set<BundleDescription> addedRequirements, Map<String, List<IPluginModelBase>> allBundles, Map<IPluginModelBase, String> allModels) throws CoreException {
+		for (String id : requirements) {
+			List<IPluginModelBase> models = allBundles.computeIfAbsent(id, k -> new ArrayList<>());
+			if (models.stream().noneMatch(m -> m.getBundleDescription().isResolved())) {
+				IPluginModelBase model = findRequiredPluginInTargetOrHost(id);
+				models.add(model);
+				BundleLauncherHelper.addDefaultStartingBundle(allModels, model);
+				if (addedRequirements != null) {
+					addedRequirements.add(model.getBundleDescription());
+				}
+			}
+		}
+	}
+
+	private static IPluginModelBase findRequiredPluginInTargetOrHost(String id) throws CoreException {
+		IPluginModelBase model = PluginRegistry.findModel(id);
+		if (model == null || !model.getBundleDescription().isResolved()) {
+			// prefer bundle from host over unresolved bundle from target
+			model = PDECore.getDefault().findPluginInHost(id).max(Comparator.comparing(p -> p.getBundleDescription().getVersion())).orElse(null);
+		}
+		if (model == null) {
+			throw new CoreException(Status.error(NLS.bind(PDEMessages.JUnitLaunchConfiguration_error_missingPlugin, id)));
+		}
+		return model;
+	}
+}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -24,16 +24,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
@@ -58,7 +54,6 @@ import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMRunner;
 import org.eclipse.jdt.launching.JavaRuntime;
-import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IFragment;
@@ -69,14 +64,13 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.ClasspathHelper;
-import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.ICoreConstants;
-import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.bnd.PdeProjectAnalyzer;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.eclipse.pde.internal.launching.IPDEConstants;
+import org.eclipse.pde.internal.launching.JUnitLaunchRequirements;
 import org.eclipse.pde.internal.launching.PDELaunchingPlugin;
 import org.eclipse.pde.internal.launching.PDEMessages;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
@@ -393,18 +387,6 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		return application;
 	}
 
-	private IPluginModelBase findRequiredPluginInTargetOrHost(String id) throws CoreException {
-		IPluginModelBase model = PluginRegistry.findModel(id);
-		if (model == null || !model.getBundleDescription().isResolved()) {
-			// prefer bundle from host over unresolved bundle from target
-			model = PDECore.getDefault().findPluginInHost(id).max(Comparator.comparing(p -> p.getBundleDescription().getVersion())).orElse(null);
-		}
-		if (model == null) {
-			abort(NLS.bind(PDEMessages.JUnitLaunchConfiguration_error_missingPlugin, id), null, IStatus.OK);
-		}
-		return model;
-	}
-
 	@Override
 	public String getProgramArguments(ILaunchConfiguration configuration) throws CoreException {
 		return LaunchArgumentsHelper.getUserProgramArguments(configuration);
@@ -537,7 +519,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		launchMode = launch.getLaunchMode();
 
 		// implicitly add the plug-ins required for JUnit testing if necessary
-		addRequiredJunitRuntimePlugins(configuration);
+		JUnitLaunchRequirements.addRequiredJunitRuntimePlugins(configuration, fAllBundles, fModels);
 
 		String attribute = launch.getAttribute(PDE_JUNIT_SHOW_COMMAND);
 		boolean isShowCommand = false;
@@ -556,58 +538,6 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		launch.setAttribute(PDE_JUNIT_SHOW_COMMAND, "false"); //$NON-NLS-1$
 		launch.setAttribute(IPDELauncherConstants.CONFIG_LOCATION, getConfigurationDirectory(configuration).toString());
 		synchronizeManifests(configuration, subMonitor.split(1));
-	}
-
-	private void addRequiredJunitRuntimePlugins(ILaunchConfiguration configuration) throws CoreException {
-		Set<String> requiredPlugins = new LinkedHashSet<>(getRequiredJunitRuntimePlugins(configuration));
-
-		if (fAllBundles.containsKey("junit-platform-runner") || fAllBundles.containsKey("org.junit.platform.runner")) { //$NON-NLS-1$ //$NON-NLS-2$
-			// add launcher and jupiter.engine to support @RunWith(JUnitPlatform.class)
-			requiredPlugins.add("junit-platform-launcher"); //$NON-NLS-1$
-			requiredPlugins.add("junit-jupiter-engine"); //$NON-NLS-1$
-		}
-		Set<BundleDescription> addedRequirements = new HashSet<>();
-		addAbsentRequirements(requiredPlugins, addedRequirements);
-
-		Set<BundleDescription> requirementsOfRequirements = DependencyManager.findRequirementsClosure(addedRequirements);
-		Set<String> rorIds = requirementsOfRequirements.stream().map(BundleDescription::getSymbolicName).collect(Collectors.toSet());
-		addAbsentRequirements(rorIds, null);
-	}
-
-	private void addAbsentRequirements(Collection<String> requirements, Set<BundleDescription> addedRequirements) throws CoreException {
-		for (String id : requirements) {
-			List<IPluginModelBase> models = fAllBundles.computeIfAbsent(id, k -> new ArrayList<>());
-			if (models.stream().noneMatch(m -> m.getBundleDescription().isResolved())) {
-				IPluginModelBase model = findRequiredPluginInTargetOrHost(id);
-				models.add(model);
-				BundleLauncherHelper.addDefaultStartingBundle(fModels, model);
-				if (addedRequirements != null) {
-					addedRequirements.add(model.getBundleDescription());
-				}
-			}
-		}
-	}
-
-	/**
-	 * @noreference This method is not intended to be referenced by clients.
-	 * @param configuration non null config
-	 * @return required plugins
-	 */
-	@SuppressWarnings("restriction")
-	public static Collection<String> getRequiredJunitRuntimePlugins(ILaunchConfiguration configuration) {
-		org.eclipse.jdt.internal.junit.launcher.ITestKind testKind = org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants.getTestRunnerKind(configuration);
-		if (testKind.isNull()) {
-			return Collections.emptyList();
-		}
-		List<String> plugins = new ArrayList<>();
-		plugins.add("org.eclipse.pde.junit.runtime"); //$NON-NLS-1$
-
-		if (org.eclipse.jdt.internal.junit.launcher.TestKindRegistry.JUNIT4_TEST_KIND_ID.equals(testKind.getId())) {
-			plugins.add("org.eclipse.jdt.junit4.runtime"); //$NON-NLS-1$
-		} else if (org.eclipse.jdt.internal.junit.launcher.TestKindRegistry.JUNIT5_TEST_KIND_ID.equals(testKind.getId())) {
-			plugins.add("org.eclipse.jdt.junit5.runtime"); //$NON-NLS-1$
-		}
-		return plugins;
 	}
 
 	/**

--- a/ui/org.eclipse.pde.ui/.settings/.api_filters
+++ b/ui/org.eclipse.pde.ui/.settings/.api_filters
@@ -95,15 +95,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="src/org/eclipse/pde/internal/ui/launcher/PluginBlock.java" type="org.eclipse.pde.internal.ui.launcher.PluginBlock">
-        <filter id="640712815">
-            <message_arguments>
-                <message_argument value="JUnitLaunchConfigurationDelegate"/>
-                <message_argument value="PluginBlock"/>
-                <message_argument value="getRequiredJunitRuntimePlugins(ILaunchConfiguration)"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/pde/internal/ui/refactoring/RenamePluginProcessor.java" type="org.eclipse.pde.internal.ui.refactoring.RenamePluginProcessor">
         <filter id="572522506">
             <message_arguments>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginBlock.java
@@ -27,13 +27,13 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.launching.JUnitLaunchRequirements;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
 import org.eclipse.pde.internal.launching.launcher.EclipsePluginValidationOperation;
 import org.eclipse.pde.internal.launching.launcher.LaunchValidationOperation;
 import org.eclipse.pde.internal.launching.launcher.RequirementHelper;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.launching.IPDELauncherConstants;
-import org.eclipse.pde.launching.JUnitLaunchConfigurationDelegate;
 import org.eclipse.pde.ui.launcher.AbstractLauncherTab;
 
 public class PluginBlock extends AbstractPluginBlock {
@@ -165,7 +165,8 @@ public class PluginBlock extends AbstractPluginBlock {
 		// Check that the application or product we are launching has its requirements included
 		try {
 			List<String> requiredIds = RequirementHelper.getApplicationLaunchRequirements(fLaunchConfig);
-			Collection<String> requiredPlugins = JUnitLaunchConfigurationDelegate.getRequiredJunitRuntimePlugins(fLaunchConfig);
+			Collection<String> requiredPlugins = JUnitLaunchRequirements
+					.getRequiredJunitRuntimeEclipsePlugins(fLaunchConfig);
 			Stream.concat(requiredPlugins.stream(), requiredIds.stream()).forEach(requiredId -> {
 				// see if launcher plugin is already included
 				IPluginModelBase base = findPlugin(requiredId);

--- a/ui/org.eclipse.pde.unittest.junit/.settings/.api_filters
+++ b/ui/org.eclipse.pde.unittest.junit/.settings/.api_filters
@@ -8,15 +8,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java" type="org.eclipse.pde.unittest.junit.launcher.JUnitPluginLaunchConfigurationDelegate">
-        <filter id="640712815">
-            <message_arguments>
-                <message_argument value="JUnitLaunchConfigurationDelegate"/>
-                <message_argument value="JUnitPluginLaunchConfigurationDelegate"/>
-                <message_argument value="getRequiredJunitRuntimePlugins(ILaunchConfiguration)"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginTestTab.java" type="org.eclipse.pde.unittest.junit.launcher.JUnitPluginTestTab">
         <filter id="571473929">
             <message_arguments>

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -26,11 +26,8 @@ import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,19 +75,17 @@ import org.eclipse.jdt.launching.SocketUtil;
 import org.eclipse.jdt.launching.VMRunnerConfiguration;
 import org.eclipse.jdt.ui.unittest.junit.JUnitTestPlugin;
 import org.eclipse.jdt.ui.unittest.junit.JUnitTestPlugin.JUnitVersion;
-import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IFragmentModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.pde.internal.core.ClasspathHelper;
-import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.ICoreConstants;
-import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.launching.IPDEConstants;
+import org.eclipse.pde.internal.launching.JUnitLaunchRequirements;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
 import org.eclipse.pde.internal.launching.launcher.EclipsePluginValidationOperation;
 import org.eclipse.pde.internal.launching.launcher.LaunchArgumentsHelper;
@@ -100,7 +95,6 @@ import org.eclipse.pde.internal.launching.launcher.LauncherUtils;
 import org.eclipse.pde.internal.launching.launcher.RequirementHelper;
 import org.eclipse.pde.internal.launching.launcher.VMHelper;
 import org.eclipse.pde.launching.IPDELauncherConstants;
-import org.eclipse.pde.launching.JUnitLaunchConfigurationDelegate;
 import org.eclipse.pde.launching.PDESourcePathProvider;
 import org.eclipse.pde.unittest.junit.JUnitPluginTestPlugin;
 import org.osgi.framework.Bundle;
@@ -366,7 +360,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 				LinkedHashMap::new, Collectors.toCollection(ArrayList::new)));
 
 		// implicitly add the plug-ins required for JUnit testing if necessary
-		addRequiredJunitRuntimePlugins(configuration);
+		JUnitLaunchRequirements.addRequiredJunitRuntimePlugins(configuration, fAllBundles, fModels);
 
 		String attribute = launch.getAttribute(PDE_JUNIT_SHOW_COMMAND);
 		boolean isShowCommand = false;
@@ -385,41 +379,6 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 		launch.setAttribute(PDE_JUNIT_SHOW_COMMAND, "false"); //$NON-NLS-1$
 		launch.setAttribute(IPDELauncherConstants.CONFIG_LOCATION, getConfigurationDirectory(configuration).toString());
 		synchronizeManifests(configuration, subMonitor.split(1));
-	}
-
-	private void addRequiredJunitRuntimePlugins(ILaunchConfiguration configuration) throws CoreException {
-		Set<String> requiredPlugins = new LinkedHashSet<>(
-				JUnitLaunchConfigurationDelegate.getRequiredJunitRuntimePlugins(configuration));
-
-		if (fAllBundles.containsKey("junit-platform-runner")) { //$NON-NLS-1$
-			// add launcher and jupiter.engine to support @RunWith(JUnitPlatform.class)
-			requiredPlugins.add("junit-platform-launcher"); //$NON-NLS-1$
-			requiredPlugins.add("junit-jupiter-engine"); //$NON-NLS-1$
-		}
-
-		Set<BundleDescription> addedRequirements = new HashSet<>();
-		addAbsentRequirements(requiredPlugins, addedRequirements);
-
-		Set<BundleDescription> requirementsOfRequirements = DependencyManager
-				.findRequirementsClosure(addedRequirements);
-		Set<String> rorIds = requirementsOfRequirements.stream().map(BundleDescription::getSymbolicName)
-				.collect(Collectors.toSet());
-		addAbsentRequirements(rorIds, null);
-	}
-
-	private void addAbsentRequirements(Collection<String> requirements, Set<BundleDescription> addedRequirements)
-			throws CoreException {
-		for (String id : requirements) {
-			List<IPluginModelBase> models = fAllBundles.computeIfAbsent(id, k -> new ArrayList<>());
-			if (models.stream().noneMatch(m -> m.getBundleDescription().isResolved())) {
-				IPluginModelBase model = findRequiredPluginInTargetOrHost(id);
-				models.add(model);
-				BundleLauncherHelper.addDefaultStartingBundle(fModels, model);
-				if (addedRequirements != null) {
-					addedRequirements.add(model.getBundleDescription());
-				}
-			}
-		}
 	}
 
 	@Override
@@ -1084,19 +1043,6 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 			application = IPDEConstants.UI_TEST_APPLICATION;
 		}
 		return application;
-	}
-
-	private IPluginModelBase findRequiredPluginInTargetOrHost(String id) throws CoreException {
-		IPluginModelBase model = PluginRegistry.findModel(id);
-		if (model == null || !model.getBundleDescription().isResolved()) {
-			// prefer bundle from host over unresolved bundle from target
-			model = PDECore.getDefault().findPluginInHost(id)
-					.max(Comparator.comparing(p -> p.getBundleDescription().getVersion())).orElse(null);
-		}
-		if (model == null) {
-			abort(NLS.bind(Messages.JUnitPluginLaunchConfigurationDelegate_error_missingPlugin, id), null, IStatus.OK);
-		}
-		return model;
 	}
 
 	@Override


### PR DESCRIPTION
Currently we have almost identical code in JUnitLaunchConfigurationDelegate and JUnitPluginLaunchConfigurationDelegate to compute the JUnit requirements.

This now extract the code into a central place JUnitLaunchRequirements for consistency and maintenance.

This is NOT modify anything, it just uses the code *as-is* to prepare for 
- https://github.com/eclipse-pde/eclipse.pde/pull/2013

so we can get an actual diff of what this PR changes!

So after this is merged, the PR can be rebased and the content of the file `ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java` is simply replaced and should then result in a usable diff of actual changes.

