### PR TITLE
Minor adjustments to PDECore.findPluginsInHost(String)

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -16,6 +16,7 @@ package org.eclipse.pde.internal.core;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -39,6 +40,7 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
 import org.eclipse.osgi.service.debug.DebugTrace;
+import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.IBundleClasspathResolver;
 import org.eclipse.pde.core.IClasspathContributor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -58,6 +60,7 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.framework.Version;
 import org.osgi.util.tracker.ServiceTracker;
 
 import aQute.bnd.build.Workspace;
@@ -219,11 +222,28 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 
 	private ServiceTracker<RepositoryListenerPlugin, RepositoryListenerPlugin> repositoryListenerServiceTracker;
 
+	public static final Comparator<IPluginModelBase> VERSION = Comparator.comparing(p -> {
+		BundleDescription description = p.getBundleDescription();
+		if (description == null) {
+			return Version.emptyVersion;
+		}
+		return description.getVersion();
+	});
+
 	public PDECore() {
 		inst = this;
 	}
 
-	public Stream<IPluginModelBase> findPluginInHost(String id) {
+	/**
+	 * Finds plugins from the host OSGi framework, in no particular order.
+	 *
+	 * @param id
+	 *            the bundle symbolic name to search for
+	 * @return a Stream of all bundles from the hosting OSGi framework in no
+	 *         particular order, if ordering matter use for example
+	 *         {@link #VERSION} comparator.
+	 */
+	public Stream<IPluginModelBase> findPluginsInHost(String id) {
 		Map<String, List<IPluginModelBase>> hostPlugins = getHostPlugins();
 		if (hostPlugins == null) {
 			return null;

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java
@@ -15,7 +15,6 @@ package org.eclipse.pde.internal.launching;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,8 +39,6 @@ public class JUnitLaunchRequirements {
 
 	public static final String JUNIT4_JDT_RUNTIME_PLUGIN = "org.eclipse.jdt.junit4.runtime"; //$NON-NLS-1$
 	public static final String JUNIT5_JDT_RUNTIME_PLUGIN = "org.eclipse.jdt.junit5.runtime"; //$NON-NLS-1$
-	private static final Comparator<IPluginModelBase> VERSION = Comparator.comparing(p -> p.getBundleDescription().getVersion());
-
 	public static void addRequiredJunitRuntimePlugins(ILaunchConfiguration configuration, Map<String, List<IPluginModelBase>> allBundles, Map<IPluginModelBase, String> allModels) throws CoreException {
 		Collection<String> runtimePlugins = getRequiredJunitRuntimeEclipsePlugins(configuration);
 		Set<BundleDescription> addedRuntimeBundles = addAbsentRequirements(runtimePlugins, allBundles, allModels);
@@ -72,7 +69,7 @@ public class JUnitLaunchRequirements {
 		for (String id : requirements) {
 			List<IPluginModelBase> models = allBundles.computeIfAbsent(id, k -> new ArrayList<>());
 			if (models.stream().noneMatch(p -> p.getBundleDescription().isResolved())) {
-				IPluginModelBase model = findRequiredPluginInTargetOrHost(PluginRegistry.findModel(id), plugins -> plugins.max(VERSION), id);
+				IPluginModelBase model = findRequiredPluginInTargetOrHost(PluginRegistry.findModel(id), plugins -> plugins.max(PDECore.VERSION), id);
 				models.add(model);
 				BundleLauncherHelper.addDefaultStartingBundle(allModels, model);
 				addedRequirements.add(model.getBundleDescription());
@@ -96,7 +93,7 @@ public class JUnitLaunchRequirements {
 	private static IPluginModelBase findRequiredPluginInTargetOrHost(IPluginModelBase model, Function<Stream<IPluginModelBase>, Optional<IPluginModelBase>> pluginSelector, String id) throws CoreException {
 		if (model == null || !model.getBundleDescription().isResolved()) {
 			// prefer bundle from host over unresolved bundle from target
-			model = pluginSelector.apply(PDECore.getDefault().findPluginInHost(id)) //
+			model = pluginSelector.apply(PDECore.getDefault().findPluginsInHost(id)) //
 					.orElseThrow(() -> new CoreException(Status.error(NLS.bind(PDEMessages.JUnitLaunchConfiguration_error_missingPlugin, id))));
 		}
 		return model;


### PR DESCRIPTION
- change the names as it no not find one plugin but many
- move the version comparator to PDECode so it is reusable
- make the version comparator more robust in case of null

extract from 
- https://github.com/eclipse-pde/eclipse.pde/pull/2037