### PR TITLE
Enable copying entries from the target editor Content tab

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
@@ -73,6 +73,8 @@ import org.eclipse.pde.internal.ui.shared.CachedCheckboxTreeViewer;
 import org.eclipse.pde.internal.ui.shared.FilteredCheckboxTree;
 import org.eclipse.pde.internal.ui.wizards.target.TargetDefinitionContentPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -309,6 +311,16 @@ public class TargetContentsGroup {
 
 		});
 
+		CopyTreeSelectionAction copySelectionAction = new CopyTreeSelectionAction(fTree.getTree());
+		fTree.getTree().addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				if (e.keyCode == 'c' && (e.stateMask & SWT.CTRL) != 0) {
+					copySelectionAction.run();
+				}
+			}
+		});
+
 		fMenuManager = new MenuManager();
 		fMenuManager.add(new Action(Messages.TargetContentsGroup_collapseAll, PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_ELCL_COLLAPSEALL)) {
 			@Override
@@ -316,6 +328,7 @@ public class TargetContentsGroup {
 				fTree.collapseAll();
 			}
 		});
+		fMenuManager.add(copySelectionAction);
 		fMenuManager.add(new CopyLocationAction(fTree));
 		Menu contextMenu = fMenuManager.createContextMenu(tree);
 		fTree.getTree().setMenu(contextMenu);


### PR DESCRIPTION
## Summary

- Wire the existing `CopyTreeSelectionAction` into the Content tab of the target-definition editor (`TargetContentsGroup`), mirroring what is already done on the Locations tab (`TargetLocationsGroup`).
- Entries can now be copied from the Content tab via the context menu or **Ctrl+C**, with support for multi-selection and expanded children (parent/child dedup is handled by the action).

## Test plan
- [ ] Open a `.target` file and switch to the Content tab.
- [ ] Select one or more bundles and verify the context menu shows **Copy** and copies the selection to the clipboard.
- [ ] With a selection active, press **Ctrl+C** and paste — verify the selected entries are on the clipboard.
- [ ] Expand a group, select the group, copy, and verify children appear indented in the copied text.