### PR TITLE
Option to add console argument in the launch configuration

### DIFF
--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.13.800.qualifier
+Bundle-Version: 3.14.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/EclipseApplicationLaunchConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2024 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -157,6 +157,9 @@ public class EclipseApplicationLaunchConfiguration extends AbstractPDELaunchConf
 				programArgs.add(0, "-showsplash"); //$NON-NLS-1$
 				programArgs.add(1, computeShowsplashArgument());
 			}
+		}
+		if (configuration.getAttribute(IPDELauncherConstants.ADD_CONSOLE, false)) {
+			programArgs.add("-console"); //$NON-NLS-1$
 		}
 		return programArgs.toArray(new String[programArgs.size()]);
 	}

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/IPDELauncherConstants.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/IPDELauncherConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2022 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -580,4 +580,13 @@ public interface IPDELauncherConstants {
 	 * @since 3.6
 	 */
 	String ADDITIONAL_PLUGINS = "additional_plugins"; //$NON-NLS-1$
+	/**
+	 * Launch configuration attribute key. The value is a boolean specifying whether
+	 * the <code>-console</code> argument should be added when launching.
+	 * When set to <code>true</code>, the application will be started with
+	 * console support enabled.
+	 * 
+	 * @since 3.14
+	 */
+	String ADD_CONSOLE = "add_console"; //$NON-NLS-1$
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -40,6 +40,8 @@ public class PDEUIMessages extends NLS {
 
 	public static String AbstractTargetPage_setTarget;
 
+	public static String ProgramBlock_runWithConsoleOption;
+
 	public static String AbstractTargetPage_reloadTarget;
 
 	public static String AbstractTargetPage_openPreferences;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/ProgramBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/ProgramBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2015 IBM Corporation and others.
+ *  Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -46,6 +46,7 @@ public class ProgramBlock {
 	private Button fProductButton;
 	private Combo fProductCombo;
 	private Button fApplicationButton;
+	private Button fRunAsConsoleSectionButton;
 	private final AbstractLauncherTab fTab;
 	private final Listener fListener = new Listener();
 	private ControlDecoration fProductComboDecoration;
@@ -109,6 +110,7 @@ public class ProgramBlock {
 
 		createProductSection(group);
 		createApplicationSection(group);
+		createRunWithConsoleOption(group);
 	}
 
 	protected void createProductSection(Composite parent) {
@@ -135,16 +137,24 @@ public class ProgramBlock {
 		fApplicationCombo.addSelectionListener(fListener);
 	}
 
+	protected void createRunWithConsoleOption(Composite parent) {
+		fRunAsConsoleSectionButton = new Button(parent, SWT.CHECK);
+		fRunAsConsoleSectionButton.setText(PDEUIMessages.ProgramBlock_runWithConsoleOption);
+		fRunAsConsoleSectionButton.addSelectionListener(fListener);
+	}
+
 	public void initializeFrom(ILaunchConfiguration config) throws CoreException {
 		initializeProductSection(config);
 		initializeApplicationSection(config);
 
 		boolean useProduct = config.getAttribute(IPDELauncherConstants.USE_PRODUCT, false) && fProductCombo.getItemCount() > 0;
+		boolean addConsole = config.getAttribute(IPDELauncherConstants.ADD_CONSOLE, false);
 		fApplicationButton.setSelection(!useProduct);
 		fApplicationCombo.setEnabled(!useProduct);
 		fProductButton.setSelection(useProduct);
 		fProductButton.setEnabled(fProductCombo.getItemCount() > 0);
 		fProductCombo.setEnabled(useProduct);
+		fRunAsConsoleSectionButton.setSelection(addConsole);
 	}
 
 	protected void initializeProductSection(ILaunchConfiguration config) throws CoreException {
@@ -196,6 +206,7 @@ public class ProgramBlock {
 	public void performApply(ILaunchConfigurationWorkingCopy config) {
 		saveApplicationSection(config);
 		saveProductSection(config);
+		saveConsoleSection(config);
 	}
 
 	protected void saveProductSection(ILaunchConfigurationWorkingCopy config) {
@@ -211,6 +222,10 @@ public class ProgramBlock {
 		} else {
 			config.setAttribute(attribute, text);
 		}
+	}
+
+	protected void saveConsoleSection(ILaunchConfigurationWorkingCopy config) {
+		config.setAttribute(IPDELauncherConstants.ADD_CONSOLE, fRunAsConsoleSectionButton.getSelection());
 	}
 
 	public void setDefaults(ILaunchConfigurationWorkingCopy config) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -538,6 +538,7 @@ ProgramBlock_runProduct=Run a &product:
 ProgramBlock_productDecorationWarning0=A product with this name cannot be found in any required bundle.  This launch may fail to start as expected unless there is an available IProductProvider that can supply this product.
 ProgramBlock_programToRun=Program to Run
 ProgramBlock_runApplication=Run an &application:
+ProgramBlock_runWithConsoleOption = Enable OSGi Console
 BasicLauncherTab_javaExec=Java executable:
 BasicLauncherTab_unbound=unbound
 BasicLauncherTab_ee=E&xecution environment:


### PR DESCRIPTION


This PR adds an option in launch configuration to add `-console` argument in program arguments.

<img width="600" height="500" alt="Screenshot 2026-03-25 at 1 50 47 PM" src="https://github.com/user-attachments/assets/fd19052d-14db-4be9-b151-3a4cb2ab07d0" />
<br><br>
<img width="600" height="500" alt="Screenshot 2026-03-25 at 12 04 18 PM" src="https://github.com/user-attachments/assets/791b59ec-1421-4751-b972-cb4a7ad501f9" />
<br><br>
<img width="600" height="500" alt="Screenshot 2026-03-25 at 12 07 10 PM" src="https://github.com/user-attachments/assets/931269bf-7339-4de2-8f77-c72a881aa8ba" />
<br><br>

Fixes : https://github.com/eclipse-pde/eclipse.pde/issues/1851