### PR TITLE
Check for mixed JUnit 5 and JUnit 6 launch type and required bundles

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchValidationOperation.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.launching;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.internal.launching.launcher.LaunchValidationOperation;
+import org.osgi.framework.Version;
+
+public class JUnitLaunchValidationOperation extends LaunchValidationOperation {
+
+	private static final Set<String> JUNIT_PLATFORM_ENGINE_BUNLDES = Set.of(new String[] { //
+			"junit-platform-engine", //$NON-NLS-1$
+			"org.junit.platform.engine", //$NON-NLS-1$
+	});
+
+	private final Map<Object, Object[]> fErrors = new HashMap<>(2);
+
+	public JUnitLaunchValidationOperation(ILaunchConfiguration configuration, Set<IPluginModelBase> models) {
+		super(configuration, models, null);
+	}
+
+	@Override
+	public void run(IProgressMonitor monitor) throws CoreException {
+		try {
+			checkJunitVersion(fLaunchConfiguration, fModels);
+		} catch (CoreException e) {
+			PDELaunchingPlugin.log(e);
+		}
+	}
+
+	@SuppressWarnings("restriction")
+	private void checkJunitVersion(ILaunchConfiguration configuration, Set<IPluginModelBase> models) throws CoreException {
+		org.eclipse.jdt.internal.junit.launcher.ITestKind testKind = org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants.getTestRunnerKind(configuration);
+		if (testKind.isNull()) {
+			return;
+		}
+		Set<Version> junitPlatformBundlesVersions = junitPlatformBundleVersions(models);
+		String testKindId = testKind.getId();
+		switch (testKindId) {
+			case TestKindRegistry.JUNIT3_TEST_KIND_ID, TestKindRegistry.JUNIT4_TEST_KIND_ID -> {
+			} // nothing to check
+			case TestKindRegistry.JUNIT5_TEST_KIND_ID -> {
+				// JUnit 5 platform bundles have version range [1.0,2.0)
+				junitPlatformBundlesVersions.stream().map(Version::getMajor).filter(i -> i.intValue() != 1).findFirst().ifPresent(otherVersion -> {
+					String message = NLS.bind(PDEMessages.JUnitLaunchConfiguration_error_JUnitLaunchAndRuntimeMissmatch, 5, otherVersion);
+					addError(message);
+				});
+			}
+			default -> throw new CoreException(Status.error("Unsupported test kind: " + testKindId)); //$NON-NLS-1$
+		}
+	}
+
+	private void addError(String message) {
+		fErrors.put(message.replaceAll("\\R", " "), null); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	@Override
+	public boolean hasErrors() {
+		return !fErrors.isEmpty();
+	}
+
+	@Override
+	public Map<Object, Object[]> getInput() {
+		Map<Object, Object[]> map = new LinkedHashMap<>();
+		map.putAll(fErrors);
+		return map;
+	}
+
+	private static Set<Version> junitPlatformBundleVersions(Set<IPluginModelBase> models) {
+		return models.stream().map(IPluginModelBase::getBundleDescription) //
+				.filter(d -> JUNIT_PLATFORM_ENGINE_BUNLDES.contains(d.getSymbolicName())) //
+				.map(BundleDescription::getVersion).collect(Collectors.toSet());
+	}
+}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/PDEMessages.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/PDEMessages.java
@@ -36,6 +36,7 @@ public class PDEMessages extends NLS {
 	public static String WorkbenchLauncherConfigurationDelegate_noStartup;
 	public static String JUnitLaunchConfiguration_error_notaplugin;
 	public static String JUnitLaunchConfiguration_error_missingPlugin;
+	public static String JUnitLaunchConfiguration_error_JUnitLaunchAndRuntimeMissmatch;
 
 	public static String OSGiLaunchConfiguration_cannotFindLaunchConfiguration;
 	public static String OSGiLaunchConfiguration_selected;

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/pderesources.properties
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/pderesources.properties
@@ -25,6 +25,13 @@ WorkbenchLauncherConfigurationDelegate_jrePathNotFound = The installation path t
 WorkbenchLauncherConfigurationDelegate_noStartup = Launching failed. Bootstrap code cannot be found.
 JUnitLaunchConfiguration_error_notaplugin = Could not launch the JUnit plug-in tests because project ''{0}'' is not a plug-in project.
 JUnitLaunchConfiguration_error_missingPlugin = Required plug-in ''{0}'' could not be found.
+JUnitLaunchConfiguration_error_JUnitLaunchAndRuntimeMissmatch = Launch targets JUnit {0} but contains JUnit {1} bundles.\n\
+Therefore this launch is expected to fail.\n\
+\n\
+Either update the launch configuration to target JUnit {1},\n\
+or restrict the versions of JUnit Jupiter and JUnit Platform\n\
+by specifying corresponding version bounds\n\
+in your test-project to match only JUnit {0}.
 
 OSGiLaunchConfiguration_cannotFindLaunchConfiguration=Cannot find the {0} OSGi framework.
 OSGiLaunchConfiguration_selected=selected

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -71,6 +71,7 @@ import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.core.util.VersionUtil;
 import org.eclipse.pde.internal.launching.IPDEConstants;
 import org.eclipse.pde.internal.launching.JUnitLaunchRequirements;
+import org.eclipse.pde.internal.launching.JUnitLaunchValidationOperation;
 import org.eclipse.pde.internal.launching.PDELaunchingPlugin;
 import org.eclipse.pde.internal.launching.PDEMessages;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
@@ -517,6 +518,9 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, false);
 		fAllBundles = fModels.keySet().stream().collect(Collectors.groupingBy(m -> m.getPluginBase().getId(), LinkedHashMap::new, Collectors.toCollection(ArrayList::new)));
 		launchMode = launch.getLaunchMode();
+
+		JUnitLaunchValidationOperation junitValidation = new JUnitLaunchValidationOperation(configuration, fModels.keySet());
+		LaunchPluginValidator.runValidationOperation(junitValidation, monitor);
 
 		// implicitly add the plug-ins required for JUnit testing if necessary
 		JUnitLaunchRequirements.addRequiredJunitRuntimePlugins(configuration, fAllBundles, fModels);

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -86,6 +86,7 @@ import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.launching.IPDEConstants;
 import org.eclipse.pde.internal.launching.JUnitLaunchRequirements;
+import org.eclipse.pde.internal.launching.JUnitLaunchValidationOperation;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
 import org.eclipse.pde.internal.launching.launcher.EclipsePluginValidationOperation;
 import org.eclipse.pde.internal.launching.launcher.LaunchArgumentsHelper;
@@ -358,6 +359,9 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 		fModels = BundleLauncherHelper.getMergedBundleMap(configuration, false);
 		fAllBundles = fModels.keySet().stream().collect(Collectors.groupingBy(m -> m.getPluginBase().getId(),
 				LinkedHashMap::new, Collectors.toCollection(ArrayList::new)));
+
+		JUnitLaunchValidationOperation junitValidation = new JUnitLaunchValidationOperation(configuration, fModels.keySet());
+		LaunchPluginValidator.runValidationOperation(junitValidation, monitor);
 
 		// implicitly add the plug-ins required for JUnit testing if necessary
 		JUnitLaunchRequirements.addRequiredJunitRuntimePlugins(configuration, fAllBundles, fModels);


### PR DESCRIPTION
This changes ensures an error dialog is shown,
if a user runs a JUnit 5 launch with required JUnit 6 bundles.

Fixes: #2045