### PR TITLE
Workaround for failure in test execution

### DIFF
--- a/ds/org.eclipse.pde.ds.tests/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.tests/META-INF/MANIFEST.MF
@@ -7,13 +7,17 @@ Bundle-Activator: org.eclipse.pde.internal.ds.tests.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.pde.core;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.pde.ds.core;bundle-version="[1.0.0,2.0.0)",
- org.eclipse.text;bundle-version="[3.3.0,4.0.0)"
+ org.eclipse.text;bundle-version="[3.3.0,4.0.0)",
+ junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
+ junit-jupiter-engine;bundle-version="[5.14.0,6.0.0)",
+ junit-platform-launcher;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-commons;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.pde.internal.ds.tests;x-internal:=true
-Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.13.0,2.0.0)"
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.pde.ds.tests

--- a/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/META-INF/MANIFEST.MF
+++ b/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/META-INF/MANIFEST.MF
@@ -16,5 +16,7 @@ Require-Bundle: org.eclipse.swt;bundle-version="[3.110.0,4.0.0)",
  junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
  junit-jupiter-engine;bundle-version="[5.14.0,6.0.0)",
  junit-platform-launcher;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)"
+ junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-commons;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/e4tools/tests/org.eclipse.e4.tools.persistence.tests/META-INF/MANIFEST.MF
+++ b/e4tools/tests/org.eclipse.e4.tools.persistence.tests/META-INF/MANIFEST.MF
@@ -17,5 +17,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
  junit-jupiter-engine;bundle-version="[5.14.0,6.0.0)",
  junit-platform-launcher;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)"
+ junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-commons;bundle-version="[1.14.0,2.0.0)",
+ junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy 


### PR DESCRIPTION
This pull request updates the test dependencies for several Eclipse plugin test bundles to include additional JUnit 5 Platform Suite components. These changes ensure that the test bundles have all necessary dependencies for running JUnit 5 tests, improving compatibility and test execution reliability.

**JUnit 5 Platform Suite dependency updates:**

* Added `junit-platform-suite-commons` and `junit-platform-suite-engine` to the required bundles in `META-INF/MANIFEST.MF` for the following test projects:
  - `org.eclipse.e4.tools.compatibility.migration.tests`
  - `org.eclipse.e4.tools.persistence.tests`
  - `org.eclipse.pde.ds.tests`

**Other dependency management:**

* Removed explicit `Import-Package` entries for JUnit 5 packages from `org.eclipse.pde.ds.tests` and replaced them with `Require-Bundle` entries, streamlining dependency management.