### PR TITLE
Fixes corruption of e4xmi file during class renaming in a setup with top level Maven project

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.editor3x/src/org/eclipse/e4/tools/emf/editor3x/refactorparticipants/RefactorParticipantDelegate.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.editor3x/src/org/eclipse/e4/tools/emf/editor3x/refactorparticipants/RefactorParticipantDelegate.java
@@ -62,6 +62,9 @@ class RefactorParticipantDelegate {
 			@Override
 			public boolean acceptPatternMatch(TextSearchMatchAccess matchAccess) throws CoreException {
 				final IFile file = matchAccess.getFile();
+				if (isFileAlreadyIncluded(file)) {
+					return false;
+				}
 				TextFileChange change = changes.get(file);
 
 				if (change == null) {
@@ -104,6 +107,25 @@ class RefactorParticipantDelegate {
 				change.addTextEditGroup(new TextEditGroup(E4_MODEL_CHANGES,
 						edit));
 				return true;
+			}
+
+			/**
+			 * Exclude files with their sub project paths that are already
+			 * included with their full workspace path or the other way around.
+			 *
+			 * @param file
+			 *            a file to be tested
+			 * @return true if the file is already included in the
+			 *         {@code changes} list
+			 */
+			private boolean isFileAlreadyIncluded(IFile file) {
+				boolean match = changes.entrySet().stream() //
+						.anyMatch(e -> e.getKey().getFullPath().toOSString().endsWith(file.getFullPath().toOSString()) //
+								|| file.getFullPath().toOSString().endsWith(e.getKey().getFullPath().toOSString()));
+				if (match) {
+					return true;
+				}
+				return false;
 			}
 		};
 


### PR DESCRIPTION
The corruption happens in a setup with a top level Maven project and plug-in projects in sub directories (eg bundles).  
If eg the name of a Java handler class is renamed in the Java file
- the e4xmi file is found twice with
  - full workspace path
  - plug-in project path

This leads to 2 changes in one e4xmi file with the same text, offset and length.  
If the old and new names are of different length the corruption occurs.

This fix skips the file if any of the paths (workspace or project) are already included for renaming.

