### PR TITLE
Fix error with search in XMI-tab of E4WorkbenchModelEditor

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui;singleton:=true
-Bundle-Version: 4.9.0.qualifier
+Bundle-Version: 4.9.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.e4.tools.emf.ui</artifactId>
-  <version>4.9.0-SNAPSHOT</version>
+  <version>4.9.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
@@ -41,8 +41,7 @@ import org.eclipse.jface.text.source.AnnotationModel;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.jface.text.source.VerticalRuler;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.KeyAdapter;
-import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -88,14 +87,15 @@ public class XmiTab extends Composite {
 		text = new Text(this, SWT.SINGLE | SWT.LEAD | SWT.BORDER);
 		text.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		text.setMessage(Messages.XmiTab_TypeTextToSearch);
-		text.addKeyListener(new KeyAdapter() {
-			@Override
-			public void keyPressed(KeyEvent e) {
-				if (e.keyCode != SWT.CR) {
-					offsetStart = 0;
-				}
+		text.addKeyListener(KeyListener.keyPressedAdapter(e -> {
+			if (e.keyCode != SWT.CR) {
+				offsetStart = 0;
+			} else { // search next occurrence
 				offsetStart = searchAndHighlight(text.getText(), offsetStart);
 			}
+		}));
+		text.addModifyListener(e -> {
+			offsetStart = searchAndHighlight(text.getText(), offsetStart);
 		});
 
 		final AnnotationModel model = new AnnotationModel();


### PR DESCRIPTION
Currently there is an issue with the search functionality inside of the XMI tab of the E4WorkbenchModelEditor: When searching for a specific text, the search "lags" behind the last entered character and thus only highlights the previously entered text.

<img width="1422" height="765" alt="SearchLag" src="https://github.com/user-attachments/assets/0123c353-e513-4c97-a289-305c0fde7410" />

This is caused by the search highlighting being recalculated on a keyPressed-Event. This event happens before the text value of the search field is recalculated. In order to fix this issue, the search highlighting should instead react to modification events of the underlying text field (in cases in which the entered character causes the text field to update).

How to reproduce/test:
1. Create a new application model (or navigate to any existing application model)
2. Inside the E4WorkbenchModelEditor, select the XMI tab
3. Select the search field and search for any text shown in the XMI (e.g. "addons") -> The problem happens, the highlighting is always one character behind the search text

I've tried adding some tests for this PR, but I could not find any test plugin for org.eclipse.e4.tools.emf.ui.

<img width="1093" height="104" alt="image" src="https://github.com/user-attachments/assets/321cf5e4-886c-4a11-ae8d-670eb1bb533b" />

Should I create a follow-up PR adding a new test plugin with some tests for this PR?
