### PR TITLE
Use JDT API to discover package names in ProjectTypeContainer

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectComponent.java
@@ -395,7 +395,7 @@ public class ProjectComponent extends BundleComponent {
 						IPath location2 = res.getLocation();
 						IApiTypeContainer cfc = outputLocationToContainer.get(location2);
 						if (cfc == null) {
-							cfc = new ProjectTypeContainer(component, (IContainer) res);
+							cfc = new ProjectTypeContainer(component, (IContainer) res, root);
 							outputLocationToContainer.put(location2, cfc);
 						}
 						return cfc;
@@ -416,7 +416,7 @@ public class ProjectComponent extends BundleComponent {
 						} else {
 							container = project.getProject().getWorkspace().getRoot().getFolder(outputLocation);
 						}
-						cfc = new ProjectTypeContainer(component, container);
+						cfc = new ProjectTypeContainer(component, container, root);
 						outputLocationToContainer.put(outputLocation, cfc);
 					}
 					return cfc;


### PR DESCRIPTION
This change addresses issue #801 by using JDT's IPackageFragmentRoot API to discover package names instead of relying on filesystem traversal.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/801