### PR TITLE
Skip optional dependencies in new JUnit Plug-in test launches by default

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/PreferenceInitializer.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/PreferenceInitializer.java
@@ -32,7 +32,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		prefs.putBoolean(ILaunchingPreferenceConstants.PROP_JUNIT_WORKSPACE_LOCATION_IS_CONTAINER, false);
 		prefs.put(ILaunchingPreferenceConstants.PROP_JUNIT_LAUNCH_WITH, ILaunchingPreferenceConstants.VALUE_JUNIT_LAUNCH_WITH_TESTPLUGIN);
 		prefs.putBoolean(ILaunchingPreferenceConstants.PROP_JUNIT_AUTO_INCLUDE, true);
-		prefs.putBoolean(ILaunchingPreferenceConstants.PROP_JUNIT_INCLUDE_OPTIONAL, true);
+		prefs.putBoolean(ILaunchingPreferenceConstants.PROP_JUNIT_INCLUDE_OPTIONAL, false);
 		prefs.putBoolean(ILaunchingPreferenceConstants.PROP_JUNIT_ADD_NEW_WORKSPACE_PLUGINS, false);
 		prefs.putBoolean(ILaunchingPreferenceConstants.PROP_JUNIT_VALIDATE_LAUNCH, true);
 		prefs.putBoolean(ILaunchingPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING, true);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/LaunchingPreferencePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/LaunchingPreferencePage.java
@@ -103,7 +103,7 @@ public class LaunchingPreferencePage extends PreferencePage implements IWorkbenc
 			fJunitAutoIncludeRequirementsButton = SWTFactory.createCheckButton(options,
 					PDEUIMessages.AdvancedLauncherTab_autoIncludeRequirements_plugins, null, true, 1);
 			fJunitIncludeOptionalButton = SWTFactory.createCheckButton(options,
-					PDEUIMessages.AdvancedLauncherTab_includeOptional_plugins, null, true, 1);
+					PDEUIMessages.AdvancedLauncherTab_includeOptional_plugins, null, false, 1);
 			fJunitAddWorkspaceButton = SWTFactory.createCheckButton(options,
 					PDEUIMessages.AdvancedLauncherTab_addNew_plugins, null, false, 1);
 			fJunitAutoValidate = SWTFactory.createCheckButton(options,


### PR DESCRIPTION
If a dependency is optional then the code must be ready to handle the absence. And if it cannot be absent, then the requirement should be mandatory. If the bundle itself can work without that requirement but some other bundle needs the first bundle to work with that optional dependency, then that other bundle has to declare a corresponding mandatory requirement.
On the other hand, considering optional dependencies can drag bundles into the runtime that are not desired and even can cause harm. And because it's not possible to remove undesired bundles with some other configuration, it's better to start with less and explicitly add what's a missing mandatory requirement.

See for example https://github.com/eclipse-pde/eclipse.pde/pull/2092#issuecomment-3487595254 ff.