### PR TITLE
Increase relevance of Import-Package quick-fix proposals

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/QuickFixProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/QuickFixProcessor.java
@@ -274,7 +274,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 				// same package
 				if (addedImportPackageResolutions.add(desc.getName())) {
 					var change = JavaResolutionFactory.createImportPackageChange(project, desc, cu, typeToImport);
-					result.add(JavaResolutionFactory.createJavaCompletionProposal(change, 4));
+					result.add(JavaResolutionFactory.createJavaCompletionProposal(change, 20));
 					isDone = true;
 				}
 			}


### PR DESCRIPTION
As proposed in https://github.com/eclipse-pde/eclipse.pde/pull/2104, this increases the relevance of Import-Package proposals to move them to the top of the list in order to encourage users to use the preferred way of imports.

The proposals to add bundle requirements has a value of `16`. Assigning a relevance of `20` to Import-Package proposals makes sure they are shown higher up in the list.

Before 
<img width="400" src="https://github.com/user-attachments/assets/f222843c-6d6d-48ae-9cbf-282538f43d29" />

After

<img width="400" src="https://github.com/user-attachments/assets/20314017-0209-4034-984f-e1d3dc8a9e02" />
