### PR TITLE
Fix API tools to persist nested classes with @noreference in .api_description

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescription.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ApiDescription.java
@@ -180,6 +180,31 @@ public class ApiDescription implements IApiDescription {
 		}
 
 		/**
+		 * Returns whether this node or any of its descendants should be persisted
+		 * in the API description. A node should be persisted if it has API visibility
+		 * or if it (or any descendant) has restrictions.
+		 *
+		 * @return true if this node or any descendant should be persisted, false otherwise
+		 */
+		protected boolean shouldPersist() {
+			// Persist if the node has API visibility
+			if (hasApiVisibility(this)) {
+				return true;
+			}
+			// Persist if the node has restrictions
+			if (!RestrictionModifiers.isUnrestricted(this.restrictions)) {
+				return true;
+			}
+			// Persist if any descendant has restrictions
+			for (ManifestNode child : children.values()) {
+				if (child.shouldPersist()) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/**
 		 * Ensure this node is up to date. Default implementation does nothing.
 		 * Subclasses should override as required.
 		 *

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ProjectApiDescription.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/ProjectApiDescription.java
@@ -121,7 +121,7 @@ public class ProjectApiDescription extends ApiDescription {
 
 		@Override
 		void persistXML(Document document, Element parentElement) {
-			if (hasApiVisibility(this)) {
+			if (shouldPersist()) {
 				Element pkg = document.createElement(IApiXmlConstants.ELEMENT_PACKAGE);
 				for (IPackageFragment fFragment : fFragments) {
 					Element fragment = document.createElement(IApiXmlConstants.ELEMENT_PACKAGE_FRAGMENT);
@@ -302,7 +302,7 @@ public class ProjectApiDescription extends ApiDescription {
 
 		@Override
 		void persistXML(Document document, Element parentElement) {
-			if (hasApiVisibility(this)) {
+			if (shouldPersist()) {
 				Element type = document.createElement(IApiXmlConstants.ELEMENT_TYPE);
 				type.setAttribute(IApiXmlConstants.ATTR_HANDLE, fType.getHandleIdentifier());
 				persistAnnotations(type);


### PR DESCRIPTION
The issue was that TypeNode.persistXML and PackageNode.persistXML only persisted nodes with API visibility, filtering out non-API types even if they had restrictions like @noreference.

Added shouldPersist() method to check if a node or its descendants should be persisted based on API visibility OR restrictions, ensuring nested types with @noreference are included in .api_description file.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/1949