### PR TITLE
Make ClasspathResolutionTest2 test projects use realistic type hierarchies

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest2.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/classpath/ClasspathResolutionTest2.java
@@ -59,13 +59,33 @@ import org.junit.rules.TestRule;
  * Bundle B:  Export-Package: b.api
  *            Import-Package: d.api, f.api(optional)
  *            Require-Bundle: C, E(optional), G(reexport)
+ *            b.api.MyObject extends c.api.MyObject implements d.api.Processor
+ *            b.internal.MyObject uses e.api + f.api (optional, internal only)
  * Bundle C:  Export-Package: c.api     (leaf)
+ *            c.api.Configurable interface, c.api.MyObject implements it
  * Bundle D:  Export-Package: d.api     (leaf)
- * Bundle E:  Export-Package: e.api     (leaf)
- * Bundle F:  Export-Package: f.api     (leaf)
+ *            d.api.Processor interface, d.api.MyObject with getData()
+ * Bundle E:  Export-Package: e.api     (leaf, e.api.MyObject with activate())
+ * Bundle F:  Export-Package: f.api     (leaf, f.api.MyObject with isAvailable())
  * Bundle G:  Export-Package: g.api; Import-Package: h.api(optional)
- * Bundle H:  Export-Package: h.api     (leaf)
+ *            g.api.MyObject.describe() uses h.api internally (optional)
+ * Bundle H:  Export-Package: h.api     (leaf, h.api.MyObject with getIdentifier())
  * </pre>
+ *
+ * <b>Type hierarchy chain exercised by A:</b>
+ * <pre>
+ * c.api.Configurable (interface)
+ *   ↑ implements
+ * c.api.MyObject (class with getValue(), getConfig())
+ *   ↑ extends
+ * b.api.MyObject (class) ← also implements d.api.Processor
+ * </pre>
+ * When A uses b.api.MyObject and calls inherited methods, the compiler
+ * needs c.api.MyObject, c.api.Configurable, d.api.Processor, and
+ * d.api.MyObject on the classpath — modelling the real-world scenario from
+ * <a href="https://github.com/eclipse-pde/eclipse.pde/issues/2195">issue
+ * #2195</a> where IWidgetValueProperty's type hierarchy required the
+ * databinding bundle on the classpath.
  *
  * Each bundle also has an internal package (e.g. {@code b.internal}) that is
  * <b>not</b> listed in Export-Package.
