### PR TITLE
Fix API tools slow down with multiple source folders sharing output

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/ProjectTypeContainerTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/builder/tests/compatibility/ProjectTypeContainerTests.java
@@ -261,7 +261,9 @@ public class ProjectTypeContainerTests extends CompatibilityTest {
 		IApiTypeContainer[] containers = component.getApiTypeContainers();
 		assertEquals("Wrong number of API type containers", 1, containers.length); //$NON-NLS-1$
 		IApiTypeContainer container = containers[0];
-		assertEquals("Should be a composite type container", IApiTypeContainer.COMPOSITE, //$NON-NLS-1$
+		// A single ProjectTypeContainer handles multiple source roots sharing
+		// the same output location by tracking all package fragment roots
+		assertEquals("Should be a folder type container", IApiTypeContainer.FOLDER, //$NON-NLS-1$
 				container.getContainerType());
 
 		String[] packageNames = container.getPackageNames();

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectComponent.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectComponent.java
@@ -14,7 +14,6 @@
 package org.eclipse.pde.api.tools.internal.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -419,30 +418,11 @@ public class ProjectComponent extends BundleComponent {
 						}
 						cfc = new ProjectTypeContainer(component, container, root);
 						outputLocationToContainer.put(outputLocation, cfc);
-					} else {
+					} else if (cfc instanceof ProjectTypeContainer) {
 						// Multiple source folders share the same output location
-						// Create a composite container to include packages from all source roots
-						List<IApiTypeContainer> containers = new ArrayList<>();
-						if (cfc instanceof CompositeApiTypeContainer) {
-							// Already a composite, add to it
-							IApiTypeContainer[] typeContainers = ((CompositeApiTypeContainer) cfc)
-									.getApiTypeContainers();
-							containers.addAll(Arrays.asList(typeContainers));
-						} else {
-							// Convert single container to composite
-							containers.add(cfc);
-						}
-						// Add new container for this source root
-						IPath projectFullPath = project.getProject().getFullPath();
-						IContainer container = null;
-						if (projectFullPath.equals(outputLocation)) {
-							container = project.getProject();
-						} else {
-							container = project.getProject().getWorkspace().getRoot().getFolder(outputLocation);
-						}
-						containers.add(new ProjectTypeContainer(component, container, root));
-						cfc = new CompositeApiTypeContainer(component, containers);
-						outputLocationToContainer.put(outputLocation, cfc);
+						// Add the new package fragment root to the existing container
+						// so it can discover packages from all source roots
+						((ProjectTypeContainer) cfc).addPackageFragmentRoot(root);
 					}
 					return cfc;
 				}


### PR DESCRIPTION
_This PR was originally https://github.com/eclipse-pde/eclipse.pde/pull/2198 but it seems to have disappeared (404) - the original PR had passed ECA_

The fix in commit 215a618 for issue #2096 introduced an O(n^2) time complexity regression when projects have multiple source folders sharing the same output location (like SWT with 26 source roots).

The problem was that each source folder caused a new CompositeApiTypeContainer to be created, wrapping all previous containers plus a new one. This resulted in exponential duplication of container visits during API analysis.

The fix modifies ProjectTypeContainer to support multiple IPackageFragmentRoots, allowing a single container to discover packages from all source folders that share the same output location. This avoids creating composite containers and maintains O(n) complexity.

Fixes #2197