### PR TITLE
Added test for E4WorkbenchModelEditor XMI tab search

### DIFF
--- a/org.eclipse.e4.tools.emf.ui.tests/.classpath
+++ b/org.eclipse.e4.tools.emf.ui.tests/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.e4.tools.emf.ui.tests/.project
+++ b/org.eclipse.e4.tools.emf.ui.tests/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.e4.tools.emf.ui.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.e4.tools.emf.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.e4.tools.emf.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.e4.tools.emf.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.e4.tools.emf.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/org.eclipse.e4.tools.emf.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.e4.tools.emf.ui.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EMF UI Test-Fragment
+Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui.tests
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse.org
+Fragment-Host: org.eclipse.e4.tools.emf.ui
+Automatic-Module-Name: org.eclipse.e4.tools.emf.ui.tests
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Import-Package: org.junit.jupiter.api;version="[5.14.3,6.0.0)"
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.ui.ide,
+ org.eclipse.e4.tools.emf.editor3x

--- a/org.eclipse.e4.tools.emf.ui.tests/build.properties
+++ b/org.eclipse.e4.tools.emf.ui.tests/build.properties
@@ -1,0 +1,2 @@
+output.. = bin/
+bin.includes = META-INF/

--- a/org.eclipse.e4.tools.emf.ui.tests/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/tests/XmiTabTest.java
+++ b/org.eclipse.e4.tools.emf.ui.tests/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/tests/XmiTabTest.java
@@ -1,0 +1,131 @@
+package org.eclipse.e4.tools.emf.ui.internal.common.component.tabs.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.tools.emf.ui.internal.common.component.tabs.XmiTab;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.Widget;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.FrameworkUtil;
+
+public class XmiTabTest {
+
+	private static final String MODEL_EDITOR_ID = "org.eclipse.e4.tools.emf.editor3x.e4wbm"; //$NON-NLS-1$
+
+	private IProject project;
+	private XmiTab xmiTab;
+	private Text searchTextWidget;
+	private StyledText sourceViewerTextWidget;
+
+	@BeforeEach
+	void setup() throws IOException, CoreException {
+		project = importTestProject("/tests/projects/xmitabtest");
+		waitForUI();
+
+		IFile file = project.getFile("src/Application.e4xmi");
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		IEditorPart part = IDE.openEditor(page, file, MODEL_EDITOR_ID, true);
+		IEclipseContext context = part.getSite().getService(IEclipseContext.class);
+		Composite composite = context.get(Composite.class);
+		waitForUI();
+
+		CTabFolder folder = (CTabFolder) composite.getChildren()[0];
+		folder.setSelection(2 /* XMI tab index */);
+		waitForUI();
+
+		xmiTab = (XmiTab) folder.getSelection().getControl();
+		searchTextWidget = (Text) xmiTab.getChildren()[0];
+		Composite sourceViewerComposite = (Composite) xmiTab.getChildren()[1];
+		sourceViewerTextWidget = (StyledText) sourceViewerComposite.getChildren()[0];
+	}
+
+	@AfterEach
+	void tearDown() throws CoreException {
+		if (project != null) {
+			project.delete(IProject.FORCE | IProject.NEVER_DELETE_PROJECT_CONTENT, null);
+		}
+	}
+
+	@Test
+	void testSearchHighlight() {
+		searchTextWidget.forceFocus();
+		waitForUI();
+
+		Display display = Display.getDefault();
+		display.post(keyEvent('a', SWT.KeyDown, display.getFocusControl()));
+		waitForUI();
+
+		int[] ranges = sourceViewerTextWidget.getSelectionRanges();
+		assertEquals(ranges[0], 41);
+		assertEquals(ranges[1], 1);
+
+		display.post(keyEvent('d', SWT.KeyDown, display.getFocusControl()));
+		waitForUI();
+
+		ranges = sourceViewerTextWidget.getSelectionRanges();
+		assertEquals(ranges[0], 262);
+		assertEquals(ranges[1], 2);
+
+		// find next occurrence
+		display.post(keyEvent(SWT.CR, SWT.KeyDown, display.getFocusControl()));
+		waitForUI();
+
+		ranges = sourceViewerTextWidget.getSelectionRanges();
+		assertEquals(ranges[0], 467);
+		assertEquals(ranges[1], 2);
+	}
+
+	private static void waitForUI() {
+		while (Display.getDefault().readAndDispatch()) {
+			// wait for UI
+		}
+	}
+
+	private static Event keyEvent(int key, int type, Widget widget) {
+		Event e = new Event();
+		e.keyCode = key;
+		e.character = (char) key;
+		e.type = type;
+		e.widget = widget;
+		return e;
+	}
+
+	private static IProject importTestProject(String path) throws IOException, CoreException {
+		URL entry = FileLocator
+				.toFileURL(FileLocator.find(FrameworkUtil.getBundle(XmiTabTest.class), IPath.fromOSString(path)));
+		if (entry == null) {
+			throw new IllegalArgumentException(path + " does not exist");
+		}
+		IPath projectFile = IPath.fromPortableString(entry.getPath()).append(IProjectDescription.DESCRIPTION_FILE_NAME);
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IProjectDescription projectDescription = workspace.loadProjectDescription(projectFile);
+		IProject project = workspace.getRoot().getProject(projectDescription.getName());
+		project.create(projectDescription, null);
+		project.open(null);
+		return project;
+	}
+}

