### PR TITLE
Add expand and collapse options to Compilers preferences page

### DIFF
--- a/ui/org.eclipse.pde.ui/icons/elcl16/expandall.svg
+++ b/ui/org.eclipse.pde.ui/icons/elcl16/expandall.svg
@@ -2,23 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.0 r9654"
-   sodipodi:docname="expandall.svg"
-   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -44,11 +37,9 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient4975-2-1"
        xlink:href="#linearGradient4994-4-7"
-       inkscape:collect="always"
        gradientTransform="translate(18,-3)" />
     <linearGradient
-       id="linearGradient4994-4-7"
-       inkscape:collect="always">
+       id="linearGradient4994-4-7">
       <stop
          id="stop4996-5-4"
          offset="0"
@@ -66,10 +57,8 @@
        gradientTransform="translate(18,-3)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5062-9"
-       xlink:href="#linearGradient4910-4-4"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4910-4-4" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4910-4-4">
       <stop
          style="stop-color:#ffffff;stop-opacity:0"
@@ -81,7 +70,6 @@
          id="stop4914-8-8" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4883-4"
        id="linearGradient4889-2"
        x1="28"
@@ -91,7 +79,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4883-4">
       <stop
          style="stop-color:#ebf9ff;stop-opacity:1"
@@ -103,7 +90,6 @@
          id="stop4887-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4883-4-7"
        id="linearGradient4889-2-1"
        x1="28"
@@ -113,7 +99,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4883-4-7">
       <stop
          style="stop-color:#ebf9ff;stop-opacity:1"
@@ -132,10 +117,8 @@
        gradientTransform="translate(20,-1)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5062-9-5"
-       xlink:href="#linearGradient4910-4-4-2"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4910-4-4-2" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4910-4-4-2">
       <stop
          style="stop-color:#ffffff;stop-opacity:0"
@@ -154,11 +137,9 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient4975-2-1-1"
        xlink:href="#linearGradient4994-4-7-4"
-       inkscape:collect="always"
        gradientTransform="translate(20,-1)" />
     <linearGradient
-       id="linearGradient4994-4-7-4"
-       inkscape:collect="always">
+       id="linearGradient4994-4-7-4">
       <stop
          id="stop4996-5-4-2"
          offset="0"
@@ -176,8 +157,7 @@
        gradientTransform="translate(22,4)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4970"
-       xlink:href="#linearGradient4989"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4989" />
     <linearGradient
        id="linearGradient4989-1">
       <stop
@@ -201,38 +181,8 @@
        gradientTransform="matrix(0,1,-1,0,1053.3622,1058.3622)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5050"
-       xlink:href="#linearGradient4989-1"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4989-1" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.9999998"
-     inkscape:cx="1.5251501"
-     inkscape:cy="27.213599"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1241"
-     inkscape:window-height="814"
-     inkscape:window-x="75"
-     inkscape:window-y="75"
-     inkscape:window-maximized="0"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:snap-global="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3999"
-       empspacing="5"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -246,75 +196,49 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
      transform="translate(0,-1036.3622)">
     <path
        style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
        d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
-       id="rect3997-9-1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
-       inkscape:export-xdpi="90"
-       inkscape:export-ydpi="90" />
+       id="rect3997-9-1" />
     <path
        style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
        d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
-       id="rect3997-9-1-1"
-       inkscape:connector-curvature="0" />
+       id="rect3997-9-1-1" />
     <path
        style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
        d="m 5,1041.3622 0,7 -2,0 0,-9 z"
-       id="rect4853-82-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       id="rect4853-82-7" />
     <path
        style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
        d="m 5,1041.3622 7,0 0,-2 -9,0 z"
-       id="rect4853-82-0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       id="rect4853-82-0" />
     <path
        style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
        d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
-       id="rect3997-9-1-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
-       inkscape:export-xdpi="90"
-       inkscape:export-ydpi="90" />
+       id="rect3997-9-1-2" />
     <path
        style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
        d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
-       id="rect3997-9-1-1-2"
-       inkscape:connector-curvature="0" />
+       id="rect3997-9-1-1-2" />
     <path
        style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
        d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
-       id="rect4853-82-0-6-8"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       id="rect4853-82-0-6-8" />
     <path
        style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
        d="m 7,1043.3622 0,7 -2,0 0,-9 z"
-       id="rect4853-82-7-1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       id="rect4853-82-7-1" />
     <path
        style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
        d="m 7,1043.3622 7,0 0,-2 -9,0 z"
-       id="rect4853-82-0-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       id="rect4853-82-0-6" />
     <path
        style="fill:url(#linearGradient5050);fill-opacity:1;stroke:none;display:inline"
        d="m 10,1044.3622 0,5 c 0,1 1,1 1,0 l 0,-5 c 0,-1 -1,-1 -1,0 z"
