### PR TITLE
Simplify preference gathering in ShowAllPreferencesHandler

### DIFF
--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.BundleDefaultsScope;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IPreferenceNodeVisitor;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.di.annotations.Execute;
@@ -36,49 +35,30 @@ public class ShowAllPreferencesHandler {
 	@Execute
 	public void execute(Shell shell, IEventBroker eventBroker) {
 		Map<String, PreferenceNodeEntry> preferenceEntries = new HashMap<>();
-		IEclipsePreferences bundleDefaultsScopePreferences = BundleDefaultsScope.INSTANCE.getNode("");
-		IEclipsePreferences configurationScopePreferences = ConfigurationScope.INSTANCE.getNode("");
-		IEclipsePreferences defaultScopePreferences = DefaultScope.INSTANCE.getNode("");
-		IEclipsePreferences instanceScopePreferences = InstanceScope.INSTANCE.getNode("");
-		try {
-			bundleDefaultsScopePreferences.accept(new PrefereneGatherer(preferenceEntries));
-			configurationScopePreferences.accept(new PrefereneGatherer(preferenceEntries));
-			defaultScopePreferences.accept(new PrefereneGatherer(preferenceEntries));
-			instanceScopePreferences.accept(new PrefereneGatherer(preferenceEntries));
-		} catch (BackingStoreException e) {
-			ErrorDialog.openError(shell, "BackingStoreException", e.getLocalizedMessage(),
-					Status.error(e.getMessage()));
-		}
-		eventBroker.post(PreferenceSpyEventTopics.PREFERENCESPY_PREFERENCE_SHOW, preferenceEntries.values());
-	}
-
-	private static class PrefereneGatherer implements IPreferenceNodeVisitor {
-
-		private final Map<String, PreferenceNodeEntry> preferenceEntries;
-
-		public PrefereneGatherer(Map<String, PreferenceNodeEntry> preferenceEntries) {
-			this.preferenceEntries = preferenceEntries;
-		}
-
-		@Override
-		public boolean visit(IEclipsePreferences node) throws BackingStoreException {
+		IPreferenceNodeVisitor gatherer = node -> {
 			// only show nodes, which have changed keys
 			String[] keys = node.keys();
 			if (keys.length <= 0) {
 				return true;
 			}
-			PreferenceNodeEntry preferenceNodeEntry = preferenceEntries.get(node.absolutePath());
-			if (null == preferenceNodeEntry) {
-				preferenceNodeEntry = new PreferenceNodeEntry(node.absolutePath());
-				preferenceEntries.put(node.absolutePath(), preferenceNodeEntry);
-			}
+			PreferenceNodeEntry preferenceNodeEntry = preferenceEntries.computeIfAbsent(node.absolutePath(),
+					PreferenceNodeEntry::new);
 			for (String key : keys) {
 				String value = node.get(key, "*default*");
-				PreferenceEntry preferenceEntry = new PreferenceEntry(node.absolutePath(), key, value, value);
-				preferenceNodeEntry.addChildren(preferenceEntry);
+				preferenceNodeEntry.addChildren(new PreferenceEntry(node.absolutePath(), key, value, value));
 			}
 			return true;
+		};
+		try {
+			BundleDefaultsScope.INSTANCE.getNode("").accept(gatherer);
+			ConfigurationScope.INSTANCE.getNode("").accept(gatherer);
+			DefaultScope.INSTANCE.getNode("").accept(gatherer);
+			InstanceScope.INSTANCE.getNode("").accept(gatherer);
+		} catch (BackingStoreException e) {
+			ErrorDialog.openError(shell, "BackingStoreException", e.getLocalizedMessage(),
+					Status.error(e.getMessage()));
 		}
+		eventBroker.post(PreferenceSpyEventTopics.PREFERENCESPY_PREFERENCE_SHOW, preferenceEntries.values());
 	}
 
 }


### PR DESCRIPTION
Replaces the private `PrefereneGatherer` class with a single `IPreferenceNodeVisitor` lambda that is reused across all four scope nodes, and inlines the scope-node variables. The lambda also uses `computeIfAbsent` for the node-lookup. The behavior is unchanged but the handler is noticeably shorter and easier to read.

Fixes #561