### PR TITLE
Fix false positive for static inner class implementing parent interface

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/leak/InterfaceExtendsLeak.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/leak/InterfaceExtendsLeak.java
@@ -371,4 +371,28 @@ public class InterfaceExtendsLeak extends LeakTest {
 		String typename = "Etest14"; //$NON-NLS-1$
 		deployLeakTest(typename + ".java", inc);//$NON-NLS-1$
 	}
+
+	/**
+	 * Tests that a static inner class implementing its parent interface does NOT produce
+	 * a leak warning (inner class referencing enclosing type should be excluded)
+	 * using a full build
+	 */
+	public void testStaticInnerClassImplementsParent15F() {
+		x15(false);
+	}
+
+	/**
+	 * Tests that a static inner class implementing its parent interface does NOT produce
+	 * a leak warning (inner class referencing enclosing type should be excluded)
+	 * using an incremental build
+	 */
+	public void testStaticInnerClassImplementsParent15I() {
+		x15(true);
+	}
+
+	private void x15(boolean inc) {
+		expectingNoProblems();
+		String typename = "Etest15"; //$NON-NLS-1$
+		deployLeakTest(typename + ".java", inc);//$NON-NLS-1$
+	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/leak/interface/Etest15.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/leak/interface/Etest15.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package x.y.z;
+
+/**
+ * Test case for static inner class implementing parent interface.
+ * This pattern should NOT produce a leak warning as the inner class
+ * is referencing its enclosing type which has the same visibility.
+ */
+public interface Etest15 {
+	
+	/**
+	 * Static inner class implementing the parent interface.
+	 * This should not be reported as leaking non-API interface.
+	 */
+	static class Etest15Impl implements Etest15 {
+		// Implementation
+	}
+}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ReferenceExtractor.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ReferenceExtractor.java
@@ -1010,6 +1010,15 @@ public class ReferenceExtractor extends ClassVisitor {
 			}
 			return false;
 		}
+		// Also check the reverse: if this type is a member of the referenced type
+		// (e.g., inner class referencing its enclosing type)
+		if (fType.getName().startsWith(referencedTypeName)) {
+			int refLength = referencedTypeName.length();
+			if (fType.getName().length() > refLength && fType.getName().charAt(refLength) == '$') {
+				// This is a member type referencing its enclosing type - exclude it
+				return false;
+			}
+		}
 		return true;
 	}
 


### PR DESCRIPTION
When a static inner class implements its parent interface (e.g., StateObjectFactory
containing StateObjectFactoryProxy implements StateObjectFactory), API tools was
incorrectly reporting "implements non-API interface" leak warnings.

Root cause: ReferenceExtractor.consider() only checked if referenced type starts
with current type name (to exclude member type references), but didn't check the
reverse case where current type is a member of referenced type.

Fix: Added check in ReferenceExtractor.consider() to also exclude references when
the current type name starts with referencedTypeName + "$", indicating a member
type referencing its enclosing type.

Test: Added Etest15.java test case and corresponding test methods in InterfaceExtendsLeak.java to verify static inner classes implementing parent
interfaces don't produce false positive warnings.