-       id="rect4853-82-0-6-8-41"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       id="rect4853-82-0-6-8-41" />
     <rect
        style="fill:#01467a;fill-opacity:1;stroke:none"
        id="rect4167"

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 IBM Corporation and others.
+ * Copyright (c) 2014, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3169,6 +3169,8 @@ public class PDEUIMessages extends NLS {
 	public static String PreferencesSection_generate_merge2;
 	public static String PreferencesSection_generate_merge3;
 	public static String PreferencesSection_generate_merge4;
+	public static String Preference_expand_all;
+	public static String Preference_collapse_all;
 
 	public static String ConvertPreferencesWizardPage_title;
 	public static String ConvertPreferencesWizardPage_description;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2025 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -694,6 +694,9 @@ Preferences_MainPage_Description = General settings for plug-in development:
 Preferences_MainPage_showObjects = Plug-in presentation:
 Preferences_MainPage_useIds = Show &identifiers
 Preferences_MainPage_useFullNames = Show &presentation names
+
+Preference_expand_all= Expand all preferences
+Preference_collapse_all= Collapse all preferences
 
 ExternalizeStringsWizard_title=Externalize Strings
 ExternalizeResolution_attrib=Externalize the {0} attribute

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/CompilersPreferencePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/CompilersPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,14 +31,20 @@ import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.SWTFactory;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
 
 /**
@@ -78,9 +84,36 @@ public class CompilersPreferencePage extends PreferencePage implements IWorkbenc
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, IHelpContextIds.COMPILERS_PREFERENCE_PAGE);
 	}
 
+	private void expandCollapseItems(Composite parent, boolean expandPage) {
+		for (Control control : parent.getChildren()) {
+			if (control instanceof ExpandableComposite page) {
+				page.setExpanded(expandPage);
+				Control child = page.getClient();
+				if (child != null && !child.isDisposed()) {
+					child.setVisible(expandPage);
+				}
+			} else if (control instanceof Composite comp) {
+				expandCollapseItems(comp, expandPage);
+			}
+		}
+		ScrolledComposite composite = getScrolledComposite(parent);
+		if (composite != null) {
+			composite.setMinSize(parent.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+		}
+	}
+
+	private ScrolledComposite getScrolledComposite(Composite comp) {
+		Composite currentComposite = comp;
+		while (currentComposite != null && !(currentComposite instanceof ScrolledComposite)) {
+			currentComposite = currentComposite.getParent();
+		}
+		return (ScrolledComposite) currentComposite;
+	}
+
 	@Override
 	protected Control createContents(Composite parent) {
 		Composite comp = SWTFactory.createComposite(parent, 1, 1, GridData.FILL_BOTH, 0, 0);
+		((GridLayout) comp.getLayout()).verticalSpacing = 0;
 		link = new Link(comp, SWT.NONE);
 		link.setLayoutData(new GridData(GridData.END, GridData.CENTER, true, false));
 		link.setFont(comp.getFont());
@@ -106,8 +139,27 @@ public class CompilersPreferencePage extends PreferencePage implements IWorkbenc
 						new String[] {"org.eclipse.pde.internal.ui.properties.compilersPropertyPage"}, data).open(); //$NON-NLS-1$
 			}
 		}));
+
 		fBlock = new PDECompilersConfigurationBlock(null, (IWorkbenchPreferenceContainer) getContainer());
-		fBlock.createControl(comp);
+		Composite blockComposite = (Composite) fBlock.createControl(comp);
+		((GridLayout) blockComposite.getLayout()).verticalSpacing = 0;
+
+		ToolBar buttonbar = new ToolBar(blockComposite, SWT.FLAT | SWT.RIGHT);
+		buttonbar.setLayoutData(new GridData(SWT.END, SWT.CENTER, true, false));
+		buttonbar.moveAbove(null);
+
+		ToolItem expandItems = new ToolItem(buttonbar, SWT.PUSH);
+		expandItems.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_ELCL_EXPANDALL));
+		expandItems.setToolTipText(PDEUIMessages.Preference_expand_all);
+
+		ToolItem collapseItems = new ToolItem(buttonbar, SWT.PUSH);
+		collapseItems
+				.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_ELCL_COLLAPSEALL));
+		collapseItems.setToolTipText(PDEUIMessages.Preference_collapse_all);
+
+		expandItems.addListener(SWT.Selection, e -> expandCollapseItems(comp, true));
+		collapseItems.addListener(SWT.Selection, e -> expandCollapseItems(comp, false));
+		blockComposite.layout(true);
 
 		// Initialize with data map in case applyData was called before createContents
 		applyData(fPageData);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/PDECompilersConfigurationBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/PDECompilersConfigurationBlock.java
@@ -518,8 +518,8 @@ public class PDECompilersConfigurationBlock extends ConfigurationBlock {
 	 */
 	public Control createControl(Composite parent) {
 		fParent = parent;
-		fMainComp = SWTFactory.createComposite(parent, 1, 1, GridData.FILL_BOTH, 0, 0);
 		SWTFactory.createVerticalSpacer(parent, 1);
+		fMainComp = SWTFactory.createComposite(parent, 1, 1, GridData.FILL_BOTH);
 		fTabFolder = new TabFolder(fMainComp, SWT.NONE);
 		GridData gd = new GridData(GridData.FILL_BOTH);
 		gd.heightHint = 375;


### PR DESCRIPTION
This change introduces `Expand all preferences` and `Collapse all preferences` toolbar options to the Compilers preference page under `Settings → Plugin Development Environment → Compilers` similar to https://github.com/eclipse-pde/eclipse.pde/pull/2117. These options simplify navigation through the expandable sections present on the preference page, making the behaviour consistent with other preference pages like `Java → Compiler → Errors/Warnings`.


https://github.com/user-attachments/assets/990ce580-f2a7-43e5-8dce-6b0cbb8781fe

