### PR TITLE
Propose all available dependency versions in compiler error quick-fixes

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/JavaResolutionFactory.java
@@ -62,6 +62,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.text.edits.TextEdit;
 import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
 /**
@@ -248,8 +249,10 @@ public class JavaResolutionFactory {
 		@Override
 		public String getName() {
 			BundleDescription requiredBundle = getChangeObject();
-			return MessageFormat.format(!isUndo() ? PDEUIMessages.UnresolvedImportFixProcessor_0
-					: PDEUIMessages.UnresolvedImportFixProcessor_1, requiredBundle.getName());
+			return MessageFormat.format(
+					!isUndo() ? PDEUIMessages.UnresolvedImportFixProcessor_0
+							: PDEUIMessages.UnresolvedImportFixProcessor_1,
+					requiredBundle.getName(), getRequirementVersion(requiredBundle.getVersion()));
 		}
 
 		@Override
@@ -330,8 +333,10 @@ public class JavaResolutionFactory {
 		@Override
 		public String getName() {
 			ExportPackageDescription importedPackage = getChangeObject();
-			return MessageFormat.format(!isUndo() ? PDEUIMessages.UnresolvedImportFixProcessor_3
-					: PDEUIMessages.UnresolvedImportFixProcessor_4, importedPackage.getName());
+			return MessageFormat.format(
+					!isUndo() ? PDEUIMessages.UnresolvedImportFixProcessor_3
+							: PDEUIMessages.UnresolvedImportFixProcessor_4,
+					importedPackage.getName(), getRequirementVersion(importedPackage.getVersion()));
 		}
 
 		@Override
@@ -342,7 +347,10 @@ public class JavaResolutionFactory {
 			}
 			return super.getModifiedElement();
 		}
+	}
 
+	private static Version getRequirementVersion(Version bundleVersion) {
+		return new Version(bundleVersion.getMajor(), bundleVersion.getMinor(), 0);
 	}
 
 	private static class ExportPackageChange extends AbstractManifestChange<IPackageFragment> {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/QuickFixProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/QuickFixProcessor.java
@@ -270,13 +270,11 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 					// really useful as import package is computed automatically
 					return;
 				}
+				var change = JavaResolutionFactory.createImportPackageChange(project, desc, cu, typeToImport);
+				result.add(JavaResolutionFactory.createJavaCompletionProposal(change, 20));
 				// guard against multiple import package resolutions for the
 				// same package
-				if (addedImportPackageResolutions.add(desc.getName())) {
-					var change = JavaResolutionFactory.createImportPackageChange(project, desc, cu, typeToImport);
-					result.add(JavaResolutionFactory.createJavaCompletionProposal(change, 20));
-					isDone = true;
-				}
+				isDone |= addedImportPackageResolutions.add(desc.getName());
 			}
 
 			@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1290,12 +1290,12 @@ Menus_new_label = &New
 
 Actions_Feature_OpenProjectWizardAction = &New Feature Project...
 Actions_Site_OpenProjectWizardAction = &New Update Site...
-UnresolvedImportFixProcessor_1=Remove ''{0}'' from required bundles
+UnresolvedImportFixProcessor_1=Remove ''{0} - {1}'' from required bundles
 UnresolvedImportFixProcessor_2=Adds a bundle that exports the needed package to the list of required bundles for this project and adds the related import statement to this Java class.
-UnresolvedImportFixProcessor_3=Add ''{0}'' to imported packages
-UnresolvedImportFixProcessor_4=Remove ''{0}'' from imported packages
+UnresolvedImportFixProcessor_3=Add ''{0} - {1}'' to imported packages
+UnresolvedImportFixProcessor_4=Remove ''{0} - {1}'' from imported packages
 UnresolvedImportFixProcessor_5=Adds an import package dependency for this project and adds the related import statement to this Java class.
-UnresolvedImportFixProcessor_0=Add ''{0}'' to required bundles
+UnresolvedImportFixProcessor_0=Add ''{0} - {1}'' to required bundles
 UpdateClasspathJob_error_title = Update Classpaths
 UpdateClasspathJob_error_message = Updating failed. See log for details.
 UpdateClasspathResolution_label=Update the classpath and compliance settings


### PR DESCRIPTION
As proposed in https://github.com/eclipse-pde/eclipse.pde/pull/2104, this adds all available versions of an importable package or requirable bundle, not only the latest one, when creating a quick-fix for a compiler error due to missing requirements.
Also the version is added in the display string to allow the user to distinguish between versions.

Before
<img width="400" src="https://github.com/user-attachments/assets/20314017-0209-4034-984f-e1d3dc8a9e02" />

After
<img width="400" src="https://github.com/user-attachments/assets/d18470d5-b7e6-4f10-953b-b956538899a9" />

Unfortunately JDT doesn't provide a way (I found) to sort the proposals by anything else than their display string and thus the latest version comes last, while I think it would better be first. But that would probably require changes in JDT first.
Besides that, I'm not yet 100% confident that this change is suitable with respect how the isDone field is computed in `QuickFixProcessor$AbstractClassResolutionCollector.addResolutionModification()`.
I'll have a look at it tomorrow and aim to land this just in time for M3.

FYI @trancexpress 