@@ -452,9 +472,12 @@ public class ClasspathResolutionTest2 {
 	 * because transitive dependencies are on the classpath (PR #2218). Before
 	 * PR #2218, transitive types caused "The type X cannot be resolved. It is
 	 * indirectly referenced from required type Y" errors.</li>
-	 * <li><b>No markers on accessible types:</b> b.api.MyObject (line 29) and
-	 * g.api.MyObject (line 34) produce zero markers because they match
-	 * {@code K_ACCESSIBLE} access rules for exported packages (§3.6.5).</li>
+	 * <li><b>No markers on accessible types:</b> b.api.MyObject (line 28) and
+	 * g.api.MyObject (line 64) produce zero markers because they match
+	 * {@code K_ACCESSIBLE} access rules for exported packages (§3.6.5).
+	 * Additionally, inherited method calls (e.g. {@code service.configure()},
+	 * {@code service.process()}) accessed through b.api.MyObject produce no
+	 * markers even though they involve transitive types (c.api, d.api).</li>
 	 * <li><b>Forbidden reference markers on all non-accessible types:</b> Every
 	 * type from non-exported packages of direct deps (b.internal, g.internal)
 	 * and from transitive-only bundles (C, D, E, F, H) produces exactly 2
@@ -481,10 +504,12 @@ public class ClasspathResolutionTest2 {
 		// ("The type 'MyObject' is not API") and one for the constructor
 		// call ("The constructor 'MyObject()' is not API").
 		//
-		// Lines 29 (b.api.MyObject) and 34 (g.api.MyObject) are
-		// K_ACCESSIBLE and must have NO markers. The total count assertion
-		// below implicitly validates this — any extra markers would
-		// increase the count.
+		// Lines 28 (b.api.MyObject) and 64 (g.api.MyObject) are
+		// K_ACCESSIBLE and must have NO markers. Lines 32-56 contain
+		// method calls through b.api.MyObject (inherited methods from
+		// c.api/d.api) and g.api.MyObject — also no markers. The total
+		// count assertion below implicitly validates this — any extra
+		// markers would increase the count.
 		record ForbiddenRef(int line, String qualifiedType, String project) {
 		}
 		List<ForbiddenRef> expected = List.of(
@@ -493,7 +518,7 @@ public class ClasspathResolutionTest2 {
 				// B/G entries. Non-exported packages are not returned by
 				// StateHelper.getVisiblePackages() — they have no explicit
 				// rule, so the catch-all EXCLUDE_ALL fires (§3.6.5).
-				new ForbiddenRef(31, "b.internal.MyObject", "B"), new ForbiddenRef(36, "g.internal.MyObject", "G"),
+				new ForbiddenRef(62, "b.internal.MyObject", "B"), new ForbiddenRef(70, "g.internal.MyObject", "G"),
 				// Transitive forbidden: ALL packages forbidden via the
 				// single **/* K_NON_ACCESSIBLE rule added by
 				// addTransitiveDependenciesWithForbiddenAccess().
@@ -502,26 +527,27 @@ public class ClasspathResolutionTest2 {
 				//
 				// C: Required by B (Require-Bundle: C,
 				// visibility:=private §3.13.1)
-				new ForbiddenRef(45, "c.api.MyObject", "C"), new ForbiddenRef(46, "c.internal.MyObject", "C"),
+				new ForbiddenRef(77, "c.api.MyObject", "C"), new ForbiddenRef(78, "c.internal.MyObject", "C"),
 				// D: Package imported by B (Import-Package: d.api §3.6.4
 				// — never re-exports)
-				new ForbiddenRef(49, "d.api.MyObject", "D"), new ForbiddenRef(50, "d.internal.MyObject", "D"),
+				new ForbiddenRef(81, "d.api.MyObject", "D"), new ForbiddenRef(82, "d.internal.MyObject", "D"),
 				// E: Optionally required by B (Require-Bundle: E;optional
 				// §3.7.5 + §3.13.1)
-				new ForbiddenRef(53, "e.api.MyObject", "E"), new ForbiddenRef(54, "e.internal.MyObject", "E"),
+				new ForbiddenRef(85, "e.api.MyObject", "E"), new ForbiddenRef(86, "e.internal.MyObject", "E"),
 				// F: Optionally imported by B (Import-Package:
 				// f.api;optional §3.7.5 + §3.6.4)
-				new ForbiddenRef(57, "f.api.MyObject", "F"), new ForbiddenRef(58, "f.internal.MyObject", "F"),
+				new ForbiddenRef(89, "f.api.MyObject", "F"), new ForbiddenRef(90, "f.internal.MyObject", "F"),
 				// H: Optionally imported by G (Import-Package:
 				// h.api;optional §3.7.5)
-				new ForbiddenRef(61, "h.api.MyObject", "H"), new ForbiddenRef(62, "h.internal.MyObject", "H"));
+				new ForbiddenRef(93, "h.api.MyObject", "H"), new ForbiddenRef(94, "h.internal.MyObject", "H"));
 
 		IMarker[] allMarkers = project.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true,
 				IResource.DEPTH_INFINITE);
 
 		// Each forbidden reference produces exactly 2 markers (type +
 		// constructor). The total count also implicitly asserts that NO
-		// markers exist for K_ACCESSIBLE references on lines 29 and 34.
+		// markers exist for K_ACCESSIBLE references (line 28 b.api,
+		// line 64 g.api) or inherited method calls (lines 32-56).
 		assertThat(allMarkers).as(
 				"Project %s must have exactly %d JDT markers: " + "%d forbidden references × 2 (type + "
 						+ "constructor). Zero 'cannot be resolved' " + "errors, zero markers on accessible types.",
@@ -627,8 +653,9 @@ public class ClasspathResolutionTest2 {
 	 * <p>
 	 * Expected markers on Ad/src/a/api/AClass.java:
 	 * <ul>
-	 * <li>Lines 30, 33, 36: no markers (K_ACCESSIBLE API)</li>
-	 * <li>Line 40: exactly 2 markers — discouraged type + constructor for
+	 * <li>Lines 26-36: no markers (K_ACCESSIBLE API and inherited method
+	 * calls through b.api.MyObject, g.api.MyObject, x.api.MyObject)</li>
+	 * <li>Line 44: exactly 2 markers — discouraged type + constructor for
 	 * x.internal.MyObject</li>
 	 * </ul>
 	 */
@@ -638,14 +665,14 @@ public class ClasspathResolutionTest2 {
 				IResource.DEPTH_INFINITE);
 
 		// Ad only has 1 discouraged reference (x.internal.MyObject on line
-		// 38) producing 2 markers (type + constructor). Zero markers for
-		// exported API (b.api, g.api, x.api).
+		// 44) producing 2 markers (type + constructor). Zero markers for
+		// exported API (b.api, g.api, x.api) and inherited method calls.
 		assertThat(allMarkers).as("Project Ad must have exactly 2 markers: " + "discouraged type + constructor for "
 				+ "x.internal.MyObject. Zero errors, zero " + "markers on accessible types.").hasSize(2);
 
 		for (IMarker m : allMarkers) {
 			assertThat(m.getAttribute(IMarker.LINE_NUMBER, -1))
-			.as("Discouraged marker must be on line 40 " + "(x.internal.MyObject)").isEqualTo(40);
+			.as("Discouraged marker must be on line 44 " + "(x.internal.MyObject)").isEqualTo(44);
 
 			assertThat(m.getAttribute(IMarker.SEVERITY, -1))
 					.as("Discouraged access must be WARNING " + "(discouragedReference=warning in "
@@ -680,9 +707,10 @@ public class ClasspathResolutionTest2 {
 
 	/**
 	 * All dependency bundles (B-H) must build without any compilation problems
-	 * — no errors AND no warnings. Each bundle's own dependencies are properly
-	 * declared in its manifest, and their source code does not reference any
-	 * forbidden types.
+	 * — no errors AND no warnings. Each bundle actively uses its declared
+	 * dependencies (e.g. B extends c.api.MyObject, implements d.api.Processor,
+	 * uses e.api/f.api internally; G uses h.api internally) but only through
+	 * properly declared imports, so no access rule violations occur.
 	 */
 	@Test
 	public void testDependencyBundlesBuildClean() throws Exception {

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/A/src/a/api/AClass.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/A/src/a/api/AClass.java
@@ -1,63 +1,95 @@
 package a.api;
 
 /**
- * Test class that references types from multiple bundles to exercise OSGi
- * visibility and JDT access rules.
+ * Test consumer that exercises OSGi visibility and JDT access rules.
  * <p>
- * Bundle A declares: {@code Import-Package: b.api, g.api}
+ * Bundle A imports: {@code b.api}, {@code g.api}. The {@code b.api.MyObject}
+ * type has a rich type hierarchy ({@code extends c.api.MyObject implements
+ * d.api.Processor}) that requires transitive dependencies on the compilation
+ * classpath for type hierarchy resolution.
  * <p>
- * With the correct PDE behavior (PR #2218), all bundles in the transitive
- * dependency closure are present on the compilation classpath:
- * <ul>
- * <li><b>Directly imported bundles</b> (B, G): exported packages are
- * {@code K_ACCESSIBLE}, non-exported packages caught by EXCLUDE_ALL_RULE
- * ({@code K_NON_ACCESSIBLE})</li>
- * <li><b>Transitive dependencies</b> (C, D, E, F, H): all-forbidden access
- * rules (single {@code **&#47;* K_NON_ACCESSIBLE} rule) — compiler can
- * resolve types but direct usage produces forbidden reference warnings
- * (configured via {@code forbiddenReference=warning})</li>
- * </ul>
+ * <b>Accessible API usage:</b> Methods inherited from the transitive type
+ * hierarchy are called through {@code b.api.MyObject} ({@code K_ACCESSIBLE}),
+ * exercising the compiler's type resolution without producing forbidden
+ * markers. This models the real-world scenario from issue #2195 where
+ * {@code IWidgetValueProperty extends IValueProperty} required the databinding
+ * bundle on the classpath.
  * <p>
- * At <b>OSGi runtime</b>, only directly imported packages (b.api, g.api)
- * would be accessible to A's classloader (OSGi Core R8 §3.9.4). The JDT
- * access rules enforce this visibility at compile time.
+ * <b>Forbidden references:</b> Direct references to types from non-imported
+ * packages produce forbidden reference markers, validating that PDE's access
+ * rules correctly enforce OSGi module layer visibility at compile time.
  */
 public class AClass {
 	// ---- Directly imported bundles (K_ACCESSIBLE for exported packages) ----
 
-	// B exports b.api, A imports b.api → K_ACCESSIBLE → no marker
-	public Object objectFromB_allowed = new b.api.MyObject();
-	// B's b.internal is NOT exported → caught by EXCLUDE_ALL → forbidden warning
+	// b.api.MyObject extends c.api.MyObject implements d.api.Processor.
+	// The compiler needs transitive types (c.api.*, d.api.*) for type
+	// hierarchy resolution — these are present as transitive forbidden deps.
+	public b.api.MyObject service = new b.api.MyObject();
+
+	// Calls inherited methods from c.api.Configurable via c.api.MyObject.
+	// No markers: accessed through b.api.MyObject (K_ACCESSIBLE).
+	public boolean configureAndVerify() {
+		service.configure("production");
+		return service.isConfigured();
+	}
+
+	// Inherited from c.api.MyObject — compiler resolves c.api.MyObject
+	// from the transitive forbidden classpath entry.
+	public Object retrieveConfig() {
+		return service.getConfig();
+	}
+
+	// From d.api.Processor interface (implemented by b.api.MyObject).
+	// Compiler resolves d.api.Processor from transitive forbidden entry.
+	public Object processItem(String input) {
+		return service.process(input);
+	}
+
+	// b.api method using d.api.MyObject in its signature — compiler
+	// resolves d.api.MyObject from the transitive forbidden classpath entry.
+	public Object processData() {
+		return service.processData(null);
+	}
+
+	// b.api method returning g.api.MyObject (G is reexported by B).
+	// g.api is directly imported by A, so no marker.
+	public g.api.MyObject createViaService() {
+		return service.createService();
+	}
+
+	// B's b.internal is NOT exported → caught by EXCLUDE_ALL → forbidden
 	public Object objectFromB_forbidden = new b.internal.MyObject();
 
 	// G exports g.api, A imports g.api → K_ACCESSIBLE → no marker
-	public Object objectFromG_allowed = new g.api.MyObject();
-	// G's g.internal is NOT exported → caught by EXCLUDE_ALL → forbidden warning
+	public g.api.MyObject gService = new g.api.MyObject();
+	// g.api.MyObject.describe() internally uses h.api (optional dep of G)
+	public String description = gService.describe();
+
+	// G's g.internal is NOT exported → caught by EXCLUDE_ALL → forbidden
 	public Object objectFromG_forbidden = new g.internal.MyObject();
 
 	// ---- Transitive dependencies (all-forbidden access rules) ----
-	// These types CAN be resolved by the compiler (on classpath for type
-	// hierarchy validation), but produce forbidden reference warnings because
-	// their entries have only **/* K_NON_ACCESSIBLE access rules.
-	// At OSGi runtime, A's classloader cannot load any of these types (§3.9.4).
+	// Direct references to forbidden types produce forbidden reference markers.
+	// At OSGi runtime, A's classloader cannot load these types (§3.9.4).
 
-	// C: Required by B (Require-Bundle: C, default visibility:=private §3.13.1)
+	// C: Required by B (Require-Bundle: C, visibility:=private §3.13.1)
 	public Object objectFromC_forbidden1 = new c.api.MyObject();
 	public Object objectFromC_forbidden2 = new c.internal.MyObject();
 
-	// D: Package imported by B (Import-Package: d.api) — never re-exports §3.6.4
+	// D: Imported by B (Import-Package: d.api) — never re-exports §3.6.4
 	public Object objectFromD_forbidden1 = new d.api.MyObject();
 	public Object objectFromD_forbidden2 = new d.internal.MyObject();
 
-	// E: Optionally required by B (Require-Bundle: E;resolution:=optional §3.7.5)
+	// E: Optionally required by B (Require-Bundle: E;optional §3.7.5)
 	public Object objectFromE_forbidden1 = new e.api.MyObject();
 	public Object objectFromE_forbidden2 = new e.internal.MyObject();
 
-	// F: Optionally imported by B (Import-Package: f.api;resolution:=optional)
+	// F: Optionally imported by B (Import-Package: f.api;optional)
 	public Object objectFromF_forbidden1 = new f.api.MyObject();
 	public Object objectFromF_forbidden2 = new f.internal.MyObject();
 
-	// H: Optionally imported by G (Import-Package: h.api;resolution:=optional)
+	// H: Optionally imported by G (Import-Package: h.api;optional)
 	public Object objectFromH_forbidden1 = new h.api.MyObject();
 	public Object objectFromH_forbidden2 = new h.internal.MyObject();
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/Ad/src/a/api/AClass.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/Ad/src/a/api/AClass.java
@@ -1,41 +1,45 @@
 package a.api;
 
 /**
- * Test class that references only exported API from direct dependencies,
- * plus both public and x-internal packages from bundle X.
+ * Test consumer that references only directly imported API from B, G, and X,
+ * exercising the rich type hierarchy and x-internal discouraged access.
  * <p>
  * Bundle Ad declares:
  * {@code Import-Package: b.api, g.api, x.api, x.internal}
  * <p>
  * Expected markers:
  * <ul>
- * <li>Lines 26, 29: b.api.MyObject, g.api.MyObject → {@code K_ACCESSIBLE}
- * → <b>no markers</b></li>
- * <li>Line 32: x.api.MyObject → {@code K_ACCESSIBLE} (normal export)
- * → <b>no marker</b></li>
- * <li>Line 35: x.internal.MyObject → {@code K_DISCOURAGED}
- * ({@code x-internal:=true} on Export-Package) → <b>discouraged access
- * warning</b></li>
+ * <li>b.api, g.api, x.api: {@code K_ACCESSIBLE} → <b>no markers</b></li>
+ * <li>x.internal: {@code K_DISCOURAGED} ({@code x-internal:=true})
+ * → <b>discouraged access warning</b></li>
  * </ul>
  * <p>
- * No transitive dependency types are referenced — Ad only uses directly
- * imported packages. This validates that exported API from direct
+ * No transitive dependency types are directly referenced — Ad only uses
+ * directly imported packages. This validates that exported API from direct
  * dependencies produces zero markers, and that x-internal packages produce
  * discouraged (not forbidden) markers.
  */
 public class AClass {
-	// ---- Directly imported bundles: exported API only ----
+	// ---- Directly imported bundles: exported API usage ----
 
-	// B exports b.api, Ad imports b.api → K_ACCESSIBLE → no marker
-	public Object objectFromB_allowed = new b.api.MyObject();
+	// B exports b.api → K_ACCESSIBLE → no marker
+	// b.api.MyObject extends c.api.MyObject implements d.api.Processor
+	public b.api.MyObject service = new b.api.MyObject();
 
-	// G exports g.api, Ad imports g.api → K_ACCESSIBLE → no marker
-	public Object objectFromG_allowed = new g.api.MyObject();
+	// Exercise inherited methods from transitive type hierarchy — no markers
+	public boolean setup() {
+		service.configure("settings");
+		return service.isConfigured();
+	}
 
-	// X exports x.api (normal), Ad imports x.api → K_ACCESSIBLE → no marker
-	public Object objectFromX_allowed = new x.api.MyObject();
+	// G exports g.api → K_ACCESSIBLE → no marker
+	public g.api.MyObject gService = new g.api.MyObject();
+	public String desc = gService.describe();
 
-	// X exports x.internal with x-internal:=true, Ad imports x.internal
-	// → K_DISCOURAGED → discouraged access warning
+	// X exports x.api → K_ACCESSIBLE → no marker
+	public x.api.MyObject xService = new x.api.MyObject();
+	public String xName = xService.getName();
+
+	// X exports x.internal with x-internal:=true → K_DISCOURAGED → warning
 	public Object objectFromX_discouraged = new x.internal.MyObject();
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/Ae/src/a/api/AClass.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/Ae/src/a/api/AClass.java
@@ -1,63 +1,95 @@
 package a.api;
 
 /**
- * Test class that references types from multiple bundles to exercise OSGi
- * visibility and JDT access rules.
+ * Test consumer that exercises OSGi visibility and JDT access rules.
  * <p>
- * Bundle A declares: {@code Import-Package: b.api, g.api}
+ * Bundle A imports: {@code b.api}, {@code g.api}. The {@code b.api.MyObject}
+ * type has a rich type hierarchy ({@code extends c.api.MyObject implements
+ * d.api.Processor}) that requires transitive dependencies on the compilation
+ * classpath for type hierarchy resolution.
  * <p>
- * With the correct PDE behavior (PR #2218), all bundles in the transitive
- * dependency closure are present on the compilation classpath:
- * <ul>
- * <li><b>Directly imported bundles</b> (B, G): exported packages are
- * {@code K_ACCESSIBLE}, non-exported packages caught by EXCLUDE_ALL_RULE
- * ({@code K_NON_ACCESSIBLE})</li>
- * <li><b>Transitive dependencies</b> (C, D, E, F, H): all-forbidden access
- * rules (single {@code **&#47;* K_NON_ACCESSIBLE} rule) — compiler can
- * resolve types but direct usage produces forbidden reference warnings
- * (configured via {@code forbiddenReference=warning})</li>
- * </ul>
+ * <b>Accessible API usage:</b> Methods inherited from the transitive type
+ * hierarchy are called through {@code b.api.MyObject} ({@code K_ACCESSIBLE}),
+ * exercising the compiler's type resolution without producing forbidden
+ * markers. This models the real-world scenario from issue #2195 where
+ * {@code IWidgetValueProperty extends IValueProperty} required the databinding
+ * bundle on the classpath.
  * <p>
- * At <b>OSGi runtime</b>, only directly imported packages (b.api, g.api)
- * would be accessible to A's classloader (OSGi Core R8 §3.9.4). The JDT
- * access rules enforce this visibility at compile time.
+ * <b>Forbidden references:</b> Direct references to types from non-imported
+ * packages produce forbidden reference markers, validating that PDE's access
+ * rules correctly enforce OSGi module layer visibility at compile time.
  */
 public class AClass {
 	// ---- Directly imported bundles (K_ACCESSIBLE for exported packages) ----
 
-	// B exports b.api, A imports b.api → K_ACCESSIBLE → no marker
-	public Object objectFromB_allowed = new b.api.MyObject();
-	// B's b.internal is NOT exported → caught by EXCLUDE_ALL → forbidden warning
+	// b.api.MyObject extends c.api.MyObject implements d.api.Processor.
+	// The compiler needs transitive types (c.api.*, d.api.*) for type
+	// hierarchy resolution — these are present as transitive forbidden deps.
+	public b.api.MyObject service = new b.api.MyObject();
+
+	// Calls inherited methods from c.api.Configurable via c.api.MyObject.
+	// No markers: accessed through b.api.MyObject (K_ACCESSIBLE).
+	public boolean configureAndVerify() {
+		service.configure("production");
+		return service.isConfigured();
+	}
+
+	// Inherited from c.api.MyObject — compiler resolves c.api.MyObject
+	// from the transitive forbidden classpath entry.
+	public Object retrieveConfig() {
+		return service.getConfig();
+	}
+
+	// From d.api.Processor interface (implemented by b.api.MyObject).
+	// Compiler resolves d.api.Processor from transitive forbidden entry.
+	public Object processItem(String input) {
+		return service.process(input);
+	}
+
+	// b.api method using d.api.MyObject in its signature — compiler
+	// resolves d.api.MyObject from the transitive forbidden classpath entry.
+	public Object processData() {
+		return service.processData(null);
+	}
+
+	// b.api method returning g.api.MyObject (G is reexported by B).
+	// g.api is directly imported by A, so no marker.
+	public g.api.MyObject createViaService() {
+		return service.createService();
+	}
+
+	// B's b.internal is NOT exported → caught by EXCLUDE_ALL → forbidden
 	public Object objectFromB_forbidden = new b.internal.MyObject();
 
 	// G exports g.api, A imports g.api → K_ACCESSIBLE → no marker
-	public Object objectFromG_allowed = new g.api.MyObject();
-	// G's g.internal is NOT exported → caught by EXCLUDE_ALL → forbidden warning
+	public g.api.MyObject gService = new g.api.MyObject();
+	// g.api.MyObject.describe() internally uses h.api (optional dep of G)
+	public String description = gService.describe();
+
+	// G's g.internal is NOT exported → caught by EXCLUDE_ALL → forbidden
 	public Object objectFromG_forbidden = new g.internal.MyObject();
 
 	// ---- Transitive dependencies (all-forbidden access rules) ----
-	// These types CAN be resolved by the compiler (on classpath for type
-	// hierarchy validation), but produce forbidden reference warnings because
-	// their entries have only **/* K_NON_ACCESSIBLE access rules.
-	// At OSGi runtime, A's classloader cannot load any of these types (§3.9.4).
+	// Direct references to forbidden types produce forbidden reference markers.
+	// At OSGi runtime, A's classloader cannot load these types (§3.9.4).
 
-	// C: Required by B (Require-Bundle: C, default visibility:=private §3.13.1)
+	// C: Required by B (Require-Bundle: C, visibility:=private §3.13.1)
 	public Object objectFromC_forbidden1 = new c.api.MyObject();
 	public Object objectFromC_forbidden2 = new c.internal.MyObject();
 
-	// D: Package imported by B (Import-Package: d.api) — never re-exports §3.6.4
+	// D: Imported by B (Import-Package: d.api) — never re-exports §3.6.4
 	public Object objectFromD_forbidden1 = new d.api.MyObject();
 	public Object objectFromD_forbidden2 = new d.internal.MyObject();
 
-	// E: Optionally required by B (Require-Bundle: E;resolution:=optional §3.7.5)
+	// E: Optionally required by B (Require-Bundle: E;optional §3.7.5)
 	public Object objectFromE_forbidden1 = new e.api.MyObject();
 	public Object objectFromE_forbidden2 = new e.internal.MyObject();
 
-	// F: Optionally imported by B (Import-Package: f.api;resolution:=optional)
+	// F: Optionally imported by B (Import-Package: f.api;optional)
 	public Object objectFromF_forbidden1 = new f.api.MyObject();
 	public Object objectFromF_forbidden2 = new f.internal.MyObject();
 
-	// H: Optionally imported by G (Import-Package: h.api;resolution:=optional)
+	// H: Optionally imported by G (Import-Package: h.api;optional)
 	public Object objectFromH_forbidden1 = new h.api.MyObject();
 	public Object objectFromH_forbidden2 = new h.internal.MyObject();
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/api/MyObject.java
@@ -1,4 +1,20 @@
 package b.api;
 
-public class MyObject {
+public class MyObject extends c.api.MyObject implements d.api.Processor {
+
+	@Override
+	public Object process(String input) {
+		return new d.api.MyObject(input);
+	}
+
+	public d.api.MyObject processData(d.api.MyObject input) {
+		if (input != null) {
+			return new d.api.MyObject(input.getData());
+		}
+		return new d.api.MyObject();
+	}
+
+	public g.api.MyObject createService() {
+		return new g.api.MyObject();
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/B/src/b/internal/MyObject.java
@@ -1,4 +1,13 @@
 package b.internal;
 
 public class MyObject {
+
+	public void doOptionalWork() {
+		e.api.MyObject lifecycle = new e.api.MyObject();
+		lifecycle.activate();
+	}
+
+	public boolean checkAvailability() {
+		return new f.api.MyObject().isAvailable();
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/api/Configurable.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/api/Configurable.java
@@ -1,0 +1,7 @@
+package c.api;
+
+public interface Configurable {
+	void configure(Object config);
+
+	boolean isConfigured();
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/C/src/c/api/MyObject.java
@@ -1,4 +1,21 @@
 package c.api;
 
-public class MyObject {
+public class MyObject implements Configurable {
+	private Object config;
+	private boolean configured;
+
+	@Override
+	public void configure(Object config) {
+		this.config = config;
+		this.configured = true;
+	}
+
+	@Override
+	public boolean isConfigured() {
+		return configured;
+	}
+
+	public Object getConfig() {
+		return config;
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/api/MyObject.java
@@ -1,4 +1,17 @@
 package d.api;
 
 public class MyObject {
+	private final String data;
+
+	public MyObject() {
+		this.data = "";
+	}
+
+	public MyObject(String data) {
+		this.data = data;
+	}
+
+	public String getData() {
+		return data;
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/api/Processor.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/D/src/d/api/Processor.java
@@ -1,0 +1,5 @@
+package d.api;
+
+public interface Processor {
+	Object process(String input);
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/E/src/e/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/E/src/e/api/MyObject.java
@@ -1,4 +1,13 @@
 package e.api;
 
 public class MyObject {
+	private boolean active;
+
+	public void activate() {
+		this.active = true;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/F/src/f/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/F/src/f/api/MyObject.java
@@ -1,4 +1,7 @@
 package f.api;
 
 public class MyObject {
+	public boolean isAvailable() {
+		return true;
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/api/MyObject.java
@@ -1,4 +1,8 @@
 package g.api;
 
 public class MyObject {
+
+	public String describe() {
+		return new h.api.MyObject().getIdentifier();
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/G/src/g/internal/MyObject.java
@@ -1,4 +1,8 @@
 package g.internal;
 
 public class MyObject {
+
+	public void initialize() {
+		new h.api.MyObject().getIdentifier();
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/H/src/h/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/H/src/h/api/MyObject.java
@@ -1,4 +1,7 @@
 package h.api;
 
 public class MyObject {
+	public String getIdentifier() {
+		return "H";
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/X/src/x/api/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/X/src/x/api/MyObject.java
@@ -1,4 +1,8 @@
 package x.api;
 
 public class MyObject {
+
+	public String getName() {
+		return x.internal.MyObject.computeName();
+	}
 }

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/X/src/x/internal/MyObject.java
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/X/src/x/internal/MyObject.java
@@ -1,4 +1,8 @@
 package x.internal;
 
 public class MyObject {
+
+	public static String computeName() {
+		return "X";
+	}
 }


### PR DESCRIPTION
Add cross-bundle type hierarchy chains (extends/implements) and actual API usage to test projects B-H and X, modelling real-world scenarios where type hierarchy required transitive dependencies on the compilation classpath.