### PR TITLE
Replace Boolean.TRUE.toString().equals() with Boolean.parseBoolean()

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/FeatureOptionsTab.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/FeatureOptionsTab.java
@@ -189,7 +189,7 @@ public class FeatureOptionsTab extends ExportOptionsTab {
 		}
 
 		String selected = settings.get(S_EXPORT_METADATA);
-		fExportMetadata.setSelection(selected == null ? true : Boolean.TRUE.toString().equals(selected));
+		fExportMetadata.setSelection(selected == null || Boolean.parseBoolean(selected));
 
 		// This enablement depends on both the jar button being selected and the destination setting being something other than install (bug 276989)
 		fExportMetadata.setEnabled(fJarButton.getSelection());
@@ -207,7 +207,7 @@ public class FeatureOptionsTab extends ExportOptionsTab {
 		selected = settings.get(S_CREATE_CATEGORIES);
 
 		fCategoryButton.setEnabled(fExportMetadata.getSelection() && fJarButton.getSelection());
-		fCategoryButton.setSelection(selected == null ? true : Boolean.TRUE.toString().equals(selected));
+		fCategoryButton.setSelection(selected == null || Boolean.parseBoolean(selected));
 		if (settings.get(S_CATEGORY_FILE) != null) {
 			fCategoryCombo.setText(settings.get(S_CATEGORY_FILE));
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/ProductExportWizardPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/exports/ProductExportWizardPage.java
@@ -161,10 +161,10 @@ public class ProductExportWizardPage extends AbstractExportWizardPage {
 		fExportSourceCombo.setEnabled(fExportSourceButton.getSelection());
 
 		String selected = settings.get(S_EXPORT_METADATA);
-		fExportMetadata.setSelection(selected == null ? true : Boolean.TRUE.toString().equals(selected));
+		fExportMetadata.setSelection(selected == null || Boolean.parseBoolean(selected));
 
 		selected = settings.get(S_ALLOW_BINARY_CYCLES);
-		fAllowBinaryCycles.setSelection(selected == null ? true : Boolean.TRUE.toString().equals(selected));
+		fAllowBinaryCycles.setSelection(selected == null || Boolean.parseBoolean(selected));
 
 		if (fMultiPlatform != null) {
 			fMultiPlatform.setSelection(settings.getBoolean(S_MULTI_PLATFORM));


### PR DESCRIPTION
Replace the verbose `Boolean.TRUE.toString().equals(selected)` pattern with the simpler `Boolean.parseBoolean(selected)` in `FeatureOptionsTab` and `ProductExportWizardPage`.

Also simplify the ternary expressions:
```java
// Before:
selected == null ? true : Boolean.TRUE.toString().equals(selected)
// After:
selected == null || Boolean.parseBoolean(selected)
```

This is consistent with adjacent `ExportOptionsTab` which already uses `Boolean.parseBoolean()` for the same purpose.