### PR TITLE
Add missing dependency org.eclipse.pde.api.tools.annotations to org.eclipse.pde.api.tools.tests

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core.tests.builder;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.jdt.core.tests.compiler;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.ant.core,
+ org.eclipse.pde.api.tools.annotations,
  org.eclipse.pde.ui.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.pde.api.tools.anttasks.tests;uses:="org.eclipse.core.resources",

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java17tags/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java17tags/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: java17tags
 Bundle-SymbolicName: java17tags
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: a.b.c

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java17tags/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java17tags/build.properties
@@ -13,5 +13,6 @@
 ###############################################################################
 source.. = src/
 output.. = bin/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java8tags/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java8tags/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: java8tags
 Bundle-SymbolicName: java8tags
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: a.b.c

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java8tags/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/tagprojects/java8tags/build.properties
@@ -13,5 +13,6 @@
 ###############################################################################
 source.. = src/
 output.. = bin/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/refproject/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/refproject/META-INF/MANIFEST.MF
@@ -11,5 +11,4 @@ Export-Package: a,
  m,
  pack.multi.part
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.eclipse.pde.api.tools;bundle-version="1.0.600",
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.pde.api.tools;bundle-version="1.0.600"

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/refproject/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/refproject/build.properties
@@ -12,5 +12,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .,\

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/usagetests/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/usagetests/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: usagetests
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: refproject,
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0",
  refprojectjava7;bundle-version="1.0.0";resolution:=optional,
  refprojectjava8;bundle-version="1.0.0";resolution:=optional
 Export-Package: internal.x.y.z;x-internal:=true,

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/usagetests/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojects/usagetests/build.properties
@@ -13,5 +13,6 @@
 ###############################################################################
 source.. = src/
 output.. = bin/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/refprojectjava7/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/refprojectjava7/META-INF/MANIFEST.MF
@@ -11,5 +11,4 @@ Export-Package: a,
  m,
  pack.multi.part
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.pde.api.tools;bundle-version="1.0.600",
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.pde.api.tools;bundle-version="1.0.600"

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/refprojectjava7/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/refprojectjava7/build.properties
@@ -12,5 +12,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .,\

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/usageprojectjava7/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/usageprojectjava7/META-INF/MANIFEST.MF
@@ -4,5 +4,4 @@ Bundle-Name: usageprojectjava7
 Bundle-SymbolicName: usageprojectjava7
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: refprojectjava7,
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+Require-Bundle: refprojectjava7

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/usageprojectjava7/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava7/usageprojectjava7/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .
 

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/refprojectjava8/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/refprojectjava8/META-INF/MANIFEST.MF
@@ -5,5 +5,4 @@ Bundle-SymbolicName: refprojectjava8
 Bundle-Version: 1.0.0
 Export-Package: c,i,m
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.pde.api.tools;bundle-version="1.0.600",
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.pde.api.tools;bundle-version="1.0.600"

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/refprojectjava8/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/refprojectjava8/build.properties
@@ -12,5 +12,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+additional.bundles = org.eclipse.jdt.annotation,org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,.
-additional.bundles = org.eclipse.jdt.annotation

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/usageprojectjava8/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/usageprojectjava8/META-INF/MANIFEST.MF
@@ -5,5 +5,4 @@ Bundle-SymbolicName: usageprojectjava8
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: refprojectjava8;bundle-version="1.0.0",
- refproject,
- org.eclipse.pde.api.tools.annotations;bundle-version="1.0.0"
+ refproject

--- a/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/usageprojectjava8/build.properties
+++ b/apitools/org.eclipse.pde.api.tools.tests/test-builder/usageprojectsjava8/usageprojectjava8/build.properties
@@ -12,6 +12,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+additional.bundles = org.eclipse.pde.api.tools.annotations
 bin.includes = META-INF/,\
                .
-


### PR DESCRIPTION
Fixes: #2225