### PR TITLE
Fix ImageBrowserView combos popup transparency

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/ImageBrowserView.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/imagebrowser/ImageBrowserView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012, 2018 Christian Pontesegger and others.
+ *  Copyright (c) 2012, 2025 Christian Pontesegger and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -167,7 +167,6 @@ public class ImageBrowserView extends ViewPart implements IImageTarget {
 	public void createPartControl(final Composite parent) {
 		final Composite composite = SWTFactory.createComposite(parent, 1, 1, GridData.FILL_BOTH, 0, 0);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, IHelpContextIds.IMAGE_BROWSER_VIEW);
-		composite.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		Composite topComp = new Composite(composite, SWT.NONE);
 		RowLayout layout = new RowLayout();
 		// need to center vertically, otherwise its looks misaligned
@@ -231,12 +230,9 @@ public class ImageBrowserView extends ViewPart implements IImageTarget {
 		spinMaxImages.setSelection(250);
 		spinMaxImages.setLayoutData(GridDataFactory.fillDefaults().create());
 		spinMaxImages.addModifyListener(e -> {
-			Display.getCurrent().asyncExec(new Runnable() {
-				@Override
-				public void run() {
-					page = 0; // reset to 1st page
-					scanImages();
-				}
+			Display.getCurrent().asyncExec(() -> {
+				page = 0; // reset to 1st page
+				scanImages();
 			});
 		});
 


### PR DESCRIPTION
On Fedora 43 system SWT.COLOR_LIST_BACKGROUND comes with transparency set and this misrenders combos popup as the color is inherited by children. Not setting any color at all is the simplest and most naturally fitting choice to fix the problem.