### PR TITLE
Make transitive dependency classpath order deterministic

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -11,6 +11,7 @@
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Läubrich - add bnd support
+ *     Lars Vogel <Lars.Vogel@vogella.com> - deterministic classpath order for duplicate bundle symbolic names
  *******************************************************************************/
 package org.eclipse.pde.internal.core;
 
@@ -97,6 +98,11 @@ class RequiredPluginsClasspathContainer {
 
 	private static final Comparator<BundleDescription> BUNDLE_VERSION = Comparator
 			.comparing(BundleDescription::getVersion);
+
+	private static final Comparator<BundleDescription> SYMBOLIC_NAME_THEN_HIGHER_VERSION = Comparator
+			.comparing(BundleDescription::getSymbolicName)
+			.thenComparing(Comparator.comparing(BundleDescription::getVersion).reversed())
+			.thenComparingLong(BundleDescription::getBundleId);
 
 	private final IPluginModelBase fModel;
 	private final IBuild fBuild;
@@ -640,8 +646,11 @@ class RequiredPluginsClasspathContainer {
 	private static List<BundleDescription> collectRequirements(List<BundleDescription> roots) {
 		var closure = DependencyManager.findRequirementsClosure(roots, INCLUDE_OPTIONAL_DEPENDENCIES);
 		String systemBundleBSN = TargetPlatformHelper.getPDEState().getSystemBundle();
+		// Tie-break by higher version, then bundle id, so the classpath stays stable
+		// across IDE restarts when multiple bundles share a symbolic name
 		return closure.stream().filter(b -> !b.getSymbolicName().equals(systemBundleBSN))
-				.sorted(Comparator.comparing(BundleDescription::getSymbolicName)).toList();
+				.sorted(SYMBOLIC_NAME_THEN_HIGHER_VERSION)
+				.toList();
 	}
 
 	private void addSecondaryDependencies(BundleDescription desc, Set<BundleDescription> added,
@@ -685,7 +694,7 @@ class RequiredPluginsClasspathContainer {
 		String systemBundleBSN = TargetPlatformHelper.getPDEState().getSystemBundle();
 		Iterator<BundleDescription> transitiveDeps = closure.stream()
 				.filter(desc -> !desc.getSymbolicName().equals(systemBundleBSN))
-				.sorted(Comparator.comparing(BundleDescription::getSymbolicName)).iterator();
+				.sorted(SYMBOLIC_NAME_THEN_HIGHER_VERSION).iterator();
 		while (transitiveDeps.hasNext()) {
 			BundleDescription desc = transitiveDeps.next();
 			if (added.add(desc)) {


### PR DESCRIPTION
When two bundles share a symbolic name in the target platform (e.g. both `jakarta.annotation-api` 1.3.5 and 2.1.1 shipped by the SDK side by side), the sort used to emit classpath entries only compared symbolic names. `Stream.sorted` is stable, so the source order — coming from a `HashSet` iteration that varies between JVM runs — leaked into the classpath, which made the "Updating plug-in dependencies" job rewrite Plug-in Dependencies containers on every IDE restart.

Adding a `HIGHER_VERSION_FIRST` tiebreaker makes the order stable across restarts and matches the preference PDE's resolver selection policy already uses. After this, restarting twice against the same target reports `updated 0 projects` instead of dozens.

Includes a Mockito-based unit test that exercises the comparator with two bundles sharing a symbolic name in ascending and descending source order and asserts the higher-version-first result is independent of input order.