### PR TITLE
Collecting all plugin models and prevent repeated lookup

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PDECore.java
@@ -222,13 +222,7 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 
 	private ServiceTracker<RepositoryListenerPlugin, RepositoryListenerPlugin> repositoryListenerServiceTracker;
 
-	public static final Comparator<IPluginModelBase> VERSION = Comparator.comparing(p -> {
-		BundleDescription description = p.getBundleDescription();
-		if (description == null) {
-			return Version.emptyVersion;
-		}
-		return description.getVersion();
-	});
+	public static final Comparator<IPluginModelBase> VERSION = Comparator.comparing(p -> getOSGiVersion(p));
 
 	public PDECore() {
 		inst = this;
@@ -538,5 +532,16 @@ public class PDECore extends Plugin implements DebugOptionsListener {
 		}
 		return repositoryListenerServiceTracker.getTracked().values().stream();
 
+	}
+
+	public static Version getOSGiVersion(IPluginModelBase model) {
+		if (model == null) {
+			return Version.emptyVersion;
+		}
+		BundleDescription description = model.getBundleDescription();
+		if (description == null) {
+			return Version.emptyVersion;
+		}
+		return description.getVersion();
 	}
 }

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchRequirements.java
@@ -15,7 +15,7 @@ package org.eclipse.pde.internal.launching;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,7 +33,8 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
-import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
 
 public class JUnitLaunchRequirements {
 
@@ -43,9 +44,16 @@ public class JUnitLaunchRequirements {
 
 	public static void addRequiredJunitRuntimePlugins(ILaunchConfiguration configuration, Map<String, List<IPluginModelBase>> collectedModels, Map<IPluginModelBase, String> startLevelMap) throws CoreException {
 		Collection<String> runtimePlugins = getRequiredJunitRuntimeEclipsePlugins(configuration);
-		Set<BundleDescription> addedRuntimeBundles = addAbsentRequirements(runtimePlugins, collectedModels, startLevelMap);
-		Set<BundleDescription> runtimeRequirements = DependencyManager.findRequirementsClosure(addedRuntimeBundles);
-		addAbsentRequirements(runtimeRequirements, collectedModels, startLevelMap);
+		//We first need to collect the runtime, either by adding it or take it from the already selected bundles
+		Collection<IPluginModelBase> collected = new HashSet<>();
+		for (String id : runtimePlugins) {
+			addIfAbsent(id, collectedModels, startLevelMap).or(() -> collectedModels.getOrDefault(id, List.of()).stream().filter(m -> m.getBundleDescription().isResolved()).findFirst()).ifPresent(collected::add);
+		}
+		//now compute the closure and add them to the collection
+		Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(collected.stream().map(IPluginModelBase::getBundleDescription).toList());
+		for (BundleDescription description : closure) {
+			collected.add(addIfAbsent(description, collectedModels, startLevelMap));
+		}
 	}
 
 	@SuppressWarnings("restriction")
@@ -59,7 +67,7 @@ public class JUnitLaunchRequirements {
 				return List.of(PDE_JUNIT_RUNTIME);
 			} // Nothing to add for JUnit-3
 			case org.eclipse.jdt.internal.junit.launcher.TestKindRegistry.JUNIT4_TEST_KIND_ID -> {
-				return List.of(PDE_JUNIT_RUNTIME,JUNIT4_JDT_RUNTIME_PLUGIN);
+				return List.of(PDE_JUNIT_RUNTIME, JUNIT4_JDT_RUNTIME_PLUGIN);
 			}
 			case org.eclipse.jdt.internal.junit.launcher.TestKindRegistry.JUNIT5_TEST_KIND_ID -> {
 				return List.of(PDE_JUNIT_RUNTIME, JUNIT5_JDT_RUNTIME_PLUGIN);
@@ -68,37 +76,36 @@ public class JUnitLaunchRequirements {
 		}
 	}
 
-	private static Set<BundleDescription> addAbsentRequirements(Collection<String> requirements, Map<String, List<IPluginModelBase>> collectedModels, Map<IPluginModelBase, String> startLevelMap) throws CoreException {
-		Set<BundleDescription> addedRequirements = new LinkedHashSet<>();
-		for (String id : requirements) {
-			List<IPluginModelBase> models = collectedModels.computeIfAbsent(id, k -> new ArrayList<>());
-			if (models.stream().noneMatch(p -> p.getBundleDescription().isResolved())) {
-				IPluginModelBase model = findRequiredPluginInTargetOrHost(PluginRegistry.findModel(id), plugins -> plugins.max(PDECore.VERSION), id);
-				models.add(model);
-				BundleLauncherHelper.addDefaultStartingBundle(startLevelMap, model);
-				addedRequirements.add(model.getBundleDescription());
-			}
-		}
-		return addedRequirements;
-	}
-
-	private static void addAbsentRequirements(Set<BundleDescription> requirements, Map<String, List<IPluginModelBase>> collectedModels, Map<IPluginModelBase, String> startLevelMap) throws CoreException {
-		for (BundleRevision bundle : requirements) {
-			String id = bundle.getSymbolicName();
-			List<IPluginModelBase> models = collectedModels.computeIfAbsent(id, k -> new ArrayList<>());
-			if (models.stream().map(IPluginModelBase::getBundleDescription).noneMatch(b -> b.isResolved() && b.getVersion().equals(bundle.getVersion()))) {
-				IPluginModelBase model = findRequiredPluginInTargetOrHost(PluginRegistry.findModel(bundle), plgs -> plgs.filter(p -> p.getBundleDescription() == bundle).findFirst(), id);
-				models.add(model);
-				BundleLauncherHelper.addDefaultStartingBundle(startLevelMap, model);
-			}
-		}
-	}
-
 	private static IPluginModelBase findRequiredPluginInTargetOrHost(IPluginModelBase model, Function<Stream<IPluginModelBase>, Optional<IPluginModelBase>> pluginSelector, String id) throws CoreException {
 		if (model == null || !model.getBundleDescription().isResolved()) {
 			// prefer bundle from host over unresolved bundle from target
 			model = pluginSelector.apply(PDECore.getDefault().findPluginsInHost(id)) //
 					.orElseThrow(() -> new CoreException(Status.error(NLS.bind(PDEMessages.JUnitLaunchConfiguration_error_missingPlugin, id))));
+		}
+		return model;
+	}
+
+	private static Optional<IPluginModelBase> addIfAbsent(String id, Map<String, List<IPluginModelBase>> fAllBundles, Map<IPluginModelBase, String> fModels) throws CoreException {
+		List<IPluginModelBase> models = fAllBundles.computeIfAbsent(id, k -> new ArrayList<>());
+		if (models.stream().noneMatch(m -> m.getBundleDescription().isResolved())) {
+			IPluginModelBase model = findRequiredPluginInTargetOrHost(PluginRegistry.findModel(id), plugins -> plugins.max(PDECore.VERSION), id);
+			models.add(model);
+			BundleLauncherHelper.addDefaultStartingBundle(fModels, model);
+			return Optional.of(model);
+		}
+		return Optional.empty();
+	}
+
+	private static IPluginModelBase addIfAbsent(BundleDescription description, Map<String, List<IPluginModelBase>> fAllBundles, Map<IPluginModelBase, String> fModels) throws CoreException {
+		IPluginModelBase model = PluginRegistry.findModel((Resource) description);
+		if (model == null) {
+			Version version = description.getVersion();
+			model = PDECore.getDefault().findPluginsInHost(description.getSymbolicName()).filter(m -> version.equals(PDECore.getOSGiVersion(m))).findFirst().orElseThrow(() -> new CoreException(Status.error("Resolved bundle description " + description + " not found in target or host!"))); //$NON-NLS-1$//$NON-NLS-2$
+		}
+		List<IPluginModelBase> models = fAllBundles.computeIfAbsent(description.getSymbolicName(), k -> new ArrayList<>());
+		if (!models.contains(model)) {
+			models.add(model);
+			BundleLauncherHelper.addDefaultStartingBundle(fModels, model);
 		}
 		return model;
 	}


### PR DESCRIPTION
Currently we add the models we convert the model we have looked up from the id into a bundle description, just to later match them up to models again.

This now stores all collected models for later usage and to prepare for additional filtering.

This is an extract from:

- https://github.com/eclipse-pde/eclipse.pde/pull/2037

and later can be used to properly filter invalid providers from the launch.