### PR TITLE
Add popup menu and notification feedback for CSS Spy clipboard export

### DIFF
--- a/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.e4.ui.css.swt;bundle-version="0.10.0",
  org.eclipse.e4.ui.css.swt.theme;bundle-version="0.9.201",
  org.eclipse.e4.ui.model.workbench;bundle-version="0.9.1",
- org.eclipse.pde.spy.core;bundle-version="1.0.200"
+ org.eclipse.pde.spy.core;bundle-version="1.0.200",
+ org.eclipse.jface.notifications;bundle-version="0.8.0"
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CssSpyPart.java
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CssSpyPart.java
@@ -38,11 +38,14 @@ import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.e4.ui.css.swt.engine.CSSSWTEngineImpl;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.services.IServiceConstants;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.layout.TreeColumnLayout;
+import org.eclipse.jface.notifications.NotificationPopup;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ColumnViewerEditor;
@@ -89,6 +92,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
@@ -598,6 +602,21 @@ public class CssSpyPart {
 		widgetsTableLayout.setColumnData(widgetClassColumn.getColumn(), new ColumnWeightData(40));
 		widgetsComposite.setLayout(widgetsTableLayout);
 
+		MenuManager menuManager = new MenuManager();
+		menuManager.setRemoveAllWhenShown(true);
+		menuManager.addMenuListener(manager -> {
+			Action copyAction = new Action(Messages.CssSpyPart_Copy_widget_info) {
+				@Override
+				public void run() {
+					copyWidgetHierarchyToClipboard();
+				}
+			};
+			copyAction.setEnabled(!widgetTreeViewer.getSelection().isEmpty());
+			manager.add(copyAction);
+		});
+		Menu menu = menuManager.createContextMenu(widgetTreeViewer.getControl());
+		widgetTreeViewer.getControl().setMenu(menu);
+
 		// / HEADERS
 		Composite container = new Composite(sashForm, SWT.NONE);
 		container.setLayout(new GridLayout(2, true));
@@ -1002,6 +1021,8 @@ public class CssSpyPart {
 		Clipboard clipboard = new Clipboard(display);
 		try {
 			clipboard.setContents(new Object[] { sb.toString() }, new Transfer[] { TextTransfer.getInstance() });
+			NotificationPopup.forDisplay(display).text(Messages.CssSpyPart_Widget_hierarchy_copied_to_clipboard)
+					.title(Messages.CssSpyPart_Copy_widget_info, true).open();
 		} finally {
 			clipboard.dispose();
 		}

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/Messages.java
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/Messages.java
@@ -24,6 +24,7 @@ public class Messages extends NLS {
 	public static String CssSpyPart_Bounds;
 	public static String CssSpyPart_Copy_widget_info;
 	public static String CssSpyPart_Copy_widget_hierarchy_tooltip;
+	public static String CssSpyPart_Widget_hierarchy_copied_to_clipboard;
 	public static String CssSpyPart_Classes;
 	public static String CssSpyPart_CSS;
 	public static String CssSpyPart_CSS_Class;

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/messages.properties
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/messages.properties
@@ -10,6 +10,7 @@ CssSpyPart_All_shells=All shells
 CssSpyPart_Bounds=Bounds:
 CssSpyPart_Copy_widget_info=Copy widget info to clipboard
 CssSpyPart_Copy_widget_hierarchy_tooltip=Copies the selected widget's hierarchy and CSS styling information to the clipboard
+CssSpyPart_Widget_hierarchy_copied_to_clipboard=Widget hierarchy copied to clipboard
 CssSpyPart_Classes=Classes:
 CssSpyPart_CSS=CSS
 CssSpyPart_CSS_Class=CSS Class


### PR DESCRIPTION
This PR adds a pop-up menu to the widget tree in the CSS Spy for copying widget information to the clipboard. It also adds a notification feedback to the user when the information is copied, using the JFace NotificationPopup builder API.