### PR TITLE
Enable the model search element by default

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
@@ -134,7 +134,7 @@ public class XmiTab extends Composite {
 
 		final String property = System
 				.getProperty(ORG_ECLIPSE_E4_TOOLS_MODELEDITOR_FILTEREDTREE_ENABLED_XMITAB_DISABLED);
-		if (property != null || preferences.getBoolean("tab-form-search-show", false)) { //$NON-NLS-1$
+		if (property != null || preferences.getBoolean("tab-form-search-show", true)) { //$NON-NLS-1$
 			sourceViewer.setEditable(false);
 			sourceViewer.getTextWidget().setEnabled(false);
 		}


### PR DESCRIPTION
In the preference for the Model Editor the useful serach preference should be enabled by default