### PR TITLE
Expand Dependency Analysis section of the Manifest Editor by default

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependenciesPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/DependenciesPage.java
@@ -79,7 +79,8 @@ public class DependenciesPage extends PDEFormPage {
 			} else {
 				gd.horizontalSpan = 2;
 			}
-			section = new DependencyAnalysisSection(this, right, ExpandableComposite.COMPACT);
+			// Expand by default
+			section = new DependencyAnalysisSection(this, right, ExpandableComposite.EXPANDED);
 		} else {
 			// No MANIFEST.MF (not a Bundle), 3.0 timeframe
 			MatchSection matchSection = new MatchSection(this, right, true);


### PR DESCRIPTION
Part of https://github.com/eclipse-pde/eclipse.pde/issues/1881