### PR TITLE
Migrate org.eclipse.pde.genericeditor.extension.tests to JUnit 5

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/META-INF/MANIFEST.MF
@@ -15,6 +15,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.equinox.p2.metadata,
  org.eclipse.core.filebuffers
 Automatic-Module-Name: org.eclipse.pde.genericeditor.extension.tests
-Import-Package: org.junit,
- org.junit.runner,
- org.junit.runners
+Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.13.0,2.0.0)"

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AbstractTargetEditorTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AbstractTargetEditorTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -44,8 +44,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.osgi.framework.FrameworkUtil;
 
 public abstract class AbstractTargetEditorTest {
@@ -58,7 +58,7 @@ public abstract class AbstractTargetEditorTest {
 		assertEquals(Arrays.asList(expectedProposals), toProposalStrings(actualProposals));
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project = ResourcesPlugin.getWorkspace().getRoot()
 				.getProject(getClass().getName() + "_" + System.currentTimeMillis());
@@ -99,7 +99,7 @@ public abstract class AbstractTargetEditorTest {
 				.toString();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (tempFile != null) {
 			tempFile.delete();

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AllTargetEditorTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AllTargetEditorTests.java
@@ -13,12 +13,11 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@SuiteClasses({ AttributeNameCompletionTests.class, AttributeValueCompletionTests.class, TagNameCompletionTests.class,
+@Suite
+@SelectClasses({ AttributeNameCompletionTests.class, AttributeValueCompletionTests.class, TagNameCompletionTests.class,
 	TagValueCompletionTests.class, Bug527084CompletionWithCommentsTest.class,
 	Bug528706CompletionWithMultilineTagsTest.class, UpdateUnitVersionsCommandTests.class, Bug531602FormattingTests.class })
 public class AllTargetEditorTests {

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AttributeNameCompletionTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AttributeNameCompletionTests.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AttributeNameCompletionTests extends AbstractTargetEditorTest {
 	@Test
@@ -61,8 +61,8 @@ public class AttributeNameCompletionTests extends AbstractTargetEditorTest {
 			if (expectedProposalsByOffset.containsKey(offset)) {
 				checkProposals(expectedProposalsByOffset.get(offset), completionProposals, offset);
 			} else {
-				assertTrue("There should not be any proposals at index " + offset + ". Following proposals found: "
-						+ proposalListToString(completionProposals), completionProposals.length == 0);
+				assertTrue(completionProposals.length == 0, "There should not be any proposals at index " + offset + ". Following proposals found: "
+						+ proposalListToString(completionProposals));
 			}
 			offset++;
 		}
@@ -89,7 +89,7 @@ public class AttributeNameCompletionTests extends AbstractTargetEditorTest {
 
 			ICompletionProposal[] completionProposals = contentAssist.computeCompletionProposals(textViewer, offset);
 			if (completionProposals.length != 0) {
-				Assert.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
+				Assertions.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
 						+ proposalListToString(completionProposals));
 			}
 			offset++;

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AttributeValueCompletionTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/AttributeValueCompletionTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AttributeValueCompletionTests extends AbstractTargetEditorTest {
 	@Test

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug527084CompletionWithCommentsTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug527084CompletionWithCommentsTest.java
@@ -14,14 +14,14 @@
 package org.eclipse.pde.genericeditor.extension.tests;
 
 import org.eclipse.jface.text.ITextViewer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Bug527084CompletionWithCommentsTest extends AbstractTargetEditorTest {
 	private ITextViewer textViewer;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		textViewer = getTextViewerForTarget("CommentsTestCaseTarget");

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug528706CompletionWithMultilineTagsTest.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug528706CompletionWithMultilineTagsTest.java
@@ -15,14 +15,14 @@ package org.eclipse.pde.genericeditor.extension.tests;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.ITextViewer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Bug528706CompletionWithMultilineTagsTest extends AbstractTargetEditorTest {
 	private ITextViewer textViewer;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		textViewer = getTextViewerForTarget("MultilineTagTestCaseTarget");

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug531602FormattingTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/Bug531602FormattingTests.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,7 +34,7 @@ import org.eclipse.pde.genericeditor.extension.tests.resources.TestTargetLocatio
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.target.IUBundleContainer;
 import org.eclipse.pde.internal.core.target.TargetDefinitionPersistenceHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 
 public class Bug531602FormattingTests extends AbstractTargetEditorTest {

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/StringAsserts.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/StringAsserts.java
@@ -21,7 +21,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /*
  * Copied from org.eclipse.jdt.ui.tests/test plugin/org/eclipse/jdt/testplugin/StringAsserts.javas
@@ -56,9 +56,9 @@ public class StringAsserts {
 				return;
 			}
 			if (actual == null) {
-				Assert.assertTrue("Content not as expected: is 'null' expected: " + expected, false);
+				Assertions.assertTrue(false, "Content not as expected: is 'null' expected: " + expected);
 			} else {
-				Assert.assertTrue("Content not as expected: expected 'null' is: " + actual, false);
+				Assertions.assertTrue(false, "Content not as expected: expected 'null' is: " + actual);
 			}
 		}
 
@@ -73,7 +73,7 @@ public class StringAsserts {
 			String message = "Content not as expected: is\n" + actual + "\nDiffers at pos " + diffPos + ": " + diffStr //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
 					+ "\nexpected:\n" + expected; //$NON-NLS-1$
 
-			Assert.assertEquals(message, expected, actual);
+			Assertions.assertEquals(expected, actual, message);
 		}
 	}
 
@@ -83,9 +83,9 @@ public class StringAsserts {
 				return;
 			}
 			if (actual == null) {
-				Assert.assertTrue("Content not as expected: is 'null' expected: " + expected, false);
+				Assertions.assertTrue(false, "Content not as expected: is 'null' expected: " + expected);
 			} else {
-				Assert.assertTrue("Content not as expected: expected 'null' is: " + actual, false);
+				Assertions.assertTrue(false, "Content not as expected: expected 'null' is: " + actual);
 			}
 		}
 
@@ -105,7 +105,7 @@ public class StringAsserts {
 
 				String message = "Content not as expected: Content is: \n" + actual + "\nDiffers at line " + line + ": "
 						+ diffStr + "\nExpected contents: \n" + expected;
-				Assert.assertEquals(message, expected, actual);
+				Assertions.assertEquals(expected, actual, message);
 			}
 			line++;
 		} while (true);
@@ -150,7 +150,7 @@ public class StringAsserts {
 			String expected = buf.toString();
 
 			String message = "Content not as expected: Content is: \n" + actual + "\nExpected contents: \n" + expected;
-			Assert.assertEquals(message, expected, actual);
+			Assertions.assertEquals(expected, actual, message);
 		}
 	}
 
@@ -193,7 +193,7 @@ public class StringAsserts {
 			String expected = buf.toString();
 
 			String message = "Content not as expected: Content is: \n" + actual + "\nExpected contents: \n" + expected;
-			Assert.assertEquals(message, expected, actual);
+			Assertions.assertEquals(expected, actual, message);
 		}
 	}
 

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TagNameCompletionTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TagNameCompletionTests.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TagNameCompletionTests extends AbstractTargetEditorTest {
 	@Test
@@ -52,7 +52,7 @@ public class TagNameCompletionTests extends AbstractTargetEditorTest {
 			if (expectedProposalsByOffset.containsKey(offset)) {
 				checkProposals(entry.getValue(), completionProposals, offset);
 			} else if (completionProposals.length != 0) {
-				Assert.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
+				Assertions.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
 						+ proposalListToString(completionProposals));
 			}
 		}
@@ -72,7 +72,7 @@ public class TagNameCompletionTests extends AbstractTargetEditorTest {
 			}
 			ICompletionProposal[] completionProposals = contentAssist.computeCompletionProposals(textViewer, offset);
 			if (completionProposals.length != 0) {
-				Assert.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
+				Assertions.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
 						+ proposalListToString(completionProposals));
 			}
 			offset++;

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TagValueCompletionTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/TagValueCompletionTests.java
@@ -18,16 +18,16 @@ import java.util.List;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TagValueCompletionTests extends AbstractTargetEditorTest {
 
 	private List<Integer> expectedCompletionOffsets;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 
@@ -60,7 +60,7 @@ public class TagValueCompletionTests extends AbstractTargetEditorTest {
 
 			ICompletionProposal[] completionProposals = contentAssist.computeCompletionProposals(textViewer, offset);
 			if (completionProposals.length > 0 && !expectedCompletionOffsets.contains(offset)) {
-				Assert.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
+				Assertions.fail("There should not be any proposals at index " + offset + ". Following proposals found: "
 						+ proposalListToString(completionProposals));
 			}
 			offset++;

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/UpdateUnitVersionsCommandTests.java
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/src/org/eclipse/pde/genericeditor/extension/tests/UpdateUnitVersionsCommandTests.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.genericeditor.extension.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +28,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UpdateUnitVersionsCommandTests extends AbstractTargetEditorTest {
 
@@ -88,10 +88,8 @@ public class UpdateUnitVersionsCommandTests extends AbstractTargetEditorTest {
 		for (Entry<String, String> unit : expected.entrySet()) {
 			String expectedID = unit.getKey();
 			String expectedVersion = unit.getValue();
-			assertTrue("ID: " + expectedID + " not found in actual. updatedText=" + updatedText,
-					actual.containsKey(expectedID));
-			assertEquals("ID: " + expectedID + " has the incorrect version. updatedText=" + updatedText,
-					expectedVersion, actual.get(expectedID));
+			assertTrue(actual.containsKey(expectedID), "ID: " + expectedID + " not found in actual. updatedText=" + updatedText);
+			assertEquals(expectedVersion, actual.get(expectedID), "ID: " + expectedID + " has the incorrect version. updatedText=" + updatedText);
 		}
 	}
 


### PR DESCRIPTION
Migrates the generic editor extension tests from JUnit 4 to JUnit 5 (Jupiter + Platform Suite). Swaps `@Test`, `@Before`/`@After`, `Assert`, and `@RunWith(Suite.class)` for their Jupiter/Platform equivalents, and updates the MANIFEST `Import-Package` accordingly. Assertion message arguments were moved to the trailing position where Jupiter's API requires it.