### PR TITLE
Remove compilation error resolution proposal for adding Junit 5 bundles

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/UnresolvedImportFixProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/UnresolvedImportFixProcessor.java
@@ -60,22 +60,6 @@ public class UnresolvedImportFixProcessor extends ClasspathFixProcessor {
 		}
 
 		/*
-		 * Creates proposal for adding require bundles in manifest file based on the
-		 * description name given
-		 */
-		public void addResolutionModification(IProject project, String desc, CompilationUnit cu,
-				String qualifiedTypeToImport) {
-			if (desc == null) {
-				return;
-			}
-			Object proposal = JavaResolutionFactory.createRequireBundleProposal(project, desc,
-					JavaResolutionFactory.TYPE_CLASSPATH_FIX, 16, cu, qualifiedTypeToImport);
-			if (proposal != null) {
-				fList.add(proposal);
-			}
-		}
-
-		/*
 		 * Returns all the ClasspathFixProposals which were found
 		 */
 		public ClasspathFixProposal[] getProposals() {
@@ -96,12 +80,6 @@ public class UnresolvedImportFixProcessor extends ClasspathFixProcessor {
 			return new ClasspathFixProposal[0];
 		}
 		ClasspathFixCollector collector = new ClasspathFixCollector();
-		// Add require bundles for junit5
-		if (name.startsWith("junit-jupiter") || name.startsWith("junit-platform") || name.startsWith("org.junit.jupiter") || name.startsWith("org.junit.platform")) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			collector.addResolutionModification(project.getProject(), "JUnit 5 bundles", null, null);////$NON-NLS-1$
-			return collector.getProposals();
-		}
-
 		IRunnableWithProgress findOperation = new FindClassResolutionsOperation(project.getProject(), name, collector);
 		try {
 			findOperation.run(new NullProgressMonitor());


### PR DESCRIPTION
For junit-5 it's sufficient and recommended to just import the packages needed for compilation. Alternatively it's also possible to require the `junit-jupiter-api` bundle.

Both is already proposed by default and in both cases it's not necessary to require the junit-4 bundle (`org.junit`) too.

As this extra proposal also complicates the code significantly, it is removed with the recommendation to use the other standard proposals in case of missing JUnit-5 dependencies too.

Furthermore the current code seems to be partially incorrect, because actually package names have to be checked while it seems that the code assumed bundle names (which only coincidentally match).

Removing it also avoids the need to handle the JUnit-6 case too.

This was initially proposed in
- https://github.com/eclipse-pde/eclipse.pde/pull/2053#issuecomment-3474463774

With this, the proposals are now (https://github.com/eclipse-pde/eclipse.pde/pull/2053#issuecomment-3474463774 contains the previous state):

<img height="400" src="https://github.com/user-attachments/assets/32d434da-3126-4fd7-a3b5-51e78ea1ec16" />

In a follow-up PR the proposals should be further enhanced to
- show package-imports at the top
- remove duplicated proposals
- show versions and propose multiple versions if available.

