### PR TITLE
Always show Installable Unit (IU) ID in target editor

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/StyledBundleLabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/StyledBundleLabelProvider.java
@@ -193,10 +193,14 @@ public class StyledBundleLabelProvider extends StyledCellLabelProvider implement
 		} else if (element instanceof IInstallableUnit iu) {
 			@SuppressWarnings("restriction")
 			String name = fTranslations.getIUProperty(iu, IInstallableUnit.PROP_NAME);
-			if (name == null) {
-				name = iu.getId();
+			if (name != null && !name.equals(iu.getId())) {
+				styledString.append(name);
+				styledString.append(" [", StyledString.DECORATIONS_STYLER); //$NON-NLS-1$
+				styledString.append(iu.getId(), StyledString.DECORATIONS_STYLER);
+				styledString.append("]", StyledString.DECORATIONS_STYLER); //$NON-NLS-1$
+			} else {
+				styledString.append(iu.getId());
 			}
-			styledString.append(name);
 			styledString.append(' ');
 			styledString.append(iu.getVersion().toString(), StyledString.QUALIFIER_STYLER);
 		} else {


### PR DESCRIPTION
Modified StyledBundleLabelProvider to always display the technical ID of Installable Units in the Target Platform Editor's Definition and Content tabs. If a descriptive name exists and differs from the ID, both are shown (Name [ID]), otherwise just the ID is displayed.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1432