### PR TITLE
Enable Manifest cleanups

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -14,6 +14,7 @@ jobs:
       author: Eclipse PDE Bot <pde-bot@eclipse.org>
       do-quickfix: false
       do-cleanups: true
+      do-manifest: true
       bundle-folders: ui/*/ ua/*/ ds/*/ build/*/ apitools/*/ e4tools/bundles/*/
     secrets:
       token: ${{ secrets.PDE_BOT_PAT }}


### PR DESCRIPTION
Since we have used them in Equinox and P2 for a while PDE should use them as well as part of [Eating your own dog food](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) and to iron out further obstacles.

Some problems are already reported here:
- https://github.com/eclipse-pde/eclipse.pde/issues/2115