### PR TITLE
Make spyPart shortcut attribute optional

### DIFF
--- a/features/org.eclipse.pde.spies-feature/feature.xml
+++ b/features/org.eclipse.pde.spies-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde.spies"
       label="%featureName"
-      version="1.0.1100.qualifier"
+      version="1.0.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.core;singleton:=true
-Bundle-Version: 1.1.600.qualifier
+Bundle-Version: 1.1.700.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.core
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/ui/org.eclipse.pde.spy.core/forceQualifierUpdate.txt
+++ b/ui/org.eclipse.pde.spy.core/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-pde/eclipse.pde/pull/2326

--- a/ui/org.eclipse.pde.spy.core/src/org/eclipse/pde/spy/core/SpyProcessor.java
+++ b/ui/org.eclipse.pde.spy.core/src/org/eclipse/pde/spy/core/SpyProcessor.java
@@ -81,7 +81,9 @@ public class SpyProcessor {
 				// Bind the command with the binding, and add the view ID as
 				// parameter.
 				// The part class name will be the ID of the part descriptor
-				bindSpyKeyBinding(bindingTable, shortCut, command, partID);
+				if (shortCut != null && !shortCut.isBlank()) {
+					bindSpyKeyBinding(bindingTable, shortCut, command, partID);
+				}
 
 				// Add the descriptor in application
 				addSpyPartDescriptor(partID, partName, iconPath, partClass, desc);


### PR DESCRIPTION
The `shortcut` attribute on the `org.eclipse.pde.spy.core.spyPart` extension point is not declared as required in its schema, but `SpyProcessor` would NPE when a contribution omitted it (`keySequence.equals` in `bindSpyKeyBinding`). This skips key-binding registration when no shortcut is provided, so a spy can opt into discoverability via the spy stack toolbar without claiming a global keystroke.

**Planned for 4.41**