### PR TITLE
Fix NPE in VersionNumberingResolution.getDescription() for package version markers

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/VersionNumberingResolution.java
+++ b/apitools/org.eclipse.pde.api.tools.ui/src/org/eclipse/pde/api/tools/ui/internal/markers/VersionNumberingResolution.java
@@ -46,7 +46,9 @@ public class VersionNumberingResolution implements IMarkerResolution2 {
 
 	@Override
 	public String getDescription() {
-		description = description.replace(System.lineSeparator(), "<br>");//$NON-NLS-1$
+		if (description != null) {
+			description = description.replace(System.lineSeparator(), "<br>");//$NON-NLS-1$
+		}
 		switch (this.kind) {
 			case IApiProblem.MAJOR_VERSION_CHANGE:
 				return NLS.bind(MarkerMessages.VersionNumberingResolution_major0, new String[] { this.description });


### PR DESCRIPTION
Markers created for package-level version changes (MAJOR/MINOR_VERSION_CHANGE_PACKAGE) have a `null` description. Guard the `String.replace()` call with a `null` check to avoid NPE.

See https://github.com/eclipse-pde/eclipse.pde/issues/2332