### PR TITLE
Fixed scrolling inside the XMI tab of the E4WorkbenchModelEditor

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.services.nls.Translation;
+import org.eclipse.e4.tools.emf.ui.common.ModelEditorPreferences;
 import org.eclipse.e4.tools.emf.ui.internal.Messages;
 import org.eclipse.e4.tools.emf.ui.internal.common.xml.AnnotationAccess;
 import org.eclipse.e4.tools.emf.ui.internal.common.xml.EMFDocumentResourceMediator;
@@ -134,9 +135,8 @@ public class XmiTab extends Composite {
 
 		final String property = System
 				.getProperty(ORG_ECLIPSE_E4_TOOLS_MODELEDITOR_FILTEREDTREE_ENABLED_XMITAB_DISABLED);
-		if (property != null || preferences.getBoolean("tab-form-search-show", true)) { //$NON-NLS-1$
+		if (property != null || preferences.getBoolean(ModelEditorPreferences.TAB_FORM_SEARCH_SHOW, true)) {
 			sourceViewer.setEditable(false);
-			sourceViewer.getTextWidget().setEnabled(false);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/2299

This PR removes the disablement of the source viewer in the XMI tab of the E4WorkbenchModelEditor. This allows scrolling inside the viewer while still keeping the contents unmodifiable.

This also enables copying of the XMI contents which might be useful e.g. for copying elementIds or other parts.

There's currently no test plugin for the XMI tab, but if https://github.com/eclipse-pde/eclipse.pde/pull/2320 gets merged, I can create a follow-up PR adding tests for the scrollbar too.