### PR TITLE
Fix: Target editor no longer shows unresolvable IUs #2220

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetLocationContentProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetLocationContentProvider.java
@@ -126,7 +126,7 @@ public class TargetLocationContentProvider implements ITreeContentProvider {
 					}
 					result.add(containers[i]);
 					IStatus status = containers[i].getStatus();
-					if (status != null && status.isOK()) {
+					if (status != null && !status.isOK()) {
 						hasContainerStatus = true;
 					}
 				}


### PR DESCRIPTION
The change 7444c3fc23d1b0a6793ff03df2c1f3c7c016488e wrongfully inverted the isOK() check, causing unresolvable IUs to no longer show up in the target editor.

Closes https://github.com/eclipse-pde/eclipse.pde/issues/2220