### PR TITLE
Disallow IPackageFragmentRoot from being null within ProjectTypeContainers

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectTypeContainer.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ProjectTypeContainer.java
@@ -15,6 +15,7 @@ package org.eclipse.pde.api.tools.internal.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -61,16 +62,14 @@ public class ProjectTypeContainer extends ApiElement implements IApiTypeContaine
 	 *
 	 * @param parent the {@link IApiElement} parent for this container
 	 * @param container folder in the workspace
-	 * @param packageFragmentRoot optional package fragment root for JDT-based
-	 *            package discovery, may be <code>null</code>
+	 * @param packageFragmentRoot package fragment root for JDT-based
+	 *            package discovery
 	 * @since 1.3.300
 	 */
 	public ProjectTypeContainer(IApiElement parent, IContainer container, IPackageFragmentRoot packageFragmentRoot) {
 		super(parent, IApiElement.API_TYPE_CONTAINER, container.getName());
 		this.fRoot = container;
-		if (packageFragmentRoot != null) {
-			this.fPackageFragmentRoots.add(packageFragmentRoot);
-		}
+		this.fPackageFragmentRoots.add(Objects.requireNonNull(packageFragmentRoot));
 	}
 
 	/**
@@ -81,7 +80,8 @@ public class ProjectTypeContainer extends ApiElement implements IApiTypeContaine
 	 * @since 1.3.400
 	 */
 	public void addPackageFragmentRoot(IPackageFragmentRoot root) {
-		if (root != null && !fPackageFragmentRoots.contains(root)) {
+		Objects.requireNonNull(root);
+		if (!fPackageFragmentRoots.contains(root)) {
 			fPackageFragmentRoots.add(root);
 			// Clear cached package names so they will be recomputed
 			fPackageNames = null;


### PR DESCRIPTION
In all current use cases of this internal class the value passed in was non-null anyway, so there is no functional change with this commit, it simply prevents future changes from trying to pass in a null here

An extra complication is that in 02fa16884eee468e9b4c4aea96566488de4aea33 the javadoc was updated to allow null IPackageFragmentRoot but the code did not match that.

Fixes https://github.com/eclipse-pde/eclipse.pde/pull/2202#discussion_r2713480707