### PR TITLE
Move from Full-qualified access to imports in Fix FeatureBasedLaunchTest

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/META-INF/MANIFEST.MF
@@ -69,6 +69,7 @@ Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  org.junit.runners.model,
  org.mockito,
  org.mockito.stubbing,
+ org.osgi.annotation.bundle;version="1.0.0",
  org.osgi.service.event;version="[1.3.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
@@ -65,12 +65,16 @@ import org.eclipse.pde.launching.EclipseApplicationLaunchConfiguration;
 import org.eclipse.pde.launching.IPDELauncherConstants;
 import org.eclipse.pde.ui.tests.util.ProjectUtils.CoreConsumer;
 import org.eclipse.pde.ui.tests.util.TargetPlatformUtil;
+import org.eclipse.platform.internal.LaunchUpdateIntroAction;
+import org.eclipse.ui.internal.ide.application.IDEApplication;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.osgi.annotation.bundle.Referenced;
 import org.osgi.framework.FrameworkUtil;
 
+@Referenced({ LaunchUpdateIntroAction.class, IDEApplication.class })
 public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 
 	@Rule
@@ -1450,10 +1454,6 @@ public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 			DependencyManager.Options... closureOptions) throws Exception {
 		// ensure app requirements are registered (done at class initialization)
 		new EclipseApplicationLaunchConfiguration();
-		@SuppressWarnings("unused") // prevent bundle removal
-		org.eclipse.platform.internal.LaunchUpdateIntroAction a;
-		@SuppressWarnings("unused") // prevent bundle removal
-		org.eclipse.ui.internal.ide.application.IDEApplication app;
 
 		TargetPlatformUtil.setRunningPlatformAsTarget();
 


### PR DESCRIPTION
This fixes the error if the MANIFEST.MF dependencies is clean-up.