### PR TITLE
Add unit tests for TargetResolveRule

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/AllTargetTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/AllTargetTests.java
@@ -25,7 +25,8 @@ import org.junit.platform.suite.api.Suite;
 		TargetDefinitionResolutionTests.class, //
 		TargetDefinitionFeatureResolutionTests.class, //
 		IUBundleContainerTests.class, //
-		ProfileContainerTests.class })
+		ProfileContainerTests.class, //
+		TargetResolveRuleTest.class })
 public class AllTargetTests {
 
 }

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/TargetResolveRuleTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/TargetResolveRuleTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.pde.ui.tests.target;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.pde.core.target.ITargetHandle;
+import org.eclipse.pde.internal.ui.editor.targetdefinition.TargetResolveRule;
+import org.junit.Test;
+
+/**
+ * Pins the contract of {@link TargetResolveRule}: resolves of the same target
+ * handle must serialize, resolves of distinct handles must not. Regression
+ * coverage for issue #310, where parallel resolves raced on the p2 profile
+ * lock and produced "ProfileLock.unlock() because lock is null" errors.
+ */
+public class TargetResolveRuleTest {
+
+	@Test
+	public void sameKeyConflicts() {
+		ISchedulingRule a = new TargetResolveRule("target-A");
+		ISchedulingRule b = new TargetResolveRule("target-A");
+
+		assertTrue("rules with the same key must conflict", a.isConflicting(b));
+		assertTrue("isConflicting must be symmetric", b.isConflicting(a));
+		assertTrue("contains must mirror isConflicting", a.contains(b));
+	}
+
+	@Test
+	public void differentKeysDoNotConflict() {
+		ISchedulingRule a = new TargetResolveRule("target-A");
+		ISchedulingRule b = new TargetResolveRule("target-B");
+
+		assertFalse(a.isConflicting(b));
+		assertFalse(b.isConflicting(a));
+		assertFalse(a.contains(b));
+	}
+
+	@Test
+	public void doesNotConflictWithForeignRule() {
+		ISchedulingRule rule = new TargetResolveRule("target-A");
+		ISchedulingRule foreign = new ISchedulingRule() {
+			@Override
+			public boolean contains(ISchedulingRule r) {
+				return r == this;
+			}
+
+			@Override
+			public boolean isConflicting(ISchedulingRule r) {
+				return r == this;
+			}
+		};
+
+		assertFalse("must only conflict with other TargetResolveRule instances",
+				rule.isConflicting(foreign));
+	}
+
+	@Test
+	public void forHandleSerializesByMemento() throws Exception {
+		ITargetHandle h1 = mock(ITargetHandle.class);
+		ITargetHandle h2 = mock(ITargetHandle.class);
+		when(h1.getMemento()).thenReturn("memento-X");
+		when(h2.getMemento()).thenReturn("memento-X");
+
+		assertTrue("two handles with the same memento must serialize",
+				TargetResolveRule.forHandle(h1).isConflicting(TargetResolveRule.forHandle(h2)));
+	}
+
+	@Test
+	public void forHandleKeepsDistinctTargetsIndependent() throws Exception {
+		ITargetHandle h1 = mock(ITargetHandle.class);
+		ITargetHandle h2 = mock(ITargetHandle.class);
+		when(h1.getMemento()).thenReturn("memento-X");
+		when(h2.getMemento()).thenReturn("memento-Y");
+
+		assertFalse("handles with different mementos must not block each other",
+				TargetResolveRule.forHandle(h1).isConflicting(TargetResolveRule.forHandle(h2)));
+	}
+
+	@Test
+	public void forHandleFallsBackWhenMementoFails() throws Exception {
+		ITargetHandle broken = mock(ITargetHandle.class);
+		when(broken.getMemento()).thenThrow(new CoreException(Status.error("boom")));
+
+		ISchedulingRule first = TargetResolveRule.forHandle(broken);
+		ISchedulingRule second = TargetResolveRule.forHandle(broken);
+
+		assertTrue("a second resolve of the same handle instance must still serialize",
+				first.isConflicting(second));
+
+		ITargetHandle otherBroken = mock(ITargetHandle.class);
+		when(otherBroken.getMemento()).thenThrow(new CoreException(Status.error("boom")));
+		assertNotEquals("distinct broken handles must not collide on the fallback key",
+				((TargetResolveRule) first).key(),
+				((TargetResolveRule) TargetResolveRule.forHandle(otherBroken)).key());
+	}
+}

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Export-Package:
  org.eclipse.pde.internal.ui.editor.product;x-internal:=true,
  org.eclipse.pde.internal.ui.editor.schema;x-friends:="org.eclipse.pde.ds.ui",
  org.eclipse.pde.internal.ui.editor.site;x-internal:=true,
