### PR TITLE
Add version constraints to junit-platform-launcher added in plug-in launch

### DIFF
--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -62,6 +62,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.junit.buildpath.BuildPathSupport;
 import org.eclipse.jdt.internal.junit.launcher.ITestKind;
 import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
 import org.eclipse.jdt.internal.junit.launcher.JUnitRuntimeClasspathEntry;
@@ -156,6 +157,7 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 		}
 	}
 
+	@SuppressWarnings("restriction")
 	private VMRunnerConfiguration getVMRunnerConfiguration(ILaunchConfiguration configuration, ILaunch launch,
 			String mode, IProgressMonitor monitor) throws CoreException {
 		VMRunnerConfiguration runConfig = null;
@@ -234,14 +236,20 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 			String[] classpath = classpathAndModulepath[0];
 			String[] modulepath = classpathAndModulepath[1];
 
-			if (junitVersion == JUnitVersion.JUNIT5 || junitVersion == JUnitVersion.JUNIT6) {
+			boolean isJUnit5 = junitVersion == JUnitVersion.JUNIT5;
+			boolean isJUnit6 = junitVersion == JUnitVersion.JUNIT6;
+			String junitPlatformVersion = BuildPathSupport.JUNIT6_VERSION;
+			if (isJUnit5) {
+				junitPlatformVersion = BuildPathSupport.JUNIT_PLATFORM_VERSION;
+			}
+			if (isJUnit5 || isJUnit6) {
 				if (!configuration.getAttribute(
 						JUnitLaunchConfigurationConstants.ATTR_DONT_ADD_MISSING_JUNIT5_DEPENDENCY, false)) {
-					if (!Arrays.stream(classpath).anyMatch(
-							s -> s.contains("junit-platform-launcher") || s.contains("org.junit.platform.launcher"))) { //$NON-NLS-1$ //$NON-NLS-2$
+					if (!Arrays.stream(classpath).anyMatch(s -> s.contains(BuildPathSupport.JUNIT_PLATFORM_LAUNCHER)
+							|| s.contains("org.junit.platform.launcher"))) { //$NON-NLS-1$
 						try {
-							JUnitRuntimeClasspathEntry x = new JUnitRuntimeClasspathEntry("junit-platform-launcher", //$NON-NLS-1$
-									null);
+							JUnitRuntimeClasspathEntry x = new JUnitRuntimeClasspathEntry(
+									BuildPathSupport.JUNIT_PLATFORM_LAUNCHER, null, junitPlatformVersion);
 							String entryString = new ClasspathLocalizer(Platform.inDevelopmentMode()).entryString(x);
 							int length = classpath.length;
 							System.arraycopy(classpath, 0, classpath = new String[length + 1], 0, length);


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2572 and https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2574. Similar to what we have in JDT, we add a version range to `junit-platform-launcher` added in `JUnitPluginLaunchConfigurationDelegate`.