### PR TITLE
Fix DynamicPluginProjectReferences.getDependentProjects

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DynamicPluginProjectReferences.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DynamicPluginProjectReferences.java
@@ -47,6 +47,7 @@ public class DynamicPluginProjectReferences implements IDynamicReferenceProvider
 					return ClasspathComputer.collectBuildRelevantDependencies(Set.of(bundle)).stream()
 							.map(b -> (org.osgi.resource.Resource) b) //
 							.filter(dependency -> dependency != bundle).map(PluginRegistry::findModel)
+							.filter(Objects::nonNull)
 							.map(IPluginModelBase::getUnderlyingResource).filter(Objects::nonNull)
 							.map(IResource::getProject).distinct().toList();
 				}


### PR DESCRIPTION
- Guard against PluginRegistry::findModel returning null before applying IPluginModelBase::getUnderlyingResource.