- org.eclipse.pde.internal.ui.editor.targetdefinition;x-internal:=true,
+ org.eclipse.pde.internal.ui.editor.targetdefinition;x-friends:="org.eclipse.pde.ui.tests",
  org.eclipse.pde.internal.ui.editor.text;x-friends:="org.eclipse.pde.ds.ui,org.eclipse.pde.ua.ui",
  org.eclipse.pde.internal.ui.editor.validation;x-internal:=true,
  org.eclipse.pde.internal.ui.elements;x-friends:="org.eclipse.pde.ds.ui,org.eclipse.pde.ua.ui",

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -42,7 +42,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.e4.core.services.events.IEventBroker;
@@ -647,37 +646,6 @@ public class TargetEditor extends FormEditor {
 	}
 
 	/**
-	 * A scheduling rule keyed by a target handle's memento string. Two
-	 * instances with the same key conflict, which serializes resolve jobs for
-	 * the same target handle while leaving resolves of different targets
-	 * independent. This avoids races on the p2 profile lock/unlock pair (see
-	 * issue #310) and the pile-up of cancelled resolve jobs in the Progress
-	 * view. Because the rule carries only a lightweight String key and is not
-	 * cached in a static map, there is no risk of unbounded retention.
-	 */
-	private record TargetResolveRule(String key) implements ISchedulingRule {
-		@Override
-		public boolean contains(ISchedulingRule rule) {
-			return isConflicting(rule);
-		}
-
-		@Override
-		public boolean isConflicting(ISchedulingRule rule) {
-			return rule instanceof TargetResolveRule other && key.equals(other.key);
-		}
-	}
-
-	private static ISchedulingRule getResolveSchedulingRule(ITargetHandle handle) {
-		String key;
-		try {
-			key = handle.getMemento();
-		} catch (CoreException e) {
-			key = String.valueOf(System.identityHashCode(handle));
-		}
-		return new TargetResolveRule(key);
-	}
-
-	/**
 	 * When changes are noticed in the target, this listener will resolve the
 	 * target and update the necessary pages in the editor.
 	 */
@@ -757,7 +725,7 @@ public class TargetEditor extends FormEditor {
 						return family.equals(getJobFamily());
 					}
 				};
-				resolveJob.setRule(getResolveSchedulingRule(getTarget().getHandle()));
+				resolveJob.setRule(TargetResolveRule.forHandle(getTarget().getHandle()));
 				resolveJob.addJobChangeListener(new JobChangeAdapter() {
 					@Override
 					public void done(org.eclipse.core.runtime.jobs.IJobChangeEvent event) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetResolveRule.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetResolveRule.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.pde.internal.ui.editor.targetdefinition;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.pde.core.target.ITargetHandle;
+
+/**
+ * A scheduling rule keyed by a target handle's memento string. Two instances
+ * with the same key conflict, which serializes resolve jobs for the same
+ * target handle while leaving resolves of different targets independent. This
+ * avoids races on the p2 profile lock/unlock pair (see issue #310) and the
+ * pile-up of cancelled resolve jobs in the Progress view. Because the rule
+ * carries only a lightweight String key and is not cached in a static map,
+ * there is no risk of unbounded retention.
+ */
+public record TargetResolveRule(String key) implements ISchedulingRule {
+
+	public static ISchedulingRule forHandle(ITargetHandle handle) {
+		String key;
+		try {
+			key = handle.getMemento();
+		} catch (CoreException e) {
+			key = String.valueOf(System.identityHashCode(handle));
+		}
+		return new TargetResolveRule(key);
+	}
+
+	@Override
+	public boolean contains(ISchedulingRule rule) {
+		return isConflicting(rule);
+	}
+
+	@Override
+	public boolean isConflicting(ISchedulingRule rule) {
+		return rule instanceof TargetResolveRule other && key.equals(other.key);
+	}
+}


### PR DESCRIPTION
Adds focused unit tests for the per-target-handle scheduling rule introduced in #2311. The rule was a private nested record in `TargetEditor`; this PR extracts it to a top-level `TargetResolveRule` in the same internal package with a public `forHandle(ITargetHandle)` factory, and grants `org.eclipse.pde.ui.tests` x-friend access so the test bundle can reach it. The package stays internal — no public API is added.

The new tests pin the contract: same memento serializes, distinct mementos stay independent, foreign rules never conflict, and the `CoreException` fallback keeps the same handle instance serialized while still distinguishing different broken handles.