### PR TITLE
Replace String.valueOf(true) with "true" literal

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/UpdateSingletonToSymbolicName.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/UpdateSingletonToSymbolicName.java
@@ -42,7 +42,7 @@ public class UpdateSingletonToSymbolicName extends AbstractManifestMarkerResolut
 				int ind2 = entry.indexOf(':');
 				String invalidDir = entry.substring(ind1 + 1, ind2);
 				((BundleSymbolicNameHeader) header).setDirective(invalidDir, null);
-				((BundleSymbolicNameHeader) header).setDirective(Constants.SINGLETON_DIRECTIVE, String.valueOf(true));
+				((BundleSymbolicNameHeader) header).setDirective(Constants.SINGLETON_DIRECTIVE, "true"); //$NON-NLS-1$
 			}
 		}
 	}


### PR DESCRIPTION
Replace `String.valueOf(true)` with a string literal `"true"` in `UpdateSingletonToSymbolicName.java`.

`String.valueOf(true)` is unnecessarily verbose and incurs a method call. A string literal is clearer and avoids unnecessary overhead.