### PR TITLE
Remove unused global Display filter from E4 ModelEditor

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ModelEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ModelEditor.java
@@ -239,7 +239,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -371,8 +370,6 @@ public class ModelEditor implements IGotoObject {
 
 	private AbstractComponentEditor<?> currentEditor;
 
-	private Listener keyListener;
-
 	private CTabFolder editorTabFolder;
 
 	private boolean mod1Down = false;
@@ -437,15 +434,6 @@ public class ModelEditor implements IGotoObject {
 
 	@PostConstruct
 	void postCreate(Composite composite) {
-		if (project == null) {
-			keyListener = event -> {
-				if ((event.stateMask & SWT.ALT) == SWT.ALT) {
-					findAndHighlight(context.get(Display.class).getFocusControl());
-				}
-			};
-			context.get(Display.class).addFilter(SWT.MouseUp, keyListener);
-		}
-
 		context.set(ModelEditor.class, this);
 		context.set(IResourcePool.class, resourcePool);
 		context.set(EditingDomain.class, modelProvider.getEditingDomain());
@@ -512,39 +500,6 @@ public class ModelEditor implements IGotoObject {
 	 */
 	public static int getTabIndex(CTabItem tabItem) {
 		return Arrays.asList(tabItem.getParent().getItems()).indexOf(tabItem);
-	}
-
-	private void findAndHighlight(Control control) {
-		if (control != null) {
-			MApplicationElement m = findModelElement(control);
-			final MApplicationElement o = m;
-			if (m != null) {
-				final List<MApplicationElement> l = new ArrayList<>();
-				do {
-					l.add(m);
-					m = (MApplicationElement) ((EObject) m).eContainer();
-				} while (m != null);
-
-				if (o instanceof MPart) {
-					System.err.println(getClass().getName() + ".findAndHighLight: " + o); //$NON-NLS-1$
-					System.err
-					.println(getClass().getName() + ".findAndHighLight: " + ((EObject) o).eContainingFeature()); //$NON-NLS-1$
-				}
-
-				viewer.setSelection(new StructuredSelection(o));
-			}
-		}
-	}
-
-	private MApplicationElement findModelElement(Control control) {
-		do {
-			if (control.getData("modelElement") != null) { //$NON-NLS-1$
-				return (MApplicationElement) control.getData("modelElement"); //$NON-NLS-1$
-			}
-			control = control.getParent();
-		} while (control != null);
-
-		return null;
 	}
 
 	private XmiTab createXMITab(Composite composite) {
@@ -1531,9 +1486,6 @@ public class ModelEditor implements IGotoObject {
 			e.printStackTrace();
 		}
 
-		if (project == null) {
-			context.get(Display.class).removeFilter(SWT.MouseUp, keyListener);
-		}
 		if (xmiTab != null) {
 			ContextInjectionFactory.uninject(xmiTab, xmiTab.getContext());
 		}

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ModelEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ModelEditor.java
@@ -238,7 +238,6 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;


### PR DESCRIPTION
## Summary

`ModelEditor` (parent of `ApplicationModelEditor`, which is the `.e4xmi` file editor used by `E4WorkbenchModelEditor`) installed a **workbench-global** `Display.addFilter(SWT.MouseUp, ...)` on every editor open. The filter's purpose was an Alt+click navigation feature: Alt+clicking any rendered workbench control should jump the editor to the corresponding model element.

The feature is dead code:

- The filter's helper `findModelElement` walks up the SWT parent chain looking for `control.getData("modelElement")`, but **nothing in the entire repository ever sets that key** — `grep -rn 'setData.*"modelElement"'` returns zero matches.
- Therefore `findAndHighlight` is always a no-op and the Alt+click branch never fires.
- The `if (project == null)` guard around the install is always true because `DIEditorPart` never injects the `EDITORPROJECT` context key.

Net effect today: every mouse-up across the entire workbench runs through a dead SWT filter while any `Application.e4xmi` editor is open, plus a stray `System.err.println` on any Alt+click that happens to have a non-null focus control — harmless in theory but a plausible contributor to reports of double-click intermittently failing in other views (e.g. Project Explorer) until the E4 editor is closed.

This PR deletes:
- The filter install in `@PostConstruct postCreate` and the matching remove in `@PreDestroy dispose`.
- The `keyListener` field and the unused `Listener` import.
- The now-orphaned `findAndHighlight` and `findModelElement` helpers (including the `System.err.println` debug lines).

No behavior change for any working feature. 48 lines removed, 0 added.

## Test plan
- [ ] Open an `Application.e4xmi` file in the E4 Model editor — editor opens and behaves as before.
- [ ] With the E4 editor open, double-click other files in Project Explorer and confirm they open correctly.
- [ ] Switch tabs between Form / List / XMI in the editor — no regressions.
- [ ] Close the editor — no exceptions in the log.