### PR TITLE
Modernize PDEPlugin logging helpers to use ILog.get()

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPlugin.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEPlugin.java
@@ -21,6 +21,7 @@ import java.util.Hashtable;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -141,7 +142,7 @@ public class PDEPlugin extends AbstractUIPlugin implements IPDEUIConstants {
 	 * @param status status to add to the error log
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	/**
@@ -149,7 +150,7 @@ public class PDEPlugin extends AbstractUIPlugin implements IPDEUIConstants {
 	 * @param message message to add to the error log
 	 */
 	public static void log(String message) {
-		log(Status.error(message));
+		ILog.get().error(message);
 	}
 
 	public static void logException(Throwable e, final String title, String message) {
@@ -173,7 +174,7 @@ public class PDEPlugin extends AbstractUIPlugin implements IPDEUIConstants {
 			}
 			status = Status.error(message, e);
 		}
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 		Display display = SWTUtil.getStandardDisplay();
 		final IStatus fstatus = status;
 		display.asyncExec(() -> ErrorDialog.openError(null, title, null, fstatus));
@@ -187,17 +188,11 @@ public class PDEPlugin extends AbstractUIPlugin implements IPDEUIConstants {
 		if (e instanceof InvocationTargetException) {
 			e = ((InvocationTargetException) e).getTargetException();
 		}
-		IStatus status = null;
-		if (e instanceof CoreException ce) {
-			// Re-use status only if it has attached exception with the stack trace
-			if (ce.getStatus().getException() != null) {
-				status = ce.getStatus();
-			}
+		if (e instanceof CoreException ce && ce.getStatus().getException() != null) {
+			ILog.get().log(ce.getStatus());
+		} else {
+			ILog.get().error(e.getMessage(), e);
 		}
-		if (status == null) {
-			status = Status.error(e.getMessage(), e);
-		}
-		log(status);
 	}
 
 	public FormColors getFormColors(Display display) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/NoLineTerminationResolution.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/NoLineTerminationResolution.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.pde.internal.core.text.bundle.BundleModel;
+import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 
 /**
@@ -68,7 +69,7 @@ public class NoLineTerminationResolution extends AbstractManifestMarkerResolutio
 				}
 				doc.replace(doc.getLength(), 0, lineDelimiter);
 			} catch (BadLocationException e) {
-				e.printStackTrace();
+				PDEPlugin.log(e);
 			}
 		}
 	}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/ManifestTypeMoveParticipant.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/refactoring/ManifestTypeMoveParticipant.java
@@ -30,6 +30,7 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
 import org.eclipse.pde.internal.core.project.PDEProject;
+import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 
 public class ManifestTypeMoveParticipant extends PDEMoveParticipant {
@@ -120,7 +121,7 @@ public class ManifestTypeMoveParticipant extends PDEMoveParticipant {
 					}
 				}
 			} catch (CoreException e) {
-				e.printStackTrace();
+				PDEPlugin.log(e);
 			}
 		}
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
@@ -38,6 +38,7 @@ import org.eclipse.jface.wizard.IWizardNode;
 import org.eclipse.pde.bnd.ui.templating.RepoTemplateLabelProvider;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
+import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEUIMessages;
 import org.eclipse.pde.internal.ui.elements.ElementList;
 import org.eclipse.pde.internal.ui.wizards.ListUtil;
@@ -200,7 +201,7 @@ public class TemplateListSelectionPage extends WizardListSelectionPage {
 						try (InputStream stream = helpContent.toURL().openStream()) {
 							return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
 						} catch (IOException e) {
-							e.printStackTrace();
+							PDEPlugin.log(e);
 							return PDEUIMessages.BaseWizardSelectionPage_noDesc;
 						}
 					});


### PR DESCRIPTION
Mirrors the `PDECore` cleanup (#2307) for the UI plugin. The `log` and `logException` helpers in `PDEPlugin` now use `ILog.get()` instead of building `Status` objects by hand and going through `getDefault().getLog()`. Public signatures are unchanged, so all ~385 call sites in `org.eclipse.pde.ui` continue to work. `InvocationTargetException` unwrapping, `CoreException` status reuse, and the `ErrorDialog` display in `logException` are all preserved.

Also replaces three stray `e.printStackTrace()` calls with `PDEPlugin.log(e)` in `NoLineTerminationResolution`, `ManifestTypeMoveParticipant`, and `TemplateListSelectionPage` so those exceptions actually reach the error log.