### PR TITLE
Replace StringBuffer with StringBuilder in AntScript

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ant/AntScript.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/ant/AntScript.java
@@ -1095,14 +1095,14 @@ public class AntScript implements IAntScript {
 	}
 
 	public static String getEscaped(String s) {
-		StringBuffer result = new StringBuffer(s.length() + 10);
+		StringBuilder result = new StringBuilder(s.length() + 10);
 		for (int i = 0; i < s.length(); ++i) {
 			appendEscapedChar(result, s.charAt(i));
 		}
 		return result.toString();
 	}
 
-	private static void appendEscapedChar(StringBuffer buffer, char c) {
+	private static void appendEscapedChar(StringBuilder buffer, char c) {
 		buffer.append(getReplacement(c));
 	}
 


### PR DESCRIPTION
Replace the synchronized `StringBuffer` with `StringBuilder` in `AntScript.getEscaped()` and the private helper `appendEscapedChar()`.

The local variable is not shared across threads, so `StringBuilder` is the appropriate choice and avoids unnecessary synchronization overhead.