### PR TITLE
Fix TargetPlatformPresentationReconciler: stop scanning past damage end

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Generic Target Platform Editor
 Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension.tests
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.pde.genericeditor.extension.tests</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.3.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AllTargetEditorTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AllTargetEditorTests.java
@@ -19,7 +19,8 @@ import org.junit.platform.suite.api.Suite;
 @Suite
 @SelectClasses({ AttributeNameCompletionTests.class, AttributeValueCompletionTests.class, TagNameCompletionTests.class,
 	TagValueCompletionTests.class, Bug527084CompletionWithCommentsTest.class,
-	Bug528706CompletionWithMultilineTagsTest.class, UpdateUnitVersionsCommandTests.class, Bug531602FormattingTests.class })
+	Bug528706CompletionWithMultilineTagsTest.class, UpdateUnitVersionsCommandTests.class, Bug531602FormattingTests.class,
+	TargetPlatformPresentationReconcilerTest.class })
 public class AllTargetEditorTests {
 
 }

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TargetPlatformPresentationReconcilerTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TargetPlatformPresentationReconcilerTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2026 vogella GmbH and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial implementation
+ *******************************************************************************/
+package org.eclipse.pde.genericeditor.extension.tests;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.jface.text.presentation.IPresentationRepairer;
+import org.eclipse.pde.internal.genericeditor.target.extension.reconciler.presentation.TargetPlatformPresentationReconciler;
+import org.junit.Test;
+
+/**
+ * Tests for {@link TargetPlatformPresentationReconciler}.
+ *
+ * <p>The reconciler overrides {@code createPresentation} to scan from offset 0
+ * so that multi-line rules (XML comments) are correctly recognised even when
+ * the damaged region is deep inside the document. These tests verify that the
+ * presentation is computed correctly for several representative document shapes
+ * and damage positions.
+ */
+public class TargetPlatformPresentationReconcilerTest {
+
+	/** Subclass that exposes the protected {@code createPresentation} for testing. */
+	private static class TestableReconciler extends TargetPlatformPresentationReconciler {
+		TextPresentation createPresentation(IDocument document, IRegion damage) {
+			IPresentationRepairer repairer = getRepairer(IDocument.DEFAULT_CONTENT_TYPE);
+			if (repairer != null) {
+				repairer.setDocument(document);
+			}
+			return createPresentation(damage, document);
+		}
+	}
+
+	@Test
+	public void testCreatePresentationReturnsNonNullForSimpleDocument() {
+		TestableReconciler reconciler = new TestableReconciler();
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
+				+ "<target name=\"test\">\n" //$NON-NLS-1$
+				+ "  <locations/>\n" //$NON-NLS-1$
+				+ "</target>\n"; //$NON-NLS-1$
+		IDocument document = new Document(content);
+		IRegion damage = new Region(0, content.length());
+
+		TextPresentation presentation = reconciler.createPresentation(document, damage);
+
+		assertNotNull("Expected a non-null TextPresentation for a simple document", presentation); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testCreatePresentationWithDamageSubsetOfDocument() {
+		TestableReconciler reconciler = new TestableReconciler();
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
+				+ "<target name=\"test\">\n" //$NON-NLS-1$
+				+ "  <locations>\n" //$NON-NLS-1$
+				+ "  </locations>\n" //$NON-NLS-1$
+				+ "</target>\n"; //$NON-NLS-1$
+		IDocument document = new Document(content);
+		// Damage is only the last few characters, not the full document.
+		int damageOffset = content.indexOf("</target>"); //$NON-NLS-1$
+		IRegion damage = new Region(damageOffset, content.length() - damageOffset);
+
+		TextPresentation presentation = reconciler.createPresentation(document, damage);
+
+		assertNotNull("Expected a non-null TextPresentation when damage covers only end of document", presentation); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testCreatePresentationWithMultilineCommentBeforeDamage() {
+		TestableReconciler reconciler = new TestableReconciler();
+		// Multi-line comment appears before the damage region. The reconciler must
+		// scan from offset 0 so it can correctly determine the scanner state
+		// (comment vs normal) at the start of the damage.
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
+				+ "<target name=\"test\">\n" //$NON-NLS-1$
+				+ "<!--\n" //$NON-NLS-1$
+				+ "  multi-line comment\n" //$NON-NLS-1$
+				+ "-->\n" //$NON-NLS-1$
+				+ "  <locations/>\n" //$NON-NLS-1$
+				+ "</target>\n"; //$NON-NLS-1$
+		IDocument document = new Document(content);
+		// Damage is after the comment closes.
+		int damageOffset = content.indexOf("<locations/>"); //$NON-NLS-1$
+		IRegion damage = new Region(damageOffset, content.length() - damageOffset);
+
+		TextPresentation presentation = reconciler.createPresentation(document, damage);
+
+		assertNotNull("Expected a non-null TextPresentation when a multi-line comment precedes the damage", //$NON-NLS-1$
+				presentation);
+	}
+
+	@Test
+	public void testCreatePresentationWithDamageInsideMultilineComment() {
+		TestableReconciler reconciler = new TestableReconciler();
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
+				+ "<target name=\"test\">\n" //$NON-NLS-1$
+				+ "<!--\n" //$NON-NLS-1$
+				+ "  line one\n" //$NON-NLS-1$
+				+ "  line two\n" //$NON-NLS-1$
+				+ "-->\n" //$NON-NLS-1$
+				+ "</target>\n"; //$NON-NLS-1$
+		IDocument document = new Document(content);
+		// Damage is inside the comment body.
+		int damageOffset = content.indexOf("  line two"); //$NON-NLS-1$
+		IRegion damage = new Region(damageOffset, "  line two\n".length()); //$NON-NLS-1$
+
+		TextPresentation presentation = reconciler.createPresentation(document, damage);
+
+		assertNotNull("Expected a non-null TextPresentation when damage is inside a multi-line comment", presentation); //$NON-NLS-1$
+	}
+}

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TargetPlatformPresentationReconcilerTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TargetPlatformPresentationReconcilerTest.java
@@ -13,27 +13,55 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.BadPartitioningException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITypedRegion;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.presentation.IPresentationRepairer;
 import org.eclipse.pde.internal.genericeditor.target.extension.reconciler.presentation.TargetPlatformPresentationReconciler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link TargetPlatformPresentationReconciler}.
  *
  * <p>The reconciler overrides {@code createPresentation} to scan from offset 0
  * so that multi-line rules (XML comments) are correctly recognised even when
- * the damaged region is deep inside the document. These tests verify that the
- * presentation is computed correctly for several representative document shapes
- * and damage positions.
+ * the damaged region is deep inside the document. The scan must stop at the
+ * end of the damage region (not the end of the document), because style ranges
+ * beyond the damage end are discarded anyway.
+ *
+ * <p>To make these tests meaningful regression tests for the performance fix,
+ * the document records the {@code (offset, length)} passed to
+ * {@code IDocumentExtension3.computePartitioning(String, int, int, boolean)} so we can
+ * verify the scan actually stops at {@code damage.getOffset() + damage.getLength()}
+ * rather than running all the way to {@code document.getLength()}.
  */
 public class TargetPlatformPresentationReconcilerTest {
+
+	/** Records the length passed to {@code computePartitioning} so tests can assert on it. */
+	private static class RecordingDocument extends Document {
+		int lastPartitioningOffset = -1;
+		int lastPartitioningLength = -1;
+
+		RecordingDocument(String content) {
+			super(content);
+		}
+
+		@Override
+		public ITypedRegion[] computePartitioning(String partitioning, int offset, int length,
+				boolean includeZeroLengthPartitions) throws BadLocationException, BadPartitioningException {
+			lastPartitioningOffset = offset;
+			lastPartitioningLength = length;
+			return super.computePartitioning(partitioning, offset, length, includeZeroLengthPartitions);
+		}
+	}
 
 	/** Subclass that exposes the protected {@code createPresentation} for testing. */
 	private static class TestableReconciler extends TargetPlatformPresentationReconciler {
@@ -46,6 +74,14 @@ public class TargetPlatformPresentationReconcilerTest {
 		}
 	}
 
+	private static void assertScanStopsAtDamageEnd(RecordingDocument document, IRegion damage) {
+		assertEquals(0, document.lastPartitioningOffset,
+				"Scan should start at offset 0 to preserve multi-line rule context"); //$NON-NLS-1$
+		int expectedScanLength = Math.min(damage.getOffset() + damage.getLength(), document.getLength());
+		assertEquals(expectedScanLength, document.lastPartitioningLength,
+				"Scan should stop at damage end, not document end"); //$NON-NLS-1$
+	}
+
 	@Test
 	public void testCreatePresentationReturnsNonNullForSimpleDocument() {
 		TestableReconciler reconciler = new TestableReconciler();
@@ -53,12 +89,13 @@ public class TargetPlatformPresentationReconcilerTest {
 				+ "<target name=\"test\">\n" //$NON-NLS-1$
 				+ "  <locations/>\n" //$NON-NLS-1$
 				+ "</target>\n"; //$NON-NLS-1$
-		IDocument document = new Document(content);
+		RecordingDocument document = new RecordingDocument(content);
 		IRegion damage = new Region(0, content.length());
 
 		TextPresentation presentation = reconciler.createPresentation(document, damage);
 
-		assertNotNull("Expected a non-null TextPresentation for a simple document", presentation); //$NON-NLS-1$
+		assertNotNull(presentation, "Expected a non-null TextPresentation for a simple document"); //$NON-NLS-1$
+		assertScanStopsAtDamageEnd(document, damage);
 	}
 
 	@Test
@@ -69,14 +106,15 @@ public class TargetPlatformPresentationReconcilerTest {
 				+ "  <locations>\n" //$NON-NLS-1$
 				+ "  </locations>\n" //$NON-NLS-1$
 				+ "</target>\n"; //$NON-NLS-1$
-		IDocument document = new Document(content);
+		RecordingDocument document = new RecordingDocument(content);
 		// Damage is only the last few characters, not the full document.
 		int damageOffset = content.indexOf("</target>"); //$NON-NLS-1$
 		IRegion damage = new Region(damageOffset, content.length() - damageOffset);
 
 		TextPresentation presentation = reconciler.createPresentation(document, damage);
 
-		assertNotNull("Expected a non-null TextPresentation when damage covers only end of document", presentation); //$NON-NLS-1$
+		assertNotNull(presentation, "Expected a non-null TextPresentation when damage covers only end of document"); //$NON-NLS-1$
+		assertScanStopsAtDamageEnd(document, damage);
 	}
 
 	@Test
@@ -92,15 +130,16 @@ public class TargetPlatformPresentationReconcilerTest {
 				+ "-->\n" //$NON-NLS-1$
 				+ "  <locations/>\n" //$NON-NLS-1$
 				+ "</target>\n"; //$NON-NLS-1$
-		IDocument document = new Document(content);
+		RecordingDocument document = new RecordingDocument(content);
 		// Damage is after the comment closes.
 		int damageOffset = content.indexOf("<locations/>"); //$NON-NLS-1$
 		IRegion damage = new Region(damageOffset, content.length() - damageOffset);
 
 		TextPresentation presentation = reconciler.createPresentation(document, damage);
 
-		assertNotNull("Expected a non-null TextPresentation when a multi-line comment precedes the damage", //$NON-NLS-1$
-				presentation);
+		assertNotNull(presentation,
+				"Expected a non-null TextPresentation when a multi-line comment precedes the damage"); //$NON-NLS-1$
+		assertScanStopsAtDamageEnd(document, damage);
 	}
 
 	@Test
@@ -113,13 +152,31 @@ public class TargetPlatformPresentationReconcilerTest {
 				+ "  line two\n" //$NON-NLS-1$
 				+ "-->\n" //$NON-NLS-1$
 				+ "</target>\n"; //$NON-NLS-1$
-		IDocument document = new Document(content);
+		RecordingDocument document = new RecordingDocument(content);
 		// Damage is inside the comment body.
 		int damageOffset = content.indexOf("  line two"); //$NON-NLS-1$
 		IRegion damage = new Region(damageOffset, "  line two\n".length()); //$NON-NLS-1$
 
 		TextPresentation presentation = reconciler.createPresentation(document, damage);
 
-		assertNotNull("Expected a non-null TextPresentation when damage is inside a multi-line comment", presentation); //$NON-NLS-1$
+		assertNotNull(presentation, "Expected a non-null TextPresentation when damage is inside a multi-line comment"); //$NON-NLS-1$
+		assertScanStopsAtDamageEnd(document, damage);
+	}
+
+	@Test
+	public void testScanEndClampedToDocumentLength() {
+		// Damage region extending past document end (can happen with a stale damage
+		// during rapid edits) must be clamped to document length to avoid a
+		// BadLocationException and preserve syntax highlighting.
+		TestableReconciler reconciler = new TestableReconciler();
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<target/>\n"; //$NON-NLS-1$
+		RecordingDocument document = new RecordingDocument(content);
+		IRegion damage = new Region(0, content.length() + 100);
+
+		TextPresentation presentation = reconciler.createPresentation(document, damage);
+
+		assertNotNull(presentation, "Expected a non-null TextPresentation when damage extends past document end"); //$NON-NLS-1$
+		assertEquals(content.length(), document.lastPartitioningLength,
+				"Scan should be clamped to document length"); //$NON-NLS-1$
 	}
 }

--- a/ui/org.eclipse.pde.genericeditor.extension/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension/META-INF/MANIFEST.MF
@@ -28,6 +28,6 @@ Export-Package: org.eclipse.pde.internal.genericeditor.target.extension.autocomp
  org.eclipse.pde.internal.genericeditor.target.extension.model.xml;x-internal:=true,
  org.eclipse.pde.internal.genericeditor.target.extension.p2;x-internal:=true,
  org.eclipse.pde.internal.genericeditor.target.extension.reconciler.folding;x-internal:=true,
- org.eclipse.pde.internal.genericeditor.target.extension.reconciler.presentation;x-internal:=true,
+ org.eclipse.pde.internal.genericeditor.target.extension.reconciler.presentation;x-friends:="org.eclipse.pde.genericeditor.extension.tests",
  org.eclipse.pde.internal.genericeditor.target.extension.validator;x-internal:=true
 Automatic-Module-Name: org.eclipse.pde.genericeditor.extension

--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/presentation/TargetPlatformPresentationReconciler.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/presentation/TargetPlatformPresentationReconciler.java
@@ -121,7 +121,7 @@ public class TargetPlatformPresentationReconciler extends PresentationReconciler
 		IPresentationRepairer repairer = this.getRepairer(IDocument.DEFAULT_CONTENT_TYPE);
 		if (repairer != null) {
 			try {
-				int scanEnd = damage.getOffset() + damage.getLength();
+				int scanEnd = Math.min(damage.getOffset() + damage.getLength(), document.getLength());
 				ITypedRegion[] regions = TextUtilities.computePartitioning(document, getDocumentPartitioning(), 0,
 						scanEnd, false);
 				if (regions.length > 0) {

--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/presentation/TargetPlatformPresentationReconciler.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/reconciler/presentation/TargetPlatformPresentationReconciler.java
@@ -109,8 +109,11 @@ public class TargetPlatformPresentationReconciler extends PresentationReconciler
 	}
 
 	/**
-	 * Performs the repair on the full document to ensure MultiLineRules are
-	 * enforced
+	 * Performs the repair from the start of the document up to and including the
+	 * damaged region to ensure MultiLineRules (e.g. XML comments) are correctly
+	 * recognised. Scanning stops at the damage end rather than the document end
+	 * because the returned {@link TextPresentation} is bounded by {@code damage}
+	 * anyway, so any style ranges beyond that point would be discarded.
 	 */
 	@Override
 	protected TextPresentation createPresentation(IRegion damage, IDocument document) {
@@ -118,8 +121,9 @@ public class TargetPlatformPresentationReconciler extends PresentationReconciler
 		IPresentationRepairer repairer = this.getRepairer(IDocument.DEFAULT_CONTENT_TYPE);
 		if (repairer != null) {
 			try {
+				int scanEnd = damage.getOffset() + damage.getLength();
 				ITypedRegion[] regions = TextUtilities.computePartitioning(document, getDocumentPartitioning(), 0,
-						document.getLength(), false);
+						scanEnd, false);
 				if (regions.length > 0) {
 					repairer.createPresentation(presentation, regions[0]);
 					return presentation;


### PR DESCRIPTION
## Summary

Fixes #2283 (also related to eclipse-platform/eclipse.platform.ui#2276).

`TargetPlatformPresentationReconciler.createPresentation()` overrides the default
`PresentationReconciler` behaviour to always scan from offset **0**. This is
necessary to correctly handle multi-line XML comment rules (`<!-- ... -->`):
without the full context from the start of the document, a comment that opened
before the damaged region would not be recognised.

However, the scan was running all the way to `document.getLength()` even though
the `TextPresentation` returned is constructed with the damage region as its
extent — meaning any style ranges added for content after the damage end are
silently discarded. This results in O(document length) work on the UI thread
for every keystroke, causing noticeable freezes in large `.target` files.

## Changes

- **`TargetPlatformPresentationReconciler`** — change the upper bound of
  `TextUtilities.computePartitioning()` from `document.getLength()` to
  `damage.getOffset() + damage.getLength()`. Scanning still starts at offset 0
  (multi-line rule correctness is preserved); it just stops where it would have
  discarded results anyway.

- **`MANIFEST.MF`** (genericeditor.extension) — declare
  `org.eclipse.pde.genericeditor.extension.tests` as a friend of the
  `reconciler.presentation` package so the new tests can subclass the reconciler.

- **`TargetPlatformPresentationReconcilerTest`** — new test class covering:
  - simple document, full damage
  - damage covering only the end of the document
  - multi-line comment *before* the damage region
  - damage region *inside* a multi-line comment

## Known limitation

For edits very close to the end of a large file the gain is small (the damage
end ≈ the document end). A more thorough fix — e.g. caching scanner state
between edits, using a real `IDocumentPartitioner` for comments, or moving
reconciliation off the UI thread — is left for a follow-up.

## Test plan

- [x] Compiles cleanly (`mvn clean compile` on the two affected bundles)
- [ ] `TargetPlatformPresentationReconcilerTest` passes in a running Eclipse test environment
- [ ] All existing `AllTargetEditorTests` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)