### PR TITLE
Fix and simplify pde.ds.annotations.tests

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations.tests/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.annotations.tests/META-INF/MANIFEST.MF
@@ -7,17 +7,18 @@ Bundle-Activator: org.eclipse.pde.ds.internal.annotations.tests.Activator
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.pde.ds.annotations;bundle-version="[1.4.0,1.5.0)",
- org.eclipse.pde.ds.core;bundle-version="[1.3.0,2.0.0)",
- org.eclipse.pde.ui;bundle-version="[3.16.0,4.0.0)",
- org.eclipse.core.resources;bundle-version="[3.23.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.34.0,4.0.0)",
- org.eclipse.text;bundle-version="[3.14.0,4.0.0)"
+Require-Bundle: org.eclipse.pde.ds.annotations;bundle-version="[1.1.0,1.5.0)",
+ org.eclipse.pde.ds.core;bundle-version="[1.1.0,2.0.0)",
+ org.eclipse.pde.ui;bundle-version="[3.9.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
+ org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
+ org.osgi.service.component.annotations;bundle-version="[1.5.0,2.0.0)"
 Export-Package: org.eclipse.pde.ds.internal.annotations.tests;x-internal:=true
-Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+Import-Package: org.assertj.core.api;version="[3.27.0,4.0.0)",
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
- org.opentest4j;version="[1.3.0,2.0.0)"
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Eclipse-BundleShape: dir
 Bundle-ClassPath: tests.jar
 Automatic-Module-Name: org.eclipse.pde.ds.annotations.tests

--- a/ds/org.eclipse.pde.ds.annotations.tests/META-INF/p2.inf
+++ b/ds/org.eclipse.pde.ds.annotations.tests/META-INF/p2.inf
@@ -1,0 +1,3 @@
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.jdt.launching.macosx
+requires.0.filter = (osgi.os=macosx)