--- a/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.classpath
+++ b/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.project
+++ b/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>xmitabtest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/src/Application.e4xmi
+++ b/org.eclipse.e4.tools.emf.ui.tests/tests/projects/xmitabtest/src/Application.e4xmi
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ASCII"?>
+<application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmi:id="_LCXToEJBEfGXuaENIB6s3w" elementId="xmitabtest.application">
+  <addons xmi:id="_LCXToUJBEfGXuaENIB6s3w" elementId="org.eclipse.e4.core.commands.service" contributionURI="bundleclass://org.eclipse.e4.core.commands/org.eclipse.e4.core.commands.CommandServiceAddon"/>
+  <addons xmi:id="_LCXTokJBEfGXuaENIB6s3w" elementId="org.eclipse.e4.ui.contexts.service" contributionURI="bundleclass://org.eclipse.e4.ui.services/org.eclipse.e4.ui.services.ContextServiceAddon"/>
+  <addons xmi:id="_LCXTo0JBEfGXuaENIB6s3w" elementId="org.eclipse.e4.ui.bindings.service" contributionURI="bundleclass://org.eclipse.e4.ui.bindings/org.eclipse.e4.ui.bindings.BindingServiceAddon"/>
+  <addons xmi:id="_LCXTpEJBEfGXuaENIB6s3w" elementId="org.eclipse.e4.ui.workbench.commands.model" contributionURI="bundleclass://org.eclipse.e4.ui.workbench/org.eclipse.e4.ui.internal.workbench.addons.CommandProcessingAddon"/>
+  <addons xmi:id="_LCXTpUJBEfGXuaENIB6s3w" elementId="org.eclipse.e4.ui.workbench.contexts.model" contributionURI="bundleclass://org.eclipse.e4.ui.workbench/org.eclipse.e4.ui.internal.workbench.addons.ContextProcessingAddon"/>
+  <addons xmi:id="_LCXTpkJBEfGXuaENIB6s3w" elementId="org.eclipse.e4.ui.workbench.bindings.model" contributionURI="bundleclass://org.eclipse.e4.ui.workbench.swt/org.eclipse.e4.ui.workbench.swt.util.BindingProcessingAddon"/>
+  <addons xmi:id="_LCXTp0JBEfGXuaENIB6s3w" elementId="org.eclipse.e4.ui.workbench.handler.model" contributionURI="bundleclass://org.eclipse.e4.ui.workbench/org.eclipse.e4.ui.internal.workbench.addons.HandlerProcessingAddon"/>
+</application:Application>


### PR DESCRIPTION
Follow-up PR for https://github.com/eclipse-pde/eclipse.pde/pull/2293 adding a new test fragment for **org.eclipse.e4.tools.emf.ui** in order to test the search functionality of the XMI tab of the E4WorkbenchModelEditor.

The added regression test case asserts that the search highlighting reacts correctly to new key inputs into the search field and considers the full text of the search field for highlighting. The test data used for this is  a simple project with a default application.