### PR TITLE
Fix incomplete computation of version ranges for quick-fixes

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/ManifestUtils.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/ManifestUtils.java
@@ -406,7 +406,7 @@ public class ManifestUtils {
 					new Version(version.getMajor() + 1, 0, 0), //
 					VersionRange.RIGHT_OPEN));
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	/**


### PR DESCRIPTION
Prevents an NPE if the required bundle/package doesn't have a version defined.

Follow-up on
- https://github.com/eclipse-pde/eclipse.pde/pull/2120

As this is just a fix, it should be included despite we're in a freeze period now.