### PR TITLE
Add version-range to bundle requirement when added through quick-fix

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/ManifestUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/ManifestUtils.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -66,6 +67,8 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 import org.osgi.framework.namespace.ExecutionEnvironmentNamespace;
 import org.osgi.resource.Namespace;
 import org.osgi.resource.Requirement;
@@ -394,6 +397,16 @@ public class ManifestUtils {
 				throw new IllegalArgumentException("Invalid execution environment filter", e); //$NON-NLS-1$
 			}
 		}
+	}
+
+	public static Optional<VersionRange> createConsumerRequirementRange(Version version) {
+		if (version != null && !Version.emptyVersion.equals(version)) {
+			return Optional.ofNullable(new VersionRange(VersionRange.LEFT_CLOSED, //
+					new Version(version.getMajor(), version.getMinor(), 0), //
+					new Version(version.getMajor() + 1, 0, 0), //
+					VersionRange.RIGHT_OPEN));
+		}
+		return null;
 	}
 
 	/**

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/bundle/ImportPackageObject.java
@@ -24,8 +24,8 @@ import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEState;
 import org.eclipse.pde.internal.core.bundle.BundlePluginBase;
 import org.eclipse.pde.internal.core.ibundle.IBundleModel;
+import org.eclipse.pde.internal.core.util.ManifestUtils;
 import org.osgi.framework.Constants;
-import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
 public class ImportPackageObject extends PackageObject {
@@ -33,13 +33,7 @@ public class ImportPackageObject extends PackageObject {
 	private static final long serialVersionUID = 1L;
 
 	private static String getVersion(ExportPackageDescription desc) {
-		Version version = desc.getVersion();
-		if (version != null && !Version.emptyVersion.equals(version)) {
-			return new VersionRange(
-					"[" + version.getMajor() + "." + version.getMinor() + "," + (version.getMajor() + 1) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$//$NON-NLS-4$
-							.toString();
-		}
-		return null;
+		return ManifestUtils.createConsumerRequirementRange(desc.getVersion()).map(VersionRange::toString).orElse(null);
 	}
 
 	public ImportPackageObject(ManifestHeader header, ManifestElement element, String versionAttribute) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.pde.internal.ui.correction.java;
 
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -51,6 +52,7 @@ import org.eclipse.pde.internal.core.text.bundle.ExportPackageHeader;
 import org.eclipse.pde.internal.core.text.bundle.ExportPackageObject;
 import org.eclipse.pde.internal.core.text.bundle.ImportPackageHeader;
 import org.eclipse.pde.internal.core.text.bundle.ImportPackageObject;
+import org.eclipse.pde.internal.core.util.ManifestUtils;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
@@ -60,6 +62,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.text.edits.TextEdit;
 import org.osgi.framework.Constants;
+import org.osgi.framework.VersionRange;
 
 /**
  * A factory class used to create resolutions for JDT problem markers which involve modifying a project's MANIFEST.MF (or possibly plugin.xml)
@@ -199,11 +202,18 @@ public class JavaResolutionFactory {
 						}
 						IPluginImport impt = base.getPluginFactory().createImport();
 						impt.setId(pluginId);
+						Optional<String> versionRange = ManifestUtils
+								.createConsumerRequirementRange(requiredBundle.getVersion())
+								.map(VersionRange::toString);
+						if (versionRange.isPresent()) {
+							impt.setVersion(versionRange.get());
+						}
 						base.getPluginBase().add(impt);
 					} else {
 						for (IPluginImport pluginImport : imports) {
 							if (pluginImport.getId().equals(pluginId)) {
 								base.getPluginBase().remove(pluginImport);
+								// TODO: Consider version too!
 							}
 						}
 					}


### PR DESCRIPTION
In the quick-fix to resolve compiler errors by adding requirements to bundles, add a version range that is restricted to the current minor up to but excluding the next major version.
Currently the requirements are added without any version.

Effectively a follow-up on
- https://github.com/eclipse-pde/eclipse.pde/pull/1007