### PR TITLE
Add system property to switch adding transitive dependencies on/off

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -104,6 +104,9 @@ class RequiredPluginsClasspathContainer {
 	private IClasspathEntry[] fEntries;
 	private boolean addImportedPackages;
 
+	private static final boolean ADD_TRANSITIVE_DEPENDENCIES_WITH_FORBIDDEN_ACCESS = Boolean
+			.parseBoolean(System.getProperty("pde.addTransitiveDependenciesWithForbiddenAccess", "true")); //$NON-NLS-1$ //$NON-NLS-2$
+
 	/**
 	 * Cached list of {@link IClasspathContributor} from plug-in extensions
 	 *
@@ -274,7 +277,9 @@ class RequiredPluginsClasspathContainer {
 
 			addJunit5RuntimeDependencies(added, entries);
 			addImplicitDependencies(desc, added, entries);
-			addTransitiveDependenciesWithForbiddenAccess(added, entries);
+			if (ADD_TRANSITIVE_DEPENDENCIES_WITH_FORBIDDEN_ACCESS) {
+				addTransitiveDependenciesWithForbiddenAccess(added, entries);
+			}
 
 			// Add any additional library entries contributed via classpath
 			// contributor


### PR DESCRIPTION
This change allows users to control whether the transitive dependencies should be recursively added to the classpath by providing boolean system property `pde.addTransitiveDependenciesWithForbiddenAccess`.

This allows to mitigate possible functional or performance regressions of the 89b00be1a4bf44132b61e46227c5803c5cc6ad6e /
https://github.com/eclipse-pde/eclipse.pde/pull/2218 which changed how PDE resolves classpath for bundle projects.

By default the property is considered to be "true".

See https://github.com/eclipse-pde/eclipse.pde/issues/2244