### PR TITLE
Prefer native Combo over CCombo in PDE form parts

### DIFF
--- a/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/parts/ComboPart.java
+++ b/ds/org.eclipse.pde.ds.ui/src/org/eclipse/pde/internal/ds/ui/parts/ComboPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 Code 9 Corporation and others.
+ * Copyright (c) 2008, 2026 Code 9 Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ds.ui.parts;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Combo;
@@ -26,41 +24,25 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 
 public class ComboPart {
 
-	protected Control combo;
+	protected Combo combo;
 
 	public ComboPart() {
 	}
 
 	public void addSelectionListener(SelectionListener listener) {
-		if (combo instanceof Combo) {
-			((Combo) combo).addSelectionListener(listener);
-		} else {
-			((CCombo) combo).addSelectionListener(listener);
-		}
+		combo.addSelectionListener(listener);
 	}
 
 	public int indexOf(String item) {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).indexOf(item);
-		}
-
-		return ((CCombo) combo).indexOf(item);
+		return combo.indexOf(item);
 	}
 
 	public void addModifyListener(ModifyListener listener) {
-		if (combo instanceof Combo) {
-			((Combo) combo).addModifyListener(listener);
-		} else {
-			((CCombo) combo).addModifyListener(listener);
-		}
+		combo.addModifyListener(listener);
 	}
 
 	public void createControl(Composite parent, FormToolkit toolkit, int style) {
-		if (toolkit.getBorderStyle() == SWT.BORDER) {
-			combo = new Combo(parent, style | SWT.BORDER);
-		} else {
-			combo = new CCombo(parent, style | SWT.FLAT);
-		}
+		combo = new Combo(parent, style | toolkit.getBorderStyle());
 		toolkit.adapt(combo, true, false);
 	}
 
@@ -69,91 +51,49 @@ public class ComboPart {
 	}
 
 	public int getSelectionIndex() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getSelectionIndex();
-		}
-		return ((CCombo) combo).getSelectionIndex();
+		return combo.getSelectionIndex();
 	}
 
 	public void add(String item, int index) {
-		if (combo instanceof Combo) {
-			((Combo) combo).add(item, index);
-		} else {
-			((CCombo) combo).add(item, index);
-		}
+		combo.add(item, index);
 	}
 
 	public void add(String item) {
-		if (combo instanceof Combo) {
-			((Combo) combo).add(item);
-		} else {
-			((CCombo) combo).add(item);
-		}
+		combo.add(item);
 	}
 
 	public void remove(int index) {
-		// Ensure the index is valid
 		if ((index < 0) || (index >= getItemCount())) {
 			return;
 		}
-		// Remove the item from the specified index
-		if (combo instanceof Combo) {
-			((Combo) combo).remove(index);
-		} else {
-			((CCombo) combo).remove(index);
-		}
+		combo.remove(index);
 	}
 
 	public void select(int index) {
-		if (combo instanceof Combo) {
-			((Combo) combo).select(index);
-		} else {
-			((CCombo) combo).select(index);
-		}
+		combo.select(index);
 	}
 
 	public String getSelection() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getText().trim();
-		}
-		return ((CCombo) combo).getText().trim();
+		return combo.getText().trim();
 	}
 
 	public void setText(String text) {
-		if (combo instanceof Combo) {
-			((Combo) combo).setText(text);
-		} else {
-			((CCombo) combo).setText(text);
-		}
+		combo.setText(text);
 	}
 
 	public void setItems(String[] items) {
-		if (combo instanceof Combo) {
-			((Combo) combo).setItems(items);
-		} else {
-			((CCombo) combo).setItems(items);
-		}
+		combo.setItems(items);
 	}
 
 	public void setEnabled(boolean enabled) {
-		if (combo instanceof Combo) {
-			combo.setEnabled(enabled);
-		} else {
-			((CCombo) combo).setEnabled(enabled);
-		}
+		combo.setEnabled(enabled);
 	}
 
 	public int getItemCount() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getItemCount();
-		}
-		return ((CCombo) combo).getItemCount();
+		return combo.getItemCount();
 	}
 
 	public String[] getItems() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getItems();
-		}
-		return ((CCombo) combo).getItems();
+		return combo.getItems();
 	}
 }

--- a/ua/org.eclipse.pde.ua.ui/src/org/eclipse/pde/internal/ua/ui/editor/cheatsheet/simple/details/SimpleCSCommandComboPart.java
+++ b/ua/org.eclipse.pde.ua.ui/src/org/eclipse/pde/internal/ua/ui/editor/cheatsheet/simple/details/SimpleCSCommandComboPart.java
@@ -22,7 +22,6 @@ import org.eclipse.pde.internal.ua.ui.editor.cheatsheet.simple.SimpleCSCommandMa
 import org.eclipse.pde.internal.ui.parts.ComboPart;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
