### PR TITLE
Fix build order computation if project and bundle name are not equals

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DynamicPluginProjectReferences.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DynamicPluginProjectReferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2018 Andrey Loskutov <loskutov@gmx.de> and others.
+ *  Copyright (c) 2018, 2026 Andrey Loskutov <loskutov@gmx.de> and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -13,31 +13,27 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
-import static java.util.Collections.singleton;
-import static java.util.stream.Collectors.toList;
-
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IDynamicReferenceProvider;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
 
 /**
  * Project references provider for JDT build to compute right build order with
  * indirect plug-in dependencies
  */
 public class DynamicPluginProjectReferences implements IDynamicReferenceProvider {
-
-	public DynamicPluginProjectReferences() {
-		super();
-	}
 
 	@Override
 	public List<IProject> getDependentProjects(IBuildConfiguration buildConfiguration) throws CoreException {
@@ -46,13 +42,13 @@ public class DynamicPluginProjectReferences implements IDynamicReferenceProvider
 		if (javaProject != null) {
 			IPluginModelBase model = PDECore.getDefault().getModelManager().findModel(javaProject.getProject());
 			if (model != null) {
-				BundleDescription currentBundle = model.getBundleDescription();
-				if (currentBundle != null) {
-					IWorkspaceRoot root = PDECore.getWorkspace().getRoot();
-					return BuildDependencyCollector.collectBuildRelevantDependencies(singleton(currentBundle)).stream()
-							.filter(dependency -> dependency != currentBundle)
-							.map(dependency -> root.getProject(dependency.getName())).filter(IProject::exists)
-							.distinct().collect(toList());
+				BundleDescription bundle = model.getBundleDescription();
+				if (bundle != null) {
+					return BuildDependencyCollector.collectBuildRelevantDependencies(Set.of(bundle)).stream()
+							.map(b -> (org.osgi.resource.Resource) b) //
+							.filter(dependency -> dependency != bundle).map(PluginRegistry::findModel)
+							.map(IPluginModelBase::getUnderlyingResource).filter(Objects::nonNull)
+							.map(IResource::getProject).distinct().toList();
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the build order computation in case an Eclipse project in a workspace is not named like its corresponding bundle, i.e. if a project's name differers from the `Bundle-SymbolicName` specified in its `MANIFEST.MF`.