### PR TITLE
Use Bundle#getResources to discover embedded SPI resources

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/SPIMapping.java
+++ b/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/SPIMapping.java
@@ -17,9 +17,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.util.HashSet;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.osgi.framework.Bundle;
 
@@ -28,22 +28,26 @@ final class SPIMapping {
 	private final Class<?> serviceClass;
 	private final Bundle bundle;
 	private final Set<String> classes;
-	private final URL url;
+	private final Collection<URL> urls;
 
-	SPIMapping(Class<?> serviceClass, Bundle bundle, URL url) {
+	SPIMapping(Class<?> serviceClass, Bundle bundle, Collection<URL> urls) {
 		this.serviceClass = serviceClass;
 		this.bundle = bundle;
-		this.url = url;
-		this.classes = readClasses(url);
+		this.urls = urls;
+		this.classes = readClasses(urls);
 	}
 
-	private Set<String> readClasses(URL entry) {
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(entry.openStream()))) {
-			return reader.lines().collect(Collectors.toSet());
-		} catch (IOException e) {
-			return new HashSet<>();
+	private static Set<String> readClasses(Collection<URL> urls) {
+		Set<String> result = new LinkedHashSet<>();
+		for (URL url : urls) {
+			try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+				reader.lines().forEach(result::add);
+			} catch (IOException e) {
+			}
 		}
+		return result;
 	}
+
 
 	boolean isCompatible(Bundle other) {
 		try {
@@ -53,8 +57,8 @@ final class SPIMapping {
 		}
 	}
 
-	URL getUrl() {
-		return url;
+	Collection<URL> getUrls() {
+		return urls;
 	}
 
 	boolean hasService(String implementation) {


### PR DESCRIPTION
Currently we use bundle.getEntry but this has some limitations, e.g. fragments and embedded jars.

While the first can be avoided with findEntries, the second can not. As we previously already used bundle.getResources it seems fine to continue using that method.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/2132