### PR TITLE
Add missing dependency for PDE Runtime to PDE Core

### DIFF
--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)";resolution:=optional,
  org.eclipse.core.resources;bundle-version="[3.20.0,4.0.0)";resolution:=optional,
  org.eclipse.jdt.ui;bundle-version="[3.31.0,4.0.0)";resolution:=optional,
+ org.eclipse.pde.core;bundle-version="[3.21.200,4.0.0)";resolution:=optional,
  org.eclipse.pde.ui;bundle-version="[3.14.200,4.0.0)";resolution:=optional,
  org.eclipse.help;bundle-version="[3.10.200,4.0.0)";resolution:=optional
 Export-Package: org.eclipse.pde.internal.runtime;x-internal:=true,


### PR DESCRIPTION
PDE Runtime has a transitive dependency to PDE Core via PDE UI. However, that dependency is optional and some relevant functionality (like the Plug-in Selection Spy) work without the PDE UI dependency but require PDE Core. In an installation that contains PDE Core but not PDE UI, the Plug-in Selection Spy will not work as the PDE Core dependency is not resolved (as it needs to be resolved transitively via the non present PDE UI dependency), thus leading to NoClassDefFoundErrors for required classes from PDE Core:
```
[2026/02/11 10:42:47.417 D060556 #000000 Heap:8192 1688 1225 Meta:626] "Equinox Log Thread - Equinox Container: 50ae596c-3e11-46e5-8b16-686223814ada,6,main" java.lang.NoClassDefFoundError: org/eclipse/pde/internal/core/util/ManifestUtils
	at org.eclipse.pde.internal.runtime.spy.SpyFormToolkit.generatePluginDetailsText(SpyFormToolkit.java:288)
	at org.eclipse.pde.internal.runtime.spy.sections.ActivePartSection.build(ActivePartSection.java:117)
	at org.eclipse.pde.internal.runtime.spy.dialogs.SpyDialog.createDialogArea(SpyDialog.java:117)
	at org.eclipse.pde.internal.runtime.spy.dialogs.SpyDialog.createContents(SpyDialog.java:86)
```

This change adds the missing dependency. With the change, you will be able to use the Plug-in Selection Spy from PDE Runtime without having PDE UI present in your installation.

