### PR TITLE
Set tycho.useJDK=SYSTEM globally for verification builds

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime/build.properties
+++ b/ui/org.eclipse.pde.junit.runtime/build.properties
@@ -19,3 +19,4 @@ bin.includes = .,\
                META-INF/
 src.includes = about.html
 output.. = bin/
+pom.model.property.tycho.useJDK=SYSTEM


### PR DESCRIPTION
We already use that for the API tools and as java 1.8 is vanish from github we want to disable it globally, it will still be checked in the ibuilds anyways.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/2099