### PR TITLE
Improve display of multi-line single String launch validation errors

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchValidationOperation.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/JUnitLaunchValidationOperation.java
@@ -75,7 +75,7 @@ public class JUnitLaunchValidationOperation extends LaunchValidationOperation {
 	}
 
 	private void addError(String message) {
-		fErrors.put(message.replaceAll("\\R", " "), null); //$NON-NLS-1$//$NON-NLS-2$
+		fErrors.put(message, null);
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginStatusDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginStatusDialog.java
@@ -16,6 +16,7 @@
 package org.eclipse.pde.internal.ui.launcher;
 
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -44,6 +45,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 
 /**
@@ -185,14 +187,23 @@ public class PluginStatusDialog extends TrayDialog {
 
 		Label label = new Label(container, SWT.NONE);
 		label.setText(PDEUIMessages.PluginStatusDialog_label);
+		GridData gridData = new GridData(GridData.FILL_BOTH);
 
-		treeViewer = new TreeViewer(container);
-		treeViewer.setContentProvider(new ContentProvider());
-		treeViewer.setLabelProvider(PDEPlugin.getDefault().getLabelProvider());
-		treeViewer.setComparator(new ViewerComparator());
-		treeViewer.setInput(fInput);
-		treeViewer.getControl().setLayoutData(new GridData(GridData.FILL_BOTH));
-
+		Entry<?, ?> onlyEntry = fInput.size() == 1 ? fInput.entrySet().iterator().next() : null;
+		if (onlyEntry != null && onlyEntry.getKey() instanceof String errorMessage && errorMessage.contains("\n") //$NON-NLS-1$
+				&& onlyEntry.getValue() == null) {
+			Text message = new Text(container, SWT.MULTI | SWT.READ_ONLY | SWT.WRAP | SWT.BORDER | SWT.V_SCROLL);
+			message.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+			message.setText(errorMessage);
+			message.setLayoutData(gridData);
+		} else {
+			treeViewer = new TreeViewer(container);
+			treeViewer.setContentProvider(new ContentProvider());
+			treeViewer.setLabelProvider(PDEPlugin.getDefault().getLabelProvider());
+			treeViewer.setComparator(new ViewerComparator());
+			treeViewer.setInput(fInput);
+			treeViewer.getControl().setLayoutData(gridData);
+		}
 		getShell().setText(PDEUIMessages.PluginStatusDialog_pluginValidation);
 		Dialog.applyDialogFont(container);
 		return container;


### PR DESCRIPTION
mainly on Windows.

Follow-up on
- https://github.com/eclipse-pde/eclipse.pde/pull/2055

On Windows 11 this now looks like

<img height="400" src="https://github.com/user-attachments/assets/123a8a69-f683-422b-a9e1-a881ccfe704e" />

Before it was
<img height="400" src="https://github.com/user-attachments/assets/ae49ebb8-1a80-4f60-9b33-23becf50e16b" />

Alternatively we could set the Text field enabled=false instead of editable=false/READ_ONLY:
<img height="400" src="https://github.com/user-attachments/assets/18ae0bcc-7dd9-414a-9a89-407acd96ebea" />

or could just use a plain label (`Label message = new Label(container, SWT.BORDER | SWT.WRAP);`, with modified text to be longer):

<img height="400" src="https://github.com/user-attachments/assets/dd7efc26-5451-4f27-9aa6-a33b7a7c51dc" />

@trancexpress can you compare it for Linux and tell what works best?