### PR TITLE
Import only junit-5 packages required for compilation in tests

### DIFF
--- a/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.pde.build.tests/META-INF/MANIFEST.MF
@@ -14,8 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.ant,
  org.eclipse.debug.core,
  org.eclipse.equinox.p2.publisher;bundle-version="1.1.0",
- org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0",
- junit-jupiter-api;bundle-version="[5.14.0,6.0.0)"
+ org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.equinox.frameworkadmin;version="2.0.0",
  org.eclipse.equinox.internal.p2.artifact.repository,

--- a/ds/org.eclipse.pde.ds.tests/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.tests/META-INF/MANIFEST.MF
@@ -7,17 +7,13 @@ Bundle-Activator: org.eclipse.pde.internal.ds.tests.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.pde.core;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.pde.ds.core;bundle-version="[1.0.0,2.0.0)",
- org.eclipse.text;bundle-version="[3.3.0,4.0.0)",
- junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
- junit-jupiter-engine;bundle-version="[5.14.0,6.0.0)",
- junit-platform-launcher;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-commons;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)"
+ org.eclipse.text;bundle-version="[3.3.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.pde.internal.ds.tests;x-internal:=true
+Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.13.0,2.0.0)"
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.pde.ds.tests

--- a/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/META-INF/MANIFEST.MF
+++ b/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/META-INF/MANIFEST.MF
@@ -12,11 +12,6 @@ Require-Bundle: org.eclipse.swt;bundle-version="[3.110.0,4.0.0)",
  org.eclipse.e4.ui.model.workbench;bundle-version="[2.1.0,3.0.0)",
  org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.ui.tests.harness;bundle-version="[1.8.100,2.0.0)",
- junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
- junit-jupiter-engine;bundle-version="[5.14.0,6.0.0)",
- junit-platform-launcher;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-commons;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)"
+ org.eclipse.ui.tests.harness;bundle-version="[1.8.100,2.0.0)"
 Bundle-ActivationPolicy: lazy
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)"

--- a/e4tools/tests/org.eclipse.e4.tools.persistence.tests/META-INF/MANIFEST.MF
+++ b/e4tools/tests/org.eclipse.e4.tools.persistence.tests/META-INF/MANIFEST.MF
@@ -13,11 +13,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.ui.tests.harness,
  org.eclipse.e4.tools.persistence,
  org.eclipse.e4.core.contexts,
- org.eclipse.e4.ui.workbench,
- junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
- junit-jupiter-engine;bundle-version="[5.14.0,6.0.0)",
- junit-platform-launcher;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-commons;bundle-version="[1.14.0,2.0.0)",
- junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)"
+ org.eclipse.e4.ui.workbench
 Bundle-ActivationPolicy: lazy 
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)"

--- a/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime.tests/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.debug.ui;bundle-version="3.14.200",
  org.eclipse.ui;bundle-version="3.114.0",
  org.eclipse.pde.ui.tests;bundle-version="3.11.500",
- junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
  org.eclipse.jdt.junit4.runtime;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.jdt.junit5.runtime;bundle-version="[1.1.0,2.0.0)",
  org.eclipse.pde.junit.runtime;bundle-version="[3.8.0,4.0.0)"


### PR DESCRIPTION
After a bug fix in Tycho it's not necessary anymore to specify the complete set of junit bundles explicitly, in order to ensure that JUnit-6 bundles are not present:
- https://github.com/eclipse-tycho/tycho/pull/5526

This reverts most of the workarounds from
- https://github.com/eclipse-pde/eclipse.pde/pull/2004
- https://github.com/eclipse-pde/eclipse.pde/pull/2054

This is currently a draft as it requires the mentioned bug-fix to be present in Tycho-5 first.
Trying these changes locally with it worked.