### PR TITLE
Migrate to AGENTS.md standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Eclipse PDE - Copilot Coding Agent Instructions
+# Eclipse PDE - AI Coding Agent Instructions
 
 ## Repository Overview
 
@@ -38,7 +38,7 @@ mvn clean verify -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 - `ui/` - Main PDE UI (26 bundles: core, editors, launching, tests, spy tools)
 - `build/` - PDE Build (legacy, maintenance mode - use Tycho instead)
 - `ds/` - Declarative Services tooling
-- `e4tools/` - Eclipse 4 tools  
+- `e4tools/` - Eclipse 4 tools
 - `ua/` - User Assistance
 - `features/` - 6 feature definitions
 - `org.eclipse.pde.doc.user/` - Documentation


### PR DESCRIPTION
Move .github/copilot-instructions.md to AGENTS.md to adopt the new open standard for AI coding agent instructions. AGENTS.md is jointly supported by OpenAI, Google, Cursor, and other major AI platforms, providing a unified format across different coding agent tools.

Changes:
- Rename .github/copilot-instructions.md to AGENTS.md
- Update header from "Copilot Coding Agent" to "AI Coding Agent"
- Maintain all existing content and structure