### PR TITLE
Add counter to update classpath message

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
@@ -45,6 +45,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.natures.BndProject;
 import org.eclipse.pde.internal.core.natures.PluginProject;
@@ -114,13 +115,15 @@ public class ClasspathContainerState {
 			int count = requests.size();
 			monitor.setWorkRemaining(count * 2);
 
-			for (UpdateRequest req : requests) {
+			String messageTemplate = PDECoreMessages.PluginModelManager_1 + " ({0}/{1}): {2}"; //$NON-NLS-1$
+			for (int i = 0; i < requests.size(); i++) {
+				UpdateRequest req = requests.get(i);
 				if (monitor.isCanceled()) {
 					break;
 				}
 				IProject project = req.project();
 				if (project.exists() && project.isOpen()) {
-					monitor.subTask(project.getName());
+					monitor.setTaskName(NLS.bind(messageTemplate, i + 1, count, project.getName()));
 					IPluginModelBase model = modelManager.findModel(project);
 					if (isPdeContainerProject(project, model) && PluginProject.isJavaProject(project)) {
 						IJavaProject javaProject = JavaCore.create(project);


### PR DESCRIPTION
When updating the classpath of the plugins, the message now includes additional information about how many out of how many plugins have been processed (e.g. 10/321), useful for large workspaces.

## Screenshots
Here's the progress monitor for 2 plugins: `plugin1` and `plugin2`

<img width="511" height="300" alt="image" src="https://github.com/user-attachments/assets/ee79728c-1509-4eaa-9852-2da9616b26f0" />

---

<img width="301" height="72" alt="image" src="https://github.com/user-attachments/assets/f9e311ef-c804-46f0-9c7b-571162c800f5" />

---

<img width="434" height="83" alt="image" src="https://github.com/user-attachments/assets/7dc2b975-fa86-48d6-bdcd-452e4771a470" />
