### PR TITLE
Don't include transitive optional dependencies to PDE container

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -678,8 +678,7 @@ class RequiredPluginsClasspathContainer {
 	 */
 	private void addTransitiveDependenciesWithForbiddenAccess(Set<BundleDescription> added,
 			List<IClasspathEntry> entries) throws CoreException {
-		Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(added,
-				INCLUDE_OPTIONAL_DEPENDENCIES);
+		Set<BundleDescription> closure = DependencyManager.findRequirementsClosure(added);
 		String systemBundleBSN = TargetPlatformHelper.getPDEState().getSystemBundle();
 		Iterator<BundleDescription> transitiveDeps = closure.stream()
 				.filter(desc -> !desc.getSymbolicName().equals(systemBundleBSN))

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest2.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest2.java
@@ -1,0 +1,273 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Andrey Loskutov <loskutov@gmx.de> and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Andrey Loskutov <loskutov@gmx.de> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.core.tests.internal.classpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.internal.core.ClasspathComputer;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.ui.tests.runtime.TestUtils;
+import org.eclipse.pde.ui.tests.util.ProjectUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+/**
+ * Regression test for classpath resolution of plugin projects. Tests that only
+ * the expected (no transitive optional) bundles are on the classpath, and that
+ * errors are reported for missing packages from not accessible bundles, but not
+ * for missing packages.
+ *
+ * See https://github.com/eclipse-pde/eclipse.pde/issues/2244.
+ */
+public class ClasspathResolutionTest2 {
+
+	@ClassRule
+	public static final TestRule CLEAR_WORKSPACE = ProjectUtils.DELETE_ALL_WORKSPACE_PROJECTS_BEFORE_AND_AFTER;
+
+	@Rule
+	public final TestRule deleteCreatedTestProjectsAfter = ProjectUtils.DELETE_CREATED_WORKSPACE_PROJECTS_AFTER;
+
+	private static IProject projectA;
+
+	private static IClasspathEntry[] classpathEntriesA;
+
+	static final List<String> expectedAccessibleBundles = List.of("B", "G");
+	static final List<String> expectedApiPackages = apiPackagesFor(expectedAccessibleBundles);
+	static final List<String> expectedInternalPackages = internalPackagesFor(expectedAccessibleBundles);
+
+	static final List<String> notAccessibleBundles = List.of("C", "D", "E", "F", "H");
+	static final List<String> notAccessibleApiPackages = apiPackagesFor(notAccessibleBundles);
+	static final List<String> notAccessibleInternalPackages = internalPackagesFor(notAccessibleBundles);
+
+	static final List<String> expectedIndirectlyRequiredBundles = List.of("C", "D");
+
+	static final List<String> allOtherProjects = Stream
+			.concat(expectedAccessibleBundles.stream(), notAccessibleBundles.stream()).sorted().toList();
+
+	static final List<String> expectedProjectsOnClasspath = Stream
+			.concat(expectedAccessibleBundles.stream(), expectedIndirectlyRequiredBundles.stream()).sorted().toList();
+
+	// See OSGiAnnotationsClasspathContributor. These annotations are added to
+	// classpath if runtime doesn't include them after
+	// https://github.com/eclipse-pde/eclipse.pde/pull/1116
+	static final Collection<String> OSGI_ANNOTATIONS = List.of("org.osgi.annotation.versioning", //$NON-NLS-1$
+			"org.osgi.annotation.bundle", "org.osgi.service.component.annotations", //$NON-NLS-1$ //$NON-NLS-2$
+			"org.osgi.service.metatype.annotations"); //$NON-NLS-1$
+
+	private static boolean wasAutoBuildEnabled;
+
+	@BeforeClass
+	public static void setupBeforeClass() throws Exception {
+		wasAutoBuildEnabled = isAutoBuildEnabled();
+		enableAutobuild(false);
+
+		List<IProject> importedProjects = new ArrayList<>();
+
+		for (String name : allOtherProjects) {
+			IProject project = ProjectUtils.importTestProject("tests/projects/" + name);
+			importedProjects.add(project);
+		}
+
+		// Build all projects in reversed order to ensure that dependencies are
+		// built before dependents
+		for (IProject project : importedProjects.reversed()) {
+			project.open(new NullProgressMonitor());
+			waitForJobs();
+		}
+		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+		waitForJobs();
+
+		// Now import and build project A, which depends on all other projects.
+		projectA = ProjectUtils.importTestProject("tests/projects/A");
+		projectA.open(new NullProgressMonitor());
+		TestUtils.processUIEvents(100);
+
+		projectA.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+		waitForJobs();
+
+		IPluginModelBase modelA = PDECore.getDefault().getModelManager().findModel(projectA);
+		classpathEntriesA = ClasspathComputer.computeClasspathEntries(modelA, projectA);
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		ProjectUtils.deleteAllWorkspaceProjects();
+		enableAutobuild(wasAutoBuildEnabled);
+	}
+
+	private static void waitForJobs() throws Exception {
+		TestUtils.waitForJobs("testRequiredPluginsClasspathContainerContract()", 100, 10000);
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
+		TestUtils.processUIEvents(100);
+	}
+
+	/**
+	 * Sets autobuild to the specified boolean value
+	 */
+	private static void enableAutobuild(boolean enable) throws CoreException {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceDescription desc = workspace.getDescription();
+		desc.setAutoBuilding(enable);
+		workspace.setDescription(desc);
+		waitForAutoBuild();
+	}
+
+	private static boolean isAutoBuildEnabled() {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceDescription desc = workspace.getDescription();
+		return desc.isAutoBuilding();
+	}
+
+	private static void waitForAutoBuild() {
+		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_BUILD);
+		try {
+			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, new NullProgressMonitor());
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Check that the classpath of plugin A contains exactly the expected
+	 * bundles. Checks that "missing type" compilation errors are reported for
+	 * all references form not accessible bundles. Checks that no dependencies
+	 * to transitive optional bundles are added to the classpath. This bundle
+	 * classpath is computed by RequiredPluginsClasspathContainer.
+	 */
+	@Test
+	public void testRequiredPluginsClasspathContainerContract() throws Exception {
+		// Check every project except A - they should build without errors
+		List<IProject> otherProjects = allOtherProjects.stream().map(ClasspathResolutionTest2::getProject).toList();
+		for (IProject project : otherProjects) {
+			IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+			for (IMarker marker : markers) {
+				if (marker.getAttribute(IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR) {
+					fail("Unexpected error in project " + project.getName() + ": "
+							+ marker.getAttribute(IMarker.MESSAGE, ""));
+				}
+			}
+		}
+
+		// Check that project A has errors, and that all errors are related to
+		// missing packages from not accessible bundles, and that no error is
+		// related to missing packages from expected accessible bundles
+		IMarker[] markers = projectA.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+
+		List<String> errorMessages = Arrays.asList(markers).stream()
+				.filter(marker -> marker.getAttribute(IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR)
+				.map(marker -> marker.getAttribute(IMarker.MESSAGE, "")).toList();
+
+		for (String message : errorMessages) {
+			// Check that no error is related to missing packages from expected
+			// accessible bundles
+			boolean isRelatedToExpectedAccessibleBundle = false;
+			for (String bundle : expectedAccessibleBundles) {
+				String pack = bundle.toLowerCase();
+				if (message.contains(pack + " cannot be resolved to a type")
+						|| message.contains("project '" + bundle + "'")) {
+					isRelatedToExpectedAccessibleBundle = true;
+					break;
+				}
+			}
+			assertFalse("Unexpected error in project A: " + message, isRelatedToExpectedAccessibleBundle);
+
+			// and that all errors are related to missing packages from not
+			// accessible bundles
+			boolean isRelatedToNotAccessibleBundle = false;
+			for (String bundle : notAccessibleBundles) {
+				String pack = bundle.toLowerCase();
+				if (message.contains(pack + " cannot be resolved to a type")
+						|| message.contains("project '" + bundle + "'")) {
+					isRelatedToNotAccessibleBundle = true;
+					break;
+				}
+			}
+			assertTrue("Unexpected error in project A: " + message, isRelatedToNotAccessibleBundle);
+		}
+
+		// There must be at least one error, otherwise the test would not be
+		// meaningful
+		assertFalse("Expected errors in project A, but found none!", errorMessages.isEmpty());
+
+		// Check that all expected accessible bundles are on the classpath, and
+		// only those
+		List<String> projectNames = new ArrayList<>(
+				Arrays.asList(classpathEntriesA).stream().map(entry -> entry.getPath().lastSegment()).toList());
+
+		removeOsgiLibraries(projectNames);
+		assertThat(projectNames).containsExactlyInAnyOrderElementsOf(expectedProjectsOnClasspath);
+
+		// Same check using the API of PDECore and ClasspathComputer instead
+		List<String> classpathEntries = new ArrayList<>(getRequiredPluginContainerEntries(projectA));
+		removeOsgiLibraries(classpathEntries);
+		assertThat(classpathEntries).containsExactlyInAnyOrderElementsOf(expectedProjectsOnClasspath);
+	}
+
+	private static void removeOsgiLibraries(List<String> names) {
+		for (String annotationLibrary : OSGI_ANNOTATIONS) {
+			for (Iterator<String> iterator = names.iterator(); iterator.hasNext();) {
+				String name = iterator.next();
+				if (name.startsWith(annotationLibrary)) {
+					iterator.remove();
+				}
+			}
+		}
+	}
+
+	private static IProject getProject(String name) {
+		return ResourcesPlugin.getWorkspace().getRoot().getProject(name);
+	}
+
+	private static List<String> apiPackagesFor(List<String> expectedAccessibleBundles) {
+		return expectedAccessibleBundles.stream().flatMap(bundle -> List.of(bundle + ".api").stream()).toList();
+	}
+
+	private static List<String> internalPackagesFor(List<String> expectedAccessibleBundles) {
+		return expectedAccessibleBundles.stream().flatMap(bundle -> List.of(bundle + ".internal").stream()).toList();
+	}
+
+	private List<String> getRequiredPluginContainerEntries(IProject project) throws CoreException {
+		IPluginModelBase model = PDECore.getDefault().getModelManager().findModel(project);
+		IClasspathEntry[] computeClasspathEntries = ClasspathComputer.computeClasspathEntries(model, project);
+		return Arrays.stream(computeClasspathEntries).map(IClasspathEntry::getPath).map(IPath::lastSegment).toList();
+	}
+}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -15,6 +15,7 @@ package org.eclipse.pde.ui.tests;
 
 import org.eclipse.pde.core.tests.internal.AllPDECoreTests;
 import org.eclipse.pde.core.tests.internal.classpath.ClasspathResolutionTest;
+import org.eclipse.pde.core.tests.internal.classpath.ClasspathResolutionTest2;
 import org.eclipse.pde.core.tests.internal.core.builders.BundleErrorReporterTest;
 import org.eclipse.pde.core.tests.internal.util.PDESchemaHelperTest;
 import org.eclipse.pde.ui.tests.build.properties.AllValidatorTests;
@@ -63,6 +64,7 @@ import org.junit.platform.suite.api.Suite;
 	ClasspathContributorTest.class, //
 	DynamicPluginProjectReferencesTest.class, //
 	ClasspathResolutionTest.class, //
+	ClasspathResolutionTest2.class, //
 	BundleErrorReporterTest.class, //
 	AllPDECoreTests.class, //
 	ProjectSmartImportTest.class, //

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>A</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,6 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=error

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: A
+Bundle-SymbolicName: A
+Bundle-Version: 1.0.0.qualifier
+Export-Package: a.api
+Require-Bundle: B;bundle-version="1.0.0",
+ G;bundle-version="1.0.0"
+Automatic-Module-Name: A
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/src/a/api/AClass.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/src/a/api/AClass.java
@@ -1,0 +1,39 @@
+package a.api;
+public class AClass {
+	// bundle B b.api package imported by A
+	public Object objectFromB_allowed = new b.api.MyObject();
+	public Object objectFromB_restricted = new  b.internal.MyObject();
+
+	// bundle G reexported via B, g.api package is imported by A
+	public Object objectFromG_allowed = new g.api.MyObject();
+	public Object objectFromG_restricted = new g.internal.MyObject();
+
+	/*
+	 * All references below never compilable before https://github.com/eclipse-pde/eclipse.pde/pull/2218
+	 *
+	 * bundles C, D, E, F, H not required by A, neither package is imported by A
+	 * bundles C, D, E, F, H only referenced in different ways from bundle B or G and not reexported
+	 */
+
+	// Bundle C directly required by B, but not reexported by B
+	public Object objectFromC_not_accessible1 = new c.api.MyObject();
+	public Object objectFromC_not_accessible2 = new c.internal.MyObject();
+
+	// Bundle D package imported by B, but not reexported by B
+	public Object objectFromD_not_accessible1 = new d.api.MyObject();
+	public Object objectFromD_not_accessible2 = new d.internal.MyObject();
+
+	/*
+	 * Regression introduced: all (transitive optional) dependencies from B or G are now accessible from A,
+	 * even if not reexported by B or G and not imported by A.
+	 */
+	// Optionally required or imported by B, but not reexported by B
+	public Object objectFromE_not_accessible1 = new e.api.MyObject();
+	public Object objectFromE_not_accessible2 = new e.internal.MyObject();
+	public Object objectFromF_not_accessible1 = new f.api.MyObject();
+	public Object objectFromF_not_accessible2 = new f.internal.MyObject();
+
+	// Bundle H package optionally imported by G, not reexported by anyone
+	public Object objectFromH_not_accessible1 = new h.api.MyObject();
+	public Object objectFromH_not_accessible2 = new h.internal.MyObject();
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>B</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: B
+Bundle-SymbolicName: B
+Bundle-Version: 1.0.0.qualifier
+Export-Package: b.api;version="1.0.0",
+ b.internal;x-friends:="A"
+Import-Package: d.api;version="1.0.0",
+ f.api;version="1.0.0";resolution:=optional
+Require-Bundle: C;bundle-version="1.0.0",
+ E;bundle-version="1.0.0";resolution:=optional,
+ G;bundle-version="1.0.0";visibility:=reexport
+Automatic-Module-Name: B
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/api/MyObject.java
@@ -1,0 +1,4 @@
+package b.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/internal/MyObject.java
@@ -1,0 +1,4 @@
+package b.internal;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>C</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: C
+Bundle-SymbolicName: C
+Bundle-Version: 1.0.0.qualifier
+Export-Package: c.api;version="1.0.0"
+Automatic-Module-Name: C
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/api/MyObject.java
@@ -1,0 +1,4 @@
+package c.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/internal/MyObject.java
@@ -1,0 +1,4 @@
+package c.internal;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>D</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: D
+Bundle-SymbolicName: D
+Bundle-Version: 1.0.0.qualifier
+Export-Package: d.api;version="1.0.0"
+Automatic-Module-Name: D
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/api/MyObject.java
@@ -1,0 +1,4 @@
+package d.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/internal/MyObject.java
@@ -1,0 +1,4 @@
+package d.internal;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>E</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: E
+Bundle-SymbolicName: E
+Bundle-Version: 1.0.0.qualifier
+Export-Package: e.api;version="1.0.0"
+Automatic-Module-Name: E
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/src/e/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/src/e/api/MyObject.java
@@ -1,0 +1,4 @@
+package e.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/src/e/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/src/e/internal/MyObject.java
@@ -1,0 +1,4 @@
+package e.internal;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>F</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: F
+Bundle-SymbolicName: F
+Bundle-Version: 1.0.0.qualifier
+Export-Package: f.api;version="1.0.0"
+Automatic-Module-Name: F
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/src/f/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/src/f/api/MyObject.java
@@ -1,0 +1,4 @@
+package f.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/src/f/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/src/f/internal/MyObject.java
@@ -1,0 +1,4 @@
+package f.internal;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>G</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: G
+Bundle-SymbolicName: G
+Bundle-Version: 1.0.0.qualifier
+Export-Package: g.api;version="1.0.0",
+ g.internal;x-friends:="A"
+Import-Package: h.api;version="1.0.0";resolution:=optional
+Automatic-Module-Name: G
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/api/MyObject.java
@@ -1,0 +1,4 @@
+package g.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/internal/MyObject.java
@@ -1,0 +1,4 @@
+package g.internal;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>H</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/.settings/org.eclipse.core.resources.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/.settings/org.eclipse.jdt.core.prefs
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: H
+Bundle-SymbolicName: H
+Bundle-Version: 1.0.0.qualifier
+Export-Package: h.api;version="1.0.0"
+Automatic-Module-Name: H
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/src/h/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/src/h/api/MyObject.java
@@ -1,0 +1,4 @@
+package h.api;
+
+public class MyObject {
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/src/h/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/src/h/internal/MyObject.java
@@ -1,0 +1,4 @@
+package h.internal;
+
+public class MyObject {
+}


### PR DESCRIPTION
Since ~20 years PDE never allowed not imported/required bundles be on the classpath of a bundle.

From PDE point of view, bundle code should only see references to the code from other bundles on project classpath if:

- the bundle requires another bundle
- or the bundle imports a package from other bundle

Transitive dependencies are only added to the classpath if the required bundle reexports one of its dependencies.

This has a simple rationale:

1) Developers can't compile code in the IDE which would be not working at runtime, saving time for development by showing the errors before starting application.
2) The IDE can quickly recompile one line code change in a workspace with hundreds of bundles, because the classpath only has the dependencies mentioned above.

With 89b00be1a4bf44132b61e46227c5803c5cc6ad6e above expectations are broken. All transitively used projects are now on the classpath.

With `org.eclipse.jdt.core.compiler.problem.forbiddenReferenc` set to `ignore` or `warning` code that can compile (but uses illegal references) will not work at runtime.

With this option set to `error` the code will not compile, but compilation will suffer from all transitive dependencies added to the bundle classpath, incremental build is significantly slower now.

With 89b00be1a4bf44132b61e46227c5803c5cc6ad6e also optional transitive dependencies are added transitively, increasing the problem impact.

Optional dependencies can be re-exported, but they are unlikely can be part of the bundle own API.

As long as proper solution for the problem introduced by 89b00be1a4bf44132b61e46227c5803c5cc6ad6e is identified, don't add optional transitive dependencies to the classpath.

This partly fixes the problem by slightly reducing set of projects added to the classpath.

Also added regression test for RequiredPluginsClasspathContainer

Shows the regression caused by
https://github.com/eclipse-pde/eclipse.pde/pull/2218 / 89b00be1a4bf44132b61e46227c5803c5cc6ad6e

The test will fail on master after
89b00be1a4bf44132b61e46227c5803c5cc6ad6e and pass before this commit.

See https://github.com/eclipse-pde/eclipse.pde/issues/2244