### PR TITLE
Fix intermittent JUnit5 test failure by adding timeout to session result poll

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime.tests/src/org/eclipse/pde/junit/runtime/tests/TestExecutionUtil.java
+++ b/ui/org.eclipse.pde.junit.runtime.tests/src/org/eclipse/pde/junit/runtime/tests/TestExecutionUtil.java
@@ -79,11 +79,14 @@ class TestExecutionUtil {
 
 		try {
 			launchAndWaitForTermination(launchConfiguration);
-			ITestRunSession result = testResult.poll();
+			ITestRunSession result = testResult.poll(30, TimeUnit.SECONDS);
 			if (result == null) {
 				fail("test was not executed");
 			}
 			return result;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("test interrupted", e);
 		} finally {
 			JUnitCore.removeTestRunListener(testRunListener);
 		}


### PR DESCRIPTION
Another attempt to stabilize tests.