### PR TITLE
Fix "Message not found for id: 0" in API tools compatible delta messages

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/AnnotationDeltaTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/AnnotationDeltaTests.java
@@ -450,4 +450,28 @@ public class AnnotationDeltaTests extends DeltaTestSetup {
 		assertEquals("Wrong element type", IDelta.ANNOTATION_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
 		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
 	}
+
+	/**
+	 * Add a member type to an annotation - compatible change
+	 */
+	@Test
+	public void test12() {
+		deployBundles("test12"); //$NON-NLS-1$
+		IApiBaseline before = getBeforeState();
+		IApiBaseline after = getAfterState();
+		IApiComponent beforeApiComponent = before.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", beforeApiComponent); //$NON-NLS-1$
+		IApiComponent afterApiComponent = after.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", afterApiComponent); //$NON-NLS-1$
+		IDelta delta = ApiComparator.compare(beforeApiComponent, afterApiComponent, before, after,
+				VisibilityModifiers.ALL_VISIBILITIES, null);
+		assertNotNull("No delta", delta); //$NON-NLS-1$
+		IDelta[] allLeavesDeltas = collectLeaves(delta);
+		assertEquals("Wrong size", 1, allLeavesDeltas.length); //$NON-NLS-1$
+		IDelta child = allLeavesDeltas[0];
+		assertEquals("Wrong kind", IDelta.ADDED, child.getKind()); //$NON-NLS-1$
+		assertEquals("Wrong flag", IDelta.TYPE_MEMBER, child.getFlags()); //$NON-NLS-1$
+		assertEquals("Wrong element type", IDelta.ANNOTATION_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
+		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
+	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/EnumDeltaTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/EnumDeltaTests.java
@@ -419,4 +419,28 @@ public class EnumDeltaTests extends DeltaTestSetup {
 		assertEquals("Wrong element type", IDelta.ENUM_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
 		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
 	}
+
+	/**
+	 * Add a member type to an enum - compatible change
+	 */
+	@Test
+	public void test17() {
+		deployBundles("test17"); //$NON-NLS-1$
+		IApiBaseline before = getBeforeState();
+		IApiBaseline after = getAfterState();
+		IApiComponent beforeApiComponent = before.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", beforeApiComponent); //$NON-NLS-1$
+		IApiComponent afterApiComponent = after.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", afterApiComponent); //$NON-NLS-1$
+		IDelta delta = ApiComparator.compare(beforeApiComponent, afterApiComponent, before, after,
+				VisibilityModifiers.ALL_VISIBILITIES, null);
+		assertNotNull("No delta", delta); //$NON-NLS-1$
+		IDelta[] allLeavesDeltas = collectLeaves(delta);
+		assertEquals("Wrong size", 1, allLeavesDeltas.length); //$NON-NLS-1$
+		IDelta child = allLeavesDeltas[0];
+		assertEquals("Wrong kind", IDelta.ADDED, child.getKind()); //$NON-NLS-1$
+		assertEquals("Wrong flag", IDelta.TYPE_MEMBER, child.getFlags()); //$NON-NLS-1$
+		assertEquals("Wrong element type", IDelta.ENUM_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
+		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
+	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/InterfaceDeltaTests.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/src/org/eclipse/pde/api/tools/comparator/tests/InterfaceDeltaTests.java
@@ -1110,4 +1110,61 @@ public class InterfaceDeltaTests extends DeltaTestSetup {
 		child = allLeavesDeltas[1];
 		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
 	}
+
+	/**
+	 * Add a default method to a @noimplement interface - compatible change
+	 */
+	@Test
+	public void test42() {
+		deployBundles("test42"); //$NON-NLS-1$
+		IApiBaseline before = getBeforeState();
+		IApiBaseline after = getAfterState();
+		IApiComponent beforeApiComponent = before.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", beforeApiComponent); //$NON-NLS-1$
+		IApiComponent afterApiComponent = after.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", afterApiComponent); //$NON-NLS-1$
+		IDelta delta = ApiComparator.compare(beforeApiComponent, afterApiComponent, before, after, VisibilityModifiers.API, null);
+		assertNotNull("No delta", delta); //$NON-NLS-1$
+		IDelta[] allLeavesDeltas = collectLeaves(delta);
+		assertEquals("Wrong size", 1, allLeavesDeltas.length); //$NON-NLS-1$
+		IDelta child = allLeavesDeltas[0];
+		assertEquals("Wrong kind", IDelta.ADDED, child.getKind()); //$NON-NLS-1$
+		assertEquals("Wrong flag", IDelta.DEFAULT_METHOD, child.getFlags()); //$NON-NLS-1$
+		assertEquals("Wrong element type", IDelta.INTERFACE_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
+		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
+	}
+
+	/**
+	 * Add default method from new superinterface to a @noimplement interface - compatible change
+	 */
+	@Test
+	public void test43() {
+		deployBundles("test43"); //$NON-NLS-1$
+		IApiBaseline before = getBeforeState();
+		IApiBaseline after = getAfterState();
+		IApiComponent beforeApiComponent = before.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", beforeApiComponent); //$NON-NLS-1$
+		IApiComponent afterApiComponent = after.getApiComponent(BUNDLE_NAME);
+		assertNotNull("no api component", afterApiComponent); //$NON-NLS-1$
+		IDelta delta = ApiComparator.compare(beforeApiComponent, afterApiComponent, before, after,
+				VisibilityModifiers.ALL_VISIBILITIES, null);
+		assertNotNull("No delta", delta); //$NON-NLS-1$
+		IDelta[] allLeavesDeltas = collectLeaves(delta);
+		assertEquals("Wrong size", 3, allLeavesDeltas.length); //$NON-NLS-1$
+		IDelta child = allLeavesDeltas[0];
+		assertEquals("Wrong kind", IDelta.ADDED, child.getKind()); //$NON-NLS-1$
+		assertEquals("Wrong flag", IDelta.OVERRIDEN_METHOD, child.getFlags()); //$NON-NLS-1$
+		assertEquals("Wrong element type", IDelta.INTERFACE_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
+		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
+		child = allLeavesDeltas[1];
+		assertEquals("Wrong kind", IDelta.ADDED, child.getKind()); //$NON-NLS-1$
+		assertEquals("Wrong flag", IDelta.SUPER_INTERFACE_DEFAULT_METHOD, child.getFlags()); //$NON-NLS-1$
+		assertEquals("Wrong element type", IDelta.INTERFACE_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
+		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
+		child = allLeavesDeltas[2];
+		assertEquals("Wrong kind", IDelta.CHANGED, child.getKind()); //$NON-NLS-1$
+		assertEquals("Wrong flag", IDelta.EXPANDED_SUPERINTERFACES_SET, child.getFlags()); //$NON-NLS-1$
+		assertEquals("Wrong element type", IDelta.INTERFACE_ELEMENT_TYPE, child.getElementType()); //$NON-NLS-1$
+		assertTrue("Not compatible", DeltaProcessor.isCompatible(child)); //$NON-NLS-1$
+	}
 }

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/annotation/test12/after/X.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/annotation/test12/after/X.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+public @interface X {
+	public class Member {}
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/annotation/test12/before/X.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/annotation/test12/before/X.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+public @interface X {
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/enum/test17/after/X.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/enum/test17/after/X.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+public enum X {
+	A, B, C;
+
+	public class Member {}
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/enum/test17/before/X.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/enum/test17/before/X.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+public enum X {
+	A, B, C;
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/after/p/I.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/after/p/I.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package p;
+
+/**
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface I {
+	default void foo() {}
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/before/p/I.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/before/p/I.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package p;
+
+/**
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface I {
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/resources/after/.api_description
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/resources/after/.api_description
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="deltatest">
+<plugin id="deltatest" />
+<package name="p">
+	<type  name="I" implement="false"/>
+</package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/resources/before/.api_description
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test42/resources/before/.api_description
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="deltatest">
+<plugin id="deltatest" />
+<package name="p">
+	<type  name="I" implement="false"/>
+</package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/after/p/I.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/after/p/I.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package p;
+
+/**
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface I extends J {
+	@Override
+	default void foo(String s) {}
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/after/p/J.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/after/p/J.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package p;
+
+public interface J {
+	void foo(String s);
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/before/p/I.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/before/p/I.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package p;
+
+/**
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface I {
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/before/p/J.java
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/before/p/J.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package p;
+
+public interface J {
+	void foo(String s);
+}

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/after/.api_description
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/after/.api_description
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="deltatest">
+<plugin id="deltatest" />
+<package name="p">
+	<type  name="I" implement="false"/>
+</package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/after/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/after/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: deltatest Plug-in
+Bundle-SymbolicName: deltatest
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: J2SE-1.4
+Export-Package: p

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/before/.api_description
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/before/.api_description
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="deltatest">
+<plugin id="deltatest" />
+<package name="p">
+	<type  name="I" implement="false"/>
+</package>
+</component>

--- a/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/before/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools.tests/tests-deltas/interface/test43/resources/before/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: deltatest Plug-in
+Bundle-SymbolicName: deltatest
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: J2SE-1.4
+Export-Package: p

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/ClassFileComparator.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/ClassFileComparator.java
@@ -498,7 +498,7 @@ public class ClassFileComparator {
 												key = getKeyForMethod(this.type2.getMethod(method.getName(), method.getSignature()), this.type2);
 											}
 										}
-										this.addDelta(getElementType(this.type1), IDelta.ADDED, isDefaultMethod ? IDelta.DEFAULT_METHOD : IDelta.SUPER_INTERFACE_WITH_METHODS, this.currentDescriptorRestrictions, this.initialDescriptorRestrictions, this.type1.getModifiers(), this.type2.getModifiers(), this.type1, key, new String[] {
+										this.addDelta(getElementType(this.type1), IDelta.ADDED, isDefaultMethod ? IDelta.SUPER_INTERFACE_DEFAULT_METHOD : IDelta.SUPER_INTERFACE_WITH_METHODS, this.currentDescriptorRestrictions, this.initialDescriptorRestrictions, this.type1.getModifiers(), this.type2.getModifiers(), this.type1, key, new String[] {
 												Util.getDescriptorName(type1),
 												type.getName(),
 												getMethodDisplayName(method, type) });

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/Messages.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/Messages.java
@@ -106,6 +106,8 @@ public class Messages extends NLS {
 								return 1;
 							case IDelta.DEPRECATION:
 								return 110;
+							case IDelta.TYPE_MEMBER:
+								return 16;
 							default:
 								break;
 						}
@@ -292,6 +294,8 @@ public class Messages extends NLS {
 								return 37;
 							case IDelta.DEPRECATION:
 								return 110;
+							case IDelta.TYPE_MEMBER:
+								return 16;
 							default:
 								break;
 						}
@@ -405,6 +409,10 @@ public class Messages extends NLS {
 								return 54;
 							case IDelta.METHOD:
 								return 55;
+							case IDelta.DEFAULT_METHOD:
+								return 113;
+							case IDelta.SUPER_INTERFACE_DEFAULT_METHOD:
+								return 115;
 							case IDelta.TYPE_MEMBER:
 								return 56;
 							case IDelta.OVERRIDEN_METHOD:
@@ -425,6 +433,8 @@ public class Messages extends NLS {
 								return 79;
 							case IDelta.DECREASE_ACCESS:
 								return 101;
+							case IDelta.INCREASE_ACCESS:
+								return 114;
 							default:
 								break;
 						}

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/compatible_delta_messages.properties
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/comparator/compatible_delta_messages.properties
@@ -230,3 +230,9 @@
 111=The deprecation modifier has been removed from {0}
 # {0} type name
 112 = The {0} restriction has been removed for type {1}
+# {0} type name, {1} method name
+113 = The default method {0}.{1} has been added in an interface that is tagged with ''@noimplement''
+# {0} type name
+114 = The access of the interface {0} has been increased
+# {0} type name, {1} super interface name, {2} method name
+115 = The interface {0} inherits default method {2} from added superinterface {1} and is tagged as @noimplement


### PR DESCRIPTION
 Add missing message mappings in Messages.getKey() for:
 - INTERFACE + ADDED + DEFAULT_METHOD (new key 113)
 - INTERFACE + ADDED + SUPER_INTERFACE_DEFAULT_METHOD (new key 115)
 - INTERFACE + CHANGED + INCREASE_ACCESS (new key 114)
 - ENUM + ADDED + TYPE_MEMBER (reuse key 16)
 - ANNOTATION + ADDED + TYPE_MEMBER (reuse key 16)

 Also fix ClassFileComparator to use SUPER_INTERFACE_DEFAULT_METHOD
 (not DEFAULT_METHOD) when reporting methods contributed by newly
 added superinterfaces in the expanded set path (line 501).

 Add reproducing tests: InterfaceDeltaTests.test42/43,
 EnumDeltaTests.test17, AnnotationDeltaTests.test12.

 Fixes https://github.com/eclipse-pde/eclipse.pde/issues/2332