### PR TITLE
Made command labels in E4WorkbenchEditor link to the editor of their respective commands

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/common/component/AbstractComponentEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/common/component/AbstractComponentEditor.java
@@ -24,7 +24,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.core.databinding.UpdateValueStrategy;
+import org.eclipse.core.databinding.conversion.Converter;
 import org.eclipse.core.databinding.observable.list.IObservableList;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.WritableValue;
 import org.eclipse.core.databinding.property.value.IValueProperty;
 import org.eclipse.core.resources.IProject;
@@ -42,6 +45,7 @@ import org.eclipse.e4.tools.services.IClipboardService.Handler;
 import org.eclipse.e4.tools.services.IResourcePool;
 import org.eclipse.e4.tools.services.impl.ResourceBundleTranslationProvider;
 import org.eclipse.e4.ui.model.application.MApplicationElement;
+import org.eclipse.e4.ui.model.application.commands.MCommand;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.MUILabel;
 import org.eclipse.emf.databinding.EMFDataBindingContext;
@@ -51,6 +55,8 @@ import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.databinding.swt.ISWTObservableValue;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.SWT;
@@ -59,12 +65,14 @@ import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Link;
 
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
@@ -497,6 +505,41 @@ public abstract class AbstractComponentEditor<M> {
 			IValueProperty<M, String> attIdProp = EMFEditProperties.value(getEditingDomain(), attId);
 			generator.bind(getMaster(), addSourceProp, attIdProp, control);
 		}
+	}
+
+	/**
+	 * Creates a {@link Link} linking to the {@link MCommand} observed by the given
+	 * observable. If a command is present, the given text is displayed as a
+	 * hyperlink.
+	 *
+	 * @param parent            the parent composite
+	 * @param text              the text to display
+	 * @param commandObservable the command observable
+	 * @param context           the data binding context
+	 * @return the created link widget
+	 */
+	protected Link createCommandLink(Composite parent, String text, IObservableValue<MCommand> commandObservable,
+			EMFDataBindingContext context) {
+		Link link = new Link(parent, SWT.NONE);
+		link.setText(text);
+		ISWTObservableValue<String> textObservable = WidgetProperties.text().observeDelayed(200, link);
+		context.bindValue(textObservable, commandObservable, new UpdateValueStrategy<>(),
+				UpdateValueStrategy.create(new Converter<>(MCommand.class, String.class) {
+					@Override
+					public String convert(MCommand command) {
+						if (command != null) {
+							return "<A>" + text + "</A>"; //$NON-NLS-1$ //$NON-NLS-2$
+						}
+						return text;
+					}
+				}));
+		link.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+			MCommand command = commandObservable.getValue();
+			if (command != null) {
+				getEditor().gotoEObject(ModelEditor.TAB_FORM, (EObject) command);
+			}
+		}));
+		return link;
 	}
 
 	@PreDestroy

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/HandledMenuItemEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/HandledMenuItemEditor.java
@@ -36,7 +36,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 
 import jakarta.inject.Inject;
@@ -72,8 +72,8 @@ public class HandledMenuItemEditor extends MenuItemEditor<MHandledMenuItem> {
 
 		// ------------------------------------------------------------
 		{
-			final Label l = new Label(parent, SWT.NONE);
-			l.setText(Messages.HandledMenuItemEditor_Command);
+			final Link l = createCommandLink(parent, Messages.HandledMenuItemEditor_Command,
+					E4Properties.itemCommand(getEditingDomain()).observeDetail(master), context);
 			l.setLayoutData(new GridData());
 
 			final Text t = new Text(parent, SWT.BORDER);

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/HandledToolItemEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/HandledToolItemEditor.java
@@ -35,7 +35,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 
 import jakarta.inject.Inject;
@@ -60,8 +60,8 @@ public class HandledToolItemEditor extends ToolItemEditor<MHandledToolItem> {
 		final IWidgetValueProperty<Text, String> textProp = WidgetProperties.text(SWT.Modify);
 
 		{
-			final Label l = new Label(parent, SWT.NONE);
-			l.setText(Messages.HandledToolItemEditor_Command);
+			final Link l = createCommandLink(parent, Messages.HandledToolItemEditor_Command,
+					E4Properties.itemCommand(getEditingDomain()).observeDetail(master), context);
 			l.setLayoutData(new GridData());
 
 			final Text t = new Text(parent, SWT.BORDER);

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/HandlerEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/HandlerEditor.java
@@ -54,7 +54,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 
 import jakarta.inject.Inject;
@@ -154,8 +154,8 @@ public class HandlerEditor extends AbstractComponentEditor<MHandler> {
 
 		// ------------------------------------------------------------
 		{
-			final Label l = new Label(parent, SWT.NONE);
-			l.setText(Messages.HandlerEditor_Command);
+			final Link l = createCommandLink(parent, Messages.HandlerEditor_Command,
+					E4Properties.command(getEditingDomain()).observeDetail(master), context);
 			l.setLayoutData(new GridData());
 
 			final Text t = new Text(parent, SWT.BORDER);

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/KeyBindingEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/KeyBindingEditor.java
@@ -66,6 +66,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 
 import jakarta.annotation.PostConstruct;
@@ -188,8 +189,8 @@ public class KeyBindingEditor extends AbstractComponentEditor<MKeyBinding> {
 
 		// ------------------------------------------------------------
 		{
-			final Label l = new Label(parent, SWT.NONE);
-			l.setText(Messages.KeyBindingEditor_Command);
+			final Link l = createCommandLink(parent, Messages.KeyBindingEditor_Command,
+					E4Properties.keyBindingCommand(getEditingDomain()).observeDetail(master), context);
 			l.setLayoutData(new GridData());
 
 			final Text t = new Text(parent, SWT.BORDER);


### PR DESCRIPTION
This PR adds a small QoL feature for navigating E4 application models/fragments with many command definitions: When a keybinding, handler, handled tool item or handled menu item links to a command, the command label is now displayed as a hyperlink. Clicking the link opens the editor of the linked command.

<img width="950" height="699" alt="LinkAnimation" src="https://github.com/user-attachments/assets/69779e8c-a6bd-4737-8fe1-0d31eb23a405" />

The editor switching functionality was already implemented via org.eclipse.e4.tools.emf.ui.internal.common.ModelEditor.gotoEObject(int, EObject). This PR just hooks up the functionality to the corresponding labels.

### How to test
1. Open the E4WorkbenchModelEditor and create a command
2. Create a Keybinding, Handler, Handled Tool Item or Handled Menu Item
3. Set the command -> The "Command" label is now hyperlinked
4. Click the hyperlinked label -> The command is selected in the tree and the corresponding editor opens

### Alternative designs
I've considered adding a new command creation wizard which would open when clicking the label while no command is set (like it is done for the "Class URI" label of handlers), but ultimately decided against it since that would offer little additional benefit while adding yet another part to the editor which must be kept in sync with the underlying Ecore model.

<img width="548" height="405" alt="image" src="https://github.com/user-attachments/assets/a099b658-f175-413c-b2d3-e7ab56ff0e4c" />

Note: I did not add tests for this change as there are no tests for the model editor (or the org.eclipse.e4.tools.emf.ui bundle) as of now. Adding such a test bundle is currently in discussion via https://github.com/eclipse-pde/eclipse.pde/pull/2320