### PR TITLE
Fix NPE in MinimalState when project VM install is null

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/MinimalState.java
@@ -162,6 +162,11 @@ public class MinimalState {
 			return manifest;
 		}
 		IVMInstall projectVmInstall = JavaRuntime.getVMInstall(javaProject);
+		if (projectVmInstall == null) {
+			PDECore.log(Status.warning("Could not determine VM install for project " //$NON-NLS-1$
+					+ resource.getProject().getName() + ", skipping BREE injection")); //$NON-NLS-1$
+			return manifest;
+		}
 
 		IExecutionEnvironment executionEnvironment = Arrays
 				.stream(JavaRuntime.getExecutionEnvironmentsManager().getExecutionEnvironments())


### PR DESCRIPTION
   JavaRuntime.getVMInstall() can return null during project setup.
   The null was passed to ExecutionEnvironment.isStrictlyCompatible()
   which uses ConcurrentHashMap.containsKey(null), causing NPE.

   This crashed the Plug-in Manifest Builder, leaving workspace projects
   in inconsistent state and causing cascading test failures in
   ProjectSmartImportTest.

See https://github.com/eclipse-pde/eclipse.pde/issues/2238