### PR TITLE
Update Color constructors to remove deprecated Device parameter

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.services/src/org/eclipse/e4/tools/services/BasicResourceProvider.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.services/src/org/eclipse/e4/tools/services/BasicResourceProvider.java
@@ -9,7 +9,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 import org.osgi.framework.BundleContext;
 
@@ -53,7 +52,7 @@ public abstract class BasicResourceProvider implements IResourceProviderService 
 			final int r = Integer.parseInt(cols[0].trim());
 			final int g = Integer.parseInt(cols[1].trim());
 			final int b = Integer.parseInt(cols[2].trim());
-			return new Color(display, new RGB(r, g, b));
+			return new Color(r, g, b);
 		}
 		return null;
 	}

--- a/ui/org.eclipse.pde.spy.event/src/org/eclipse/pde/spy/event/internal/ui/CapturedEventTree.java
+++ b/ui/org.eclipse.pde.spy.event/src/org/eclipse/pde/spy/event/internal/ui/CapturedEventTree.java
@@ -152,7 +152,7 @@ public class CapturedEventTree extends TreeViewer {
 
 		treeItemCursor = new TreeItemCursor(getTree().getCursor(), display.getSystemCursor(SWT.CURSOR_HAND));
 
-		treeItemForeground = new TreeItemForeground(new Color(display, new RGB(0, 0, 120)),
+		treeItemForeground = new TreeItemForeground(new Color(new RGB(0, 0, 120)),
 				display.getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT), display.getSystemColor(SWT.COLOR_BLACK));
 
 		treeItemBackground = new TreeItemBackground(display.getSystemColor(SWT.COLOR_LIST_SELECTION),

--- a/ui/org.eclipse.pde.ui.templates/templates_3.1/editor/java/ColorManager.java
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.1/editor/java/ColorManager.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 public class ColorManager {
 
@@ -18,7 +17,7 @@ public class ColorManager {
 	public Color getColor(RGB rgb) {
 		Color color = fColorTable.get(rgb);
 		if (color == null) {
-			color = new Color(Display.getCurrent(), rgb);
+			color = new Color(rgb);
 			fColorTable.put(rgb, color);
 		}
 		return color;

--- a/ui/org.eclipse.pde.ui.templates/templates_3.1/extensibleEditor/java/$javaClassPrefix$PresentationReconciler.java
+++ b/ui/org.eclipse.pde.ui.templates/templates_3.1/extensibleEditor/java/$javaClassPrefix$PresentationReconciler.java
@@ -2,7 +2,6 @@ package $packageName$;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
@@ -15,8 +14,8 @@ import org.eclipse.jface.text.rules.Token;
 
 public class $javaClassPrefix$PresentationReconciler extends PresentationReconciler {
 
-    private final TextAttribute tagAttribute = new TextAttribute(new Color(Display.getCurrent(), new RGB(0,0, 255)));
-    private final TextAttribute headerAttribute = new TextAttribute(new Color(Display.getCurrent(), new RGB(128,128,128)));
+    private final TextAttribute tagAttribute = new TextAttribute(new Color(new RGB(0,0, 255)));
+    private final TextAttribute headerAttribute = new TextAttribute(new Color(new RGB(128,128,128)));
 
     public $javaClassPrefix$PresentationReconciler() {
         // TODO this is logic for .project file to color tags in blue. Replace with your language logic!

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/ColorManager.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/text/ColorManager.java
@@ -123,7 +123,7 @@ public class ColorManager implements IColorManager, IPDEColorConstants {
 				return;
 			}
 		}
-		fColorTable.put(property, new Color(Display.getCurrent(), setting));
+		fColorTable.put(property, new Color(setting));
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/MessageLine.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/MessageLine.java
@@ -75,7 +75,7 @@ public class MessageLine extends CLabel {
 				setText(message);
 				setImage(findImage(status));
 				if (fErrorMsgAreaBackground == null) {
-					fErrorMsgAreaBackground = new Color(getDisplay(), ERROR_BACKGROUND_RGB);
+					fErrorMsgAreaBackground = new Color(ERROR_BACKGROUND_RGB);
 				}
 				setBackground(fErrorMsgAreaBackground);
 				return;


### PR DESCRIPTION
This PR updates Color constructors to remove the deprecated Device parameter, following the changes in SWT (https://github.com/eclipse-platform/eclipse.platform.swt/issues/3232). It also removes the now unused imports of Display and RGB in the modified files.