### PR TITLE
Updating plug-in dependencies job should provide project information

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
@@ -108,6 +108,7 @@ public class ClasspathContainerState {
 				monitor.setWorkRemaining(WORK);
 				IProject project = request.project();
 				if (project.exists() && project.isOpen()) {
+					monitor.subTask(project.getName());
 					IPluginModelBase model = modelManager.findModel(project);
 					if (model != null && PluginProject.isJavaProject(project)) {
 						IJavaProject javaProject = JavaCore.create(project);


### PR DESCRIPTION
Updating plug-in dependencies can sometimes run relatively long, in its current form it give no indication which project requires a lot of time.

This adds the info, which project is currently updated.