### PR TITLE
Replace StringBuffer with StringBuilder in BundleHelper

### DIFF
--- a/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/BundleHelper.java
+++ b/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/BundleHelper.java
@@ -187,7 +187,7 @@ public class BundleHelper {
 			if (supplierFilters.size() == 1) {
 				nativeFilter = supplierFilters.get(0).toString();
 			} else if (supplierFilters.size() > 1) {
-				StringBuffer buffer = new StringBuffer("(|"); //$NON-NLS-1$
+				StringBuilder buffer = new StringBuilder("(|"); //$NON-NLS-1$
 				for (Filter filter : supplierFilters) {
 					buffer.append(filter.toString());
 				}


### PR DESCRIPTION
Replace the synchronized `StringBuffer` with `StringBuilder` in `BundleHelper.getFilter()`.

The local variable `buffer` is not shared across threads, so `StringBuilder` is the appropriate choice and avoids unnecessary synchronization overhead.