-import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
@@ -39,11 +38,7 @@ public class SimpleCSCommandComboPart extends ComboPart implements ISimpleCSComm
 	}
 
 	public void addDisposeListener(DisposeListener listener) {
-		if (combo == null) {
-			return;
-		} else if (combo instanceof Combo) {
-			combo.addDisposeListener(listener);
-		} else {
+		if (combo != null) {
 			combo.addDisposeListener(listener);
 		}
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ArgumentsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ArgumentsSection.java
@@ -34,7 +34,6 @@ import org.eclipse.pde.internal.ui.editor.PDESection;
 import org.eclipse.pde.internal.ui.parts.ComboViewerPart;
 import org.eclipse.pde.internal.ui.parts.FormEntry;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.dnd.Clipboard;
@@ -42,7 +41,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IActionBars;
@@ -123,12 +121,8 @@ public class ArgumentsSection extends PDESection {
 		fArchCombo.createControl(archParent, toolkit, SWT.SINGLE | SWT.BORDER | SWT.READ_ONLY);
 		fArchCombo.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false));
 		fArchCombo.setItems(Arrays.stream(TAB_ARCHLABELS).filter(Objects::nonNull).toArray(String[]::new));
-		Control archComboControl = fArchCombo.getControl();
-		if (archComboControl instanceof Combo) {
-			((Combo) archComboControl).select(fLastArch[fLastTab]);
-		} else {
-			((CCombo) archComboControl).select(fLastArch[fLastTab]);
-		}
+		Combo archComboControl = (Combo) fArchCombo.getControl();
+		archComboControl.select(fLastArch[fLastTab]);
 		fArchCombo.addSelectionChangedListener(event -> {
 			if (fProgramArgs.isDirty()) {
 				fProgramArgs.commit();
@@ -136,14 +130,7 @@ public class ArgumentsSection extends PDESection {
 			if (fVMArgs.isDirty()) {
 				fVMArgs.commit();
 			}
-			// remember the change in combo for currently selected platform
-			Control fArchComboControl = fArchCombo.getControl();
-			if (fArchComboControl instanceof Combo) {
-				fLastArch[fLastTab] = ((Combo) fArchComboControl).getSelectionIndex();
-			} else {
-				fLastArch[fLastTab] = ((CCombo) fArchComboControl).getSelectionIndex();
-			}
-
+			fLastArch[fLastTab] = ((Combo) fArchCombo.getControl()).getSelectionIndex();
 			refresh();
 		});
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/EnvironmentSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/EnvironmentSection.java
@@ -25,14 +25,12 @@ import org.eclipse.pde.internal.ui.editor.FormLayoutFactory;
 import org.eclipse.pde.internal.ui.parts.ComboPart;
 import org.eclipse.pde.internal.ui.util.LocaleUtil;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IFormColors;
@@ -254,14 +252,7 @@ public class EnvironmentSection extends SectionPart {
 	 * @return text of the widget or <code>null</code>
 	 */
 	private String getText(ComboPart combo) {
-		String text;
-		Control control = combo.getControl();
-		if (control instanceof Combo) {
-			text = ((Combo) control).getText();
-		} else {
-			text = ((CCombo) control).getText();
-		}
-		text = text.trim();
+		String text = ((Combo) combo.getControl()).getText().trim();
 		if (text.length() == 0) {
 			return null;
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ComboPart.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ComboPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2003, 2009 IBM Corporation and others.
+ *  Copyright (c) 2003, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.parts;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Combo;
@@ -24,41 +22,25 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 
 public class ComboPart {
 
-	protected Control combo;
+	protected Combo combo;
 
 	public ComboPart() {
 	}
 
 	public void addSelectionListener(SelectionListener listener) {
-		if (combo instanceof Combo) {
-			((Combo) combo).addSelectionListener(listener);
-		} else {
-			((CCombo) combo).addSelectionListener(listener);
-		}
+		combo.addSelectionListener(listener);
 	}
 
 	public int indexOf(String item) {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).indexOf(item);
-		}
-
-		return ((CCombo) combo).indexOf(item);
+		return combo.indexOf(item);
 	}
 
 	public void addModifyListener(ModifyListener listener) {
-		if (combo instanceof Combo) {
-			((Combo) combo).addModifyListener(listener);
-		} else {
-			((CCombo) combo).addModifyListener(listener);
-		}
+		combo.addModifyListener(listener);
 	}
 
 	public void createControl(Composite parent, FormToolkit toolkit, int style) {
-		if (toolkit.getBorderStyle() == SWT.BORDER) {
-			combo = new Combo(parent, style | SWT.BORDER);
-		} else {
-			combo = new CCombo(parent, style | SWT.FLAT);
-		}
+		combo = new Combo(parent, style | toolkit.getBorderStyle());
 		toolkit.adapt(combo, true, false);
 	}
 
@@ -67,99 +49,53 @@ public class ComboPart {
 	}
 
 	public int getSelectionIndex() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getSelectionIndex();
-		}
-		return ((CCombo) combo).getSelectionIndex();
+		return combo.getSelectionIndex();
 	}
 
 	public void add(String item, int index) {
-		if (combo instanceof Combo) {
-			((Combo) combo).add(item, index);
-		} else {
-			((CCombo) combo).add(item, index);
-		}
+		combo.add(item, index);
 	}
 
 	public void add(String item) {
-		if (combo instanceof Combo) {
-			((Combo) combo).add(item);
-		} else {
-			((CCombo) combo).add(item);
-		}
+		combo.add(item);
 	}
 
 	public void remove(int index) {
-		// Ensure the index is valid
 		if ((index < 0) || (index >= getItemCount())) {
 			return;
 		}
-		// Remove the item from the specified index
-		if (combo instanceof Combo) {
-			((Combo) combo).remove(index);
-		} else {
-			((CCombo) combo).remove(index);
-		}
+		combo.remove(index);
 	}
 
 	public void select(int index) {
-		if (combo instanceof Combo) {
-			((Combo) combo).select(index);
-		} else {
-			((CCombo) combo).select(index);
-		}
+		combo.select(index);
 	}
 
 	public String getSelection() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getText().trim();
-		}
-		return ((CCombo) combo).getText().trim();
+		return combo.getText().trim();
 	}
 
 	public void setText(String text) {
-		if (combo instanceof Combo) {
-			((Combo) combo).setText(text);
-		} else {
-			((CCombo) combo).setText(text);
-		}
+		combo.setText(text);
 	}
 
 	public void setItems(String[] items) {
-		if (combo instanceof Combo) {
-			((Combo) combo).setItems(items);
-		} else {
-			((CCombo) combo).setItems(items);
-		}
+		combo.setItems(items);
 	}
 
 	public void setEnabled(boolean enabled) {
-		if (combo instanceof Combo) {
-			combo.setEnabled(enabled);
-		} else {
-			((CCombo) combo).setEnabled(enabled);
-		}
+		combo.setEnabled(enabled);
 	}
 
 	public int getItemCount() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getItemCount();
-		}
-		return ((CCombo) combo).getItemCount();
+		return combo.getItemCount();
 	}
 
 	public String[] getItems() {
-		if (combo instanceof Combo) {
-			return ((Combo) combo).getItems();
-		}
-		return ((CCombo) combo).getItems();
+		return combo.getItems();
 	}
 
 	public void setVisibleItemCount(int count) {
-		if (combo instanceof Combo) {
-			((Combo) combo).setVisibleItemCount(count);
-		} else {
-			((CCombo) combo).setVisibleItemCount(count);
-		}
+		combo.setVisibleItemCount(count);
 	}
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ComboViewerPart.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/ComboViewerPart.java
@@ -26,15 +26,13 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
 public class ComboViewerPart {
-	private Control fCombo;
+	private Combo fCombo;
 	private ComboViewer fComboViewer;
 	private List<Object> fObjects;
 
@@ -47,13 +45,8 @@ public class ComboViewerPart {
 	}
 
 	public void createControl(Composite parent, FormToolkit toolkit, int style) {
-		if (toolkit.getBorderStyle() == SWT.BORDER) {
-			fCombo = new Combo(parent, style | SWT.BORDER);
-			fComboViewer = new ComboViewer((Combo) fCombo);
-		} else {
-			fCombo = new CCombo(parent, style | SWT.FLAT);
-			fComboViewer = new ComboViewer((CCombo) fCombo);
-		}
+		fCombo = new Combo(parent, style | toolkit.getBorderStyle());
+		fComboViewer = new ComboViewer(fCombo);
 
 		fObjects = new ArrayList<>();
 		fComboViewer.setLabelProvider(new LabelProvider());


### PR DESCRIPTION
## Summary
- `ComboPart` (PDE UI and DS UI copies) and `ComboViewerPart` always create a native `Combo` instead of branching to `CCombo` when the `FormToolkit` is borderless.
- Dead `instanceof Combo`/`(CCombo)` downcast branches removed from `ArgumentsSection` and `EnvironmentSection`; unused `CCombo`/`Control` imports dropped.
- `CCombo` is kept only where structurally required — Table/Tree cell editors in `AbstractPluginBlock`, `RepositoryReferenceSection`, `UpdatesSection` and `PluginConfigurationSection`.

`CCombo`'s primary advantage over native `Combo` is a settable height (per its Javadoc), which PDE form editors don't need. Native `Combo` renders consistently with current OS themes on Linux/GTK and macOS, where `CCombo` looks dated.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/2304

## Test plan
- [x] Open a target-definition editor → **Environment** tab: OS/WS/Arch/NL dropdowns render as native combos and still select/persist values.
- [x] Open a product editor → **Launching** tab: architecture dropdown in *Program and VM Arguments* section still switches per-arch arguments.
- [x] Open a product editor → **Overview** tab → extension ID combo (`ExtensionIdComboPart`) still adds/removes IDs correctly.
- [x] Open a DS component (`.xml`): **Options** section → Configuration Policy dropdown; *Add/Edit Reference* dialog → Cardinality/Policy dropdowns; *Add/Edit Property* dialog → Type dropdown — all render as native combos.
- [x] Launcher *Plug-ins* tab: Start Level / Auto-Start cell editors still open (still `CCombo`, intentionally).