--- a/ds/org.eclipse.pde.ds.annotations.tests/projects/test2/test.project
+++ b/ds/org.eclipse.pde.ds.annotations.tests/projects/test2/test.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/AnnotationProcessorTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/AnnotationProcessorTest.java
@@ -2,13 +2,10 @@ package org.eclipse.pde.ds.internal.annotations.tests;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.text.Document;
@@ -31,21 +28,13 @@ public abstract class AnnotationProcessorTest extends TestBase {
 	@BeforeEach
 	public void setUp() throws Exception {
 		testProject = ResourcesPlugin.getWorkspace().getRoot().getProject(getTestProjectName());
-		assumeTrue(testProject.exists(), "Test project does not exist!");
+		assertTrue(testProject.exists(), "Test project does not exist!");
 
 		IFile dsFile = testProject.getFile(IPath.fromOSString(getComponentDescriptorPath()));
-		assertTrue(dsFile.exists(),"Missing component descriptor!");
-
-		ByteArrayOutputStream buf = new ByteArrayOutputStream();
-		try (InputStream src = dsFile.getContents()) {
-			byte[] bytes = new byte[4096];
-			int c;
-			while ((c = src.read(bytes)) != -1) {
-				buf.write(bytes, 0, c);
-			}
-		}
-
-		dsModel = new DSModel(new Document(buf.toString(dsFile.getCharset())), false);
+		dsFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		assertTrue(dsFile.exists(), "Missing component descriptor:" + dsFile);
+		String dsFileContent = dsFile.readString();
+		dsModel = new DSModel(new Document(dsFileContent), false);
 		dsModel.setUnderlyingResource(dsFile);
 		dsModel.load();
 

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/CompilationParticipantTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/CompilationParticipantTest.java
@@ -1,6 +1,6 @@
 package org.eclipse.pde.ds.internal.annotations.tests;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -15,6 +15,6 @@ public abstract class CompilationParticipantTest extends TestBase {
 	@BeforeEach
 	public void setUp() {
 		testProject = ResourcesPlugin.getWorkspace().getRoot().getProject(getTestProjectName());
-		assumeTrue(testProject.exists(), "Test project does not exist!");
+		assertTrue(testProject.exists(), "Test project does not exist!");
 	}
 }

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/DefaultComponentTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/DefaultComponentTest.java
@@ -12,10 +12,8 @@ import org.eclipse.pde.internal.ds.core.IDSImplementation;
 import org.eclipse.pde.internal.ds.core.IDSProvide;
 import org.eclipse.pde.internal.ds.core.IDSReference;
 import org.eclipse.pde.internal.ds.core.IDSService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 @SuppressWarnings("restriction")
 public class DefaultComponentTest extends AnnotationProcessorTest {
 

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ErrorProjectTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ErrorProjectTest.java
@@ -7,10 +7,8 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 public class ErrorProjectTest extends CompilationParticipantTest {
 
 	private static final IPath PATH_PREFIX = IPath.fromOSString("src/ds/annotations/test2/");

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ExtendedLifeCycleMethodComponentTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ExtendedLifeCycleMethodComponentTest.java
@@ -3,10 +3,8 @@ package org.eclipse.pde.ds.internal.annotations.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 @SuppressWarnings("restriction")
 public class ExtendedLifeCycleMethodComponentTest extends AnnotationProcessorTest {
 

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ExtendedReferenceMethodComponentTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ExtendedReferenceMethodComponentTest.java
@@ -6,10 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.concurrent.Executor;
 
 import org.eclipse.pde.internal.ds.core.IDSReference;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 @SuppressWarnings("restriction")
 public class ExtendedReferenceMethodComponentTest extends AnnotationProcessorTest {
 

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/FullComponentTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/FullComponentTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Set;
@@ -16,10 +16,8 @@ import org.eclipse.pde.internal.ds.core.IDSProperty;
 import org.eclipse.pde.internal.ds.core.IDSProvide;
 import org.eclipse.pde.internal.ds.core.IDSReference;
 import org.eclipse.pde.internal.ds.core.IDSService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 @SuppressWarnings("restriction")
 public class FullComponentTest extends AnnotationProcessorTest {
 
@@ -111,9 +109,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyString() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 0;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("stringProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("stringValue", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("String", properties[PROPERTY_INDEX].getPropertyType());
@@ -123,9 +121,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyImplicitString() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 1;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("implicitStringProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("implicitStringValue", properties[PROPERTY_INDEX].getPropertyValue());
 		assertNull(properties[PROPERTY_INDEX].getPropertyType());
@@ -135,9 +133,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyExplicitString() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 2;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("explicitStringProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("explicitStringValue", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("String", properties[PROPERTY_INDEX].getPropertyType());
@@ -147,9 +145,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyInteger() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 3;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("integerProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("1", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Integer", properties[PROPERTY_INDEX].getPropertyType());
@@ -159,9 +157,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyLong() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 4;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("longProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("2", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Long", properties[PROPERTY_INDEX].getPropertyType());
@@ -171,9 +169,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyShort() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 5;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("shortProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("3", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Short", properties[PROPERTY_INDEX].getPropertyType());
@@ -183,9 +181,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyByte() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 6;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("byteProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("4", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Byte", properties[PROPERTY_INDEX].getPropertyType());
@@ -195,9 +193,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyCharacter() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 7;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("characterProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("53", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Character", properties[PROPERTY_INDEX].getPropertyType());
@@ -207,9 +205,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyFloat() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 8;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("floatProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("6.7", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Float", properties[PROPERTY_INDEX].getPropertyType());
@@ -219,9 +217,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyDouble() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 9;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("doubleProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("8.9", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Double", properties[PROPERTY_INDEX].getPropertyType());
@@ -231,9 +229,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyImplicitStringArray() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 10;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("implicitStringArrayProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertNull(properties[PROPERTY_INDEX].getPropertyValue());
 		assertNull(properties[PROPERTY_INDEX].getPropertyType());
@@ -243,9 +241,9 @@ public class FullComponentTest extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyExplicitStringArray() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 11;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("explicitStringArrayProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertNull(properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("String", properties[PROPERTY_INDEX].getPropertyType());

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/FullComponentTestV1_2.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/FullComponentTestV1_2.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Set;
@@ -16,10 +16,8 @@ import org.eclipse.pde.internal.ds.core.IDSProperty;
 import org.eclipse.pde.internal.ds.core.IDSProvide;
 import org.eclipse.pde.internal.ds.core.IDSReference;
 import org.eclipse.pde.internal.ds.core.IDSService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 @SuppressWarnings("restriction")
 public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 
@@ -111,9 +109,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyImplicitString() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 0;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("implicitStringProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("implicitStringValue", properties[PROPERTY_INDEX].getPropertyValue());
 		assertNull(properties[PROPERTY_INDEX].getPropertyType());
@@ -123,9 +121,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyExplicitString() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 1;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("explicitStringProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("explicitStringValue", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("String", properties[PROPERTY_INDEX].getPropertyType());
@@ -135,9 +133,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyInteger() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 2;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("integerProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("1", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Integer", properties[PROPERTY_INDEX].getPropertyType());
@@ -147,9 +145,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyLong() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 3;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("longProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("2", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Long", properties[PROPERTY_INDEX].getPropertyType());
@@ -159,9 +157,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyShort() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 4;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("shortProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("3", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Short", properties[PROPERTY_INDEX].getPropertyType());
@@ -171,9 +169,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyByte() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 5;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("byteProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("4", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Byte", properties[PROPERTY_INDEX].getPropertyType());
@@ -183,9 +181,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyCharacter() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 6;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("characterProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("53", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Character", properties[PROPERTY_INDEX].getPropertyType());
@@ -195,9 +193,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyFloat() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 7;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("floatProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("6.7", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Float", properties[PROPERTY_INDEX].getPropertyType());
@@ -207,9 +205,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyDouble() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 8;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("doubleProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertEquals("8.9", properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("Double", properties[PROPERTY_INDEX].getPropertyType());
@@ -219,9 +217,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyImplicitStringArray() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 9;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("implicitStringArrayProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertNull(properties[PROPERTY_INDEX].getPropertyValue());
 		assertNull(properties[PROPERTY_INDEX].getPropertyType());
@@ -231,9 +229,9 @@ public class FullComponentTestV1_2 extends AnnotationProcessorTest {
 	@Test
 	public void componentPropertyExplicitStringArray() throws Exception {
 		IDSProperty[] properties = dsModel.getDSComponent().getPropertyElements();
-		assumeTrue(properties != null);
+		assertNotNull(properties);
 		final int PROPERTY_INDEX = 10;
-		assumeTrue(properties.length > PROPERTY_INDEX);
+		assertTrue(properties.length > PROPERTY_INDEX);
 		assertEquals("explicitStringArrayProperty", properties[PROPERTY_INDEX].getPropertyName());
 		assertNull(properties[PROPERTY_INDEX].getPropertyValue());
 		assertEquals("String", properties[PROPERTY_INDEX].getPropertyType());

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ManagedProjectTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/ManagedProjectTest.java
@@ -1,9 +1,9 @@
 package org.eclipse.pde.ds.internal.annotations.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -16,10 +16,8 @@ import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.ds.internal.annotations.DSAnnotationCompilationParticipant;
 import org.eclipse.pde.internal.core.ibundle.IBundleModel;
 import org.eclipse.pde.internal.core.ibundle.IBundlePluginModelBase;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("Simply doesn't work in the new build environment yet")
 @SuppressWarnings("restriction")
 public class ManagedProjectTest extends CompilationParticipantTest {
 
@@ -48,9 +46,9 @@ public class ManagedProjectTest extends CompilationParticipantTest {
 	@Test
 	public void manifestHeaderServiceComponentAdded() throws Exception {
 		IPluginModelBase pluginModel = PluginRegistry.findModel(testProject);
-		assumeTrue(pluginModel instanceof IBundlePluginModelBase, "Test project not a bundle project!");
+		assertThat(pluginModel).isInstanceOf(IBundlePluginModelBase.class);
 		IBundleModel bundleModel = ((IBundlePluginModelBase) pluginModel).getBundleModel();
-		assumeTrue(bundleModel != null, "Missing bundle manifest!");
+		assertNotNull(bundleModel, "Missing bundle manifest!");
 		String serviceComponentHeader = bundleModel.getBundle().getHeader("Service-Component");
 		assertNotNull(serviceComponentHeader, "Missing Service-Component header!");
 		String[] entries = serviceComponentHeader.split("\\s*,\\s*");

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/TestBase.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/TestBase.java
@@ -1,15 +1,9 @@
 package org.eclipse.pde.ds.internal.annotations.tests;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(WorkspaceSetupExtension.class)
 public abstract class TestBase {
 
 	protected static final String DS_PROBLEM_MARKER = "org.eclipse.pde.ds.annotations.problem";
-
-	@BeforeEach
-	public void ensureWorkspaceReady() throws Exception {
-		WorkspaceSetupExtension.getWorkspaceJob().join();
-	}
 }

--- a/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/UnmanagedProjectTest.java
+++ b/ds/org.eclipse.pde.ds.annotations.tests/src/org/eclipse/pde/ds/internal/annotations/tests/UnmanagedProjectTest.java
@@ -1,10 +1,7 @@
 package org.eclipse.pde.ds.internal.annotations.tests;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.pde.ds.internal.annotations.DSAnnotationCompilationParticipant;
 import org.junit.jupiter.api.Test;
 
@@ -18,8 +15,6 @@ public class UnmanagedProjectTest extends CompilationParticipantTest {
 
 	@Test
 	public void managedProject() throws Exception {
-		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("ds.annotations.test0");
-		assumeTrue(project.exists());
-		assertFalse(DSAnnotationCompilationParticipant.isManaged(project));
+		assertFalse(DSAnnotationCompilationParticipant.isManaged(testProject));
 	}
 }


### PR DESCRIPTION
Convert assumptions to assertions since all of them should actually be assertions.
Furthermore this replaces leftover JUnit-4 assumptions.

This is currently a draft as not everything is working yet locally.

Follow-up on
- https://github.com/eclipse-pde/eclipse.pde/pull/2048