### PR TITLE
Add missing bundle so that UpdateUnitVersionsCommandTests doesn't fail when ran from Eclipse

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Generic Target Platform Editor
 Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension.tests
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.genericeditor.extension.tests</artifactId>
-  <version>1.3.100-SNAPSHOT</version>
+  <version>1.3.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
When running `UpdateUnitVersionsCommandTests` in Eclipse, the test fails. An error is logged before the fail:

```
!ENTRY org.eclipse.pde.genericeditor.extension 2 0 2025-11-14 12:34:50.660
!MESSAGE Cannot invoke "org.eclipse.equinox.internal.p2.repository.Transport.download(java.net.URI, java.io.OutputStream, org.eclipse.core.runtime.IProgressMonitor)" because the return value of "org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.getTransport()" is null
!STACK 0
java.lang.NullPointerException: Cannot invoke "org.eclipse.equinox.internal.p2.repository.Transport.download(java.net.URI, java.io.OutputStream, org.eclipse.core.runtime.IProgressMonitor)" because the return value of "org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.getTransport()" is null
	at org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.handleRemoteIndexFile(AbstractRepositoryManager.java:797)
	at org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.loadIndexFile(AbstractRepositoryManager.java:791)
	at org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.loadRepository(AbstractRepositoryManager.java:727)
	at org.eclipse.equinox.internal.p2.metadata.repository.MetadataRepositoryManager.loadRepository(MetadataRepositoryManager.java:107)
	at org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager.loadRepository(IMetadataRepositoryManager.java:101)
	at org.eclipse.pde.internal.genericeditor.target.extension.p2.P2Fetcher.fetchAvailableUnits(P2Fetcher.java:63)
	at org.eclipse.pde.internal.genericeditor.target.extension.model.RepositoryCache.lambda$11(RepositoryCache.java:106)
	at org.eclipse.core.runtime.jobs.Job$2.run(Job.java:187)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

If I restore defaults in the launch config, this code finds the service for `Transport` in the bundle `org.eclipse.equinox.p2.transport.ecf`: `org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.lookupServiceRegistrations(String, Filter)`

```
				/* services registered under the class name */
				result = publishedServicesByClass.get(clazz);
```

`filter` has contents:

```
(|(p2.agent.service.name=org.eclipse.equinox.internal.p2.repository.Transport)(p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport))
```

Should be defined in this file I guess:

https://github.com/eclipse-equinox/p2/blob/master/bundles/org.eclipse.equinox.p2.transport.ecf/OSGI-INF/ecfTransport.xml