### PR TITLE
Caught the exception when a version is malformed in target file

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -3219,6 +3219,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String TargetEditor_6;
 
+	public static String TargetEditor_7;
+
 	public static String FeatureImportWizardPage_importHasInvalid;
 
 	public static String ProductInfoSection_plugins;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -195,6 +195,10 @@ public class TargetEditor extends FormEditor {
 			setActivePage(fSourceTabIndex);
 			CoreException ce = new CoreException(Status.error(e.getMessage(), e));
 			showError(PDEUIMessages.TargetEditor_5, ce);
+		} catch (IllegalArgumentException e) {
+			setActivePage(fSourceTabIndex);
+			CoreException ce = new CoreException(Status.error(e.getMessage(), e));
+			showError(PDEUIMessages.TargetEditor_7, ce);
 		}
 	}
 
@@ -557,7 +561,7 @@ public class TargetEditor extends FormEditor {
 					ITargetHandle externalTarget = service.getTarget(((IURIEditorInput) fInput).getURI());
 					fTarget = externalTarget.getTargetDefinition();
 				}
-			} catch (CoreException e) {
+			} catch (CoreException | IllegalArgumentException e) {
 				fTarget = service.newTarget();
 				throw e;
 			}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1999,6 +1999,7 @@ TargetEditor_3=Unable to perform save
 TargetEditor_4=Target Editor
 TargetEditor_5=Unable to load target definition model. Fix the target definition model in Source View.
 TargetEditor_6=The editor input ''{0}'' is not supported.
+TargetEditor_7=Unable to parse the IU version. Fix the target definition model in Source View.
 TargetCreationPage_0=Initialize the target definition with:
 TargetCreationPage_1=Nothing: Start &with an empty target definition
 TargetCreationPage_2=&Default: Default target for the running platform


### PR DESCRIPTION
Issue: #1945 
Exception is caught to open the target editor when a version is malformed.