### PR TITLE
Group target content by Location by default

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
@@ -209,7 +209,7 @@ public class TargetContentsGroup {
 	 * @param toolkit toolkit to create controls with
 	 */
 	protected void createFormContents(Composite parent, FormToolkit toolkit) {
-		fGrouping = GROUP_BY_NONE;
+		fGrouping = GROUP_BY_CONTAINER;
 
 		Composite comp = toolkit.createComposite(parent);
 		GridLayout layout = new GridLayout(2, false);
@@ -236,7 +236,7 @@ public class TargetContentsGroup {
 	 * @param parent parent composite
 	 */
 	protected void createDialogContents(Composite parent) {
-		fGrouping = GROUP_BY_NONE;
+		fGrouping = GROUP_BY_CONTAINER;
 
 		Composite comp = SWTFactory.createComposite(parent, 2, 1, GridData.FILL_BOTH, 0, 0);
 
@@ -411,7 +411,7 @@ public class TargetContentsGroup {
 			fGroupComboPart.setItems(new String[] {Messages.TargetContentsGroup_1, Messages.TargetContentsGroup_2, Messages.TargetContentsGroup_3});
 			fGroupComboPart.setVisibleItemCount(30);
 			fGroupComboPart.addSelectionListener(widgetSelectedAdapter(e -> handleGroupChange()));
-			fGroupComboPart.select(0);
+			fGroupComboPart.select(GROUP_BY_CONTAINER);
 
 		} else {
 			Composite buttonComp = SWTFactory.createComposite(parent, 1, 1, GridData.FILL_VERTICAL, 0, 0);
@@ -462,7 +462,7 @@ public class TargetContentsGroup {
 			gd.horizontalIndent = 10;
 			fGroupCombo.setLayoutData(gd);
 			fGroupCombo.addSelectionListener(widgetSelectedAdapter(e -> handleGroupChange()));
-			fGroupCombo.select(0);
+			fGroupCombo.select(GROUP_BY_CONTAINER);
 		}
 
 		fSelectButton.addSelectionListener(widgetSelectedAdapter(e -> {


### PR DESCRIPTION
## Summary

- In the Content tab of the target-definition editor, default the "Group by" combo to **Location** instead of **None**.
- Makes it immediately obvious where each resolved bundle originates when a target has multiple locations, without adding any extra label text.

Alternative to #2296 (which suffixed the location to every bundle label). Based on review feedback that "sort/group by location" already answers the "where is this plug-in coming from?" question.

## Test plan
- [ ] Open a `.target` file in the editor, switch to the Content tab, verify that bundles are grouped by their originating location by default.
- [ ] Verify the "Group by" combo can still be switched to `None` / `File Path` and back.
- [ ] Verify feature mode still disables the grouping combo as before.