### PR TITLE
Wire target editor Copy through workbench binding service

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/ContentSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/ContentSection.java
@@ -67,6 +67,7 @@ public class ContentSection extends SectionPart {
 		client.setLayoutData(new GridData(GridData.FILL_BOTH | GridData.GRAB_VERTICAL));
 
 		fContentGroup = TargetContentsGroup.createInForm(client, toolkit);
+		fContentGroup.hookGlobalActions(fEditor.getEditorSite().getActionBars());
 		fEditor.getTargetChangedListener().setContentTree(fContentGroup);
 		fContentGroup.addTargetChangedListener(fEditor.getTargetChangedListener());
 		fContentGroup.addTargetChangedListener((definition, source, resolve, forceResolve) -> {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/LocationsSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/LocationsSection.java
@@ -67,6 +67,7 @@ public class LocationsSection extends SectionPart {
 		client.setLayoutData(new GridData(GridData.FILL_BOTH | GridData.GRAB_VERTICAL));
 
 		fContainerGroup = TargetLocationsGroup.createInForm(client, toolkit);
+		fContainerGroup.hookGlobalActions(fEditor.getEditorSite().getActionBars());
 		fEditor.getTargetChangedListener().setLocationTree(fContainerGroup);
 		fContainerGroup.addTargetChangedListener(fEditor.getTargetChangedListener());
 		fContainerGroup.addTargetReloadListener(fEditor.getTargetChangedListener());

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/CopyTreeSelectionAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/CopyTreeSelectionAction.java
@@ -21,8 +21,11 @@ import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
@@ -40,6 +43,28 @@ class CopyTreeSelectionAction extends Action {
 		setDisabledImageDescriptor(workbenchImages.getImageDescriptor(ISharedImages.IMG_TOOL_COPY_DISABLED));
 
 		setActionDefinitionId(ActionFactory.COPY.getCommandId());
+	}
+
+	/**
+	 * Installs {@code copyAction} as the {@link ActionFactory#COPY global copy
+	 * handler} on {@code bars} while {@code tree} has focus, so that the
+	 * platform binding service delivers the platform-correct Copy keystroke
+	 * (Ctrl+C / Cmd+C / user-remapped binding).
+	 */
+	static void hookAsGlobalCopyHandler(Tree tree, Action copyAction, IActionBars bars) {
+		tree.addFocusListener(new FocusAdapter() {
+			@Override
+			public void focusGained(FocusEvent e) {
+				bars.setGlobalActionHandler(ActionFactory.COPY.getId(), copyAction);
+				bars.updateActionBars();
+			}
+
+			@Override
+			public void focusLost(FocusEvent e) {
+				bars.setGlobalActionHandler(ActionFactory.COPY.getId(), null);
+				bars.updateActionBars();
+			}
+		});
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetContentsGroup.java
@@ -73,8 +73,6 @@ import org.eclipse.pde.internal.ui.shared.CachedCheckboxTreeViewer;
 import org.eclipse.pde.internal.ui.shared.FilteredCheckboxTree;
 import org.eclipse.pde.internal.ui.wizards.target.TargetDefinitionContentPage;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.KeyAdapter;
-import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -82,8 +80,10 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Menu;
+import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.osgi.framework.BundleException;
 
@@ -116,6 +116,7 @@ public class TargetContentsGroup {
 	private Label fGroupLabel;
 	private Combo fGroupCombo;
 	private ComboPart fGroupComboPart;
+	private CopyTreeSelectionAction fCopySelectionAction;
 
 	private ViewerFilter fSourceFilter;
 	private ViewerFilter fPluginFilter;
@@ -183,6 +184,16 @@ public class TargetContentsGroup {
 	 */
 	public void addTargetChangedListener(ITargetChangedListener listener) {
 		fChangeListeners.add(listener);
+	}
+
+	/**
+	 * Installs the copy action as the {@link ActionFactory#COPY global copy
+	 * handler} for the hosting editor while the tree has focus, so that the
+	 * platform binding service delivers the platform-correct Copy keystroke
+	 * (Ctrl+C / Cmd+C / user-remapped binding).
+	 */
+	public void hookGlobalActions(IActionBars bars) {
+		CopyTreeSelectionAction.hookAsGlobalCopyHandler(fTree.getTree(), fCopySelectionAction, bars);
 	}
 
 	/**
@@ -311,15 +322,7 @@ public class TargetContentsGroup {
 
 		});
 
-		CopyTreeSelectionAction copySelectionAction = new CopyTreeSelectionAction(fTree.getTree());
-		fTree.getTree().addKeyListener(new KeyAdapter() {
-			@Override
-			public void keyPressed(KeyEvent e) {
-				if (e.keyCode == 'c' && (e.stateMask & SWT.CTRL) != 0) {
-					copySelectionAction.run();
-				}
-			}
-		});
+		fCopySelectionAction = new CopyTreeSelectionAction(fTree.getTree());
 
 		fMenuManager = new MenuManager();
 		fMenuManager.add(new Action(Messages.TargetContentsGroup_collapseAll, PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_ELCL_COLLAPSEALL)) {
@@ -328,7 +331,7 @@ public class TargetContentsGroup {
 				fTree.collapseAll();
 			}
 		});
-		fMenuManager.add(copySelectionAction);
+		fMenuManager.add(fCopySelectionAction);
 		fMenuManager.add(new CopyLocationAction(fTree));
 		Menu contextMenu = fMenuManager.createContextMenu(tree);
 		fTree.getTree().setMenu(contextMenu);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetLocationsGroup.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/TargetLocationsGroup.java
@@ -64,6 +64,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.progress.UIJob;
 
@@ -269,11 +271,19 @@ public class TargetLocationsGroup {
 			public void keyPressed(KeyEvent e) {
 				if (e.keyCode == SWT.DEL && fRemoveButton.getEnabled()) {
 					handleRemove();
-				} else if (e.keyCode == 'c' && (e.stateMask & SWT.CTRL) != 0) {
-					fCopySelectionAction.run();
 				}
 			}
 		});
+	}
+
+	/**
+	 * Installs the copy action as the {@link ActionFactory#COPY global copy
+	 * handler} for the hosting editor while the tree has focus, so that the
+	 * platform binding service delivers the platform-correct Copy keystroke
+	 * (Ctrl+C / Cmd+C / user-remapped binding).
+	 */
+	public void hookGlobalActions(IActionBars bars) {
+		CopyTreeSelectionAction.hookAsGlobalCopyHandler(fTreeViewer.getTree(), fCopySelectionAction, bars);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Addresses review feedback from @jonahgraham and @merks on #2302.

Both `TargetContentsGroup` and `TargetLocationsGroup` had a `KeyAdapter` that hard-coded `e.keyCode == 'c' && (e.stateMask & SWT.CTRL) != 0` to run the copy action. That check:

- is wrong on macOS (should be Cmd+C, not Ctrl+C),
- fires for any modifier combination that has Ctrl set (e.g. **Ctrl+Alt+C**, Ctrl+Shift+C, ...),
- bypasses any user-configured keybinding.

`CopyTreeSelectionAction` already declares `setActionDefinitionId(ActionFactory.COPY.getCommandId())`, so the proper wiring is to register it as the editor's global `ActionFactory.COPY` handler while the tree has focus, and let the platform binding service deliver the correct keystroke.

### Changes

- Drop the `KeyAdapter` Ctrl+C branch in both groups (the `SWT.DEL` remove branch in `TargetLocationsGroup` stays).
- Promote the copy action to a field in `TargetContentsGroup`.
- Add `hookGlobalActions(IActionBars)` on both groups — on tree focus gained install the COPY handler, on focus lost clear it, so the binding doesn't hijack Copy from other widgets in the editor.
- Call `hookGlobalActions(...)` from `ContentSection` and `LocationsSection` with `fEditor.getEditorSite().getActionBars()`.

### Tradeoff

The wizard dialog path (`TargetDefinitionContentPage`, using `createInDialog`) has no `IActionBars` and therefore loses the Ctrl+C keystroke on the tree. **Right-click → Copy still works** there, since the context menu is wired identically. A follow-up can add a dialog-scoped binding if that path turns out to matter.

## Test plan

- [ ] Open a `.target` file → Content tab. Select one or more bundles, press the platform Copy shortcut (Ctrl+C on Linux/Windows, Cmd+C on macOS), paste into an editor — selection copies.
- [ ] Same on the Locations tab.
- [ ] With focus in a combo/text field in the editor, press Ctrl+C — does not trigger the tree copy action.
- [ ] Remap `org.eclipse.ui.edit.copy` in **Preferences → General → Keys**, focus the tree, use the new binding — works.
- [ ] Right-click → Copy still works on both tabs (editor and wizard).
- [ ] In `TargetLocationsGroup`, pressing `Delete` on a selected location still triggers remove.