### PR TITLE
Serialize LoadTargetDefinitionJob per target handle

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java
@@ -32,6 +32,7 @@ import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PDEPreferencesManager;
 import org.eclipse.pde.internal.core.target.Messages;
 import org.eclipse.pde.internal.core.target.TargetPlatformService;
+import org.eclipse.pde.internal.core.target.TargetResolveSchedulingRule;
 
 /**
  * Sets the current target platform based on a target definition.
@@ -80,6 +81,10 @@ public class LoadTargetDefinitionJob extends WorkspaceJob {
 		Job.getJobManager().cancel(JOB_FAMILY_ID);
 		Job job = new LoadTargetDefinitionJob(target);
 		job.setUser(true);
+		// Serialize loads/resolves of the same target so a new load waits for a
+		// cancelled one to drain, avoiding p2 profile lock races and
+		// Progress-view pile-up.
+		job.setRule(TargetResolveSchedulingRule.forHandle(target.getHandle()));
 		if (listener != null) {
 			job.addJobChangeListener(listener);
 		}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetResolveSchedulingRule.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetResolveSchedulingRule.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.pde.internal.core.target;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.pde.core.target.ITargetHandle;
+
+/**
+ * A scheduling rule that conflicts with other instances sharing the same key,
+ * serializing jobs that operate on the same target handle.
+ */
+public record TargetResolveSchedulingRule(String key) implements ISchedulingRule {
+
+	public static ISchedulingRule forHandle(ITargetHandle handle) {
+		String key;
+		try {
+			key = handle.getMemento();
+		} catch (CoreException e) {
+			key = String.valueOf(System.identityHashCode(handle));
+		}
+		return new TargetResolveSchedulingRule(key);
+	}
+
+	@Override
+	public boolean contains(ISchedulingRule rule) {
+		return isConflicting(rule);
+	}
+
+	@Override
+	public boolean isConflicting(ISchedulingRule rule) {
+		return rule instanceof TargetResolveSchedulingRule other && key.equals(other.key);
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -42,7 +42,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.e4.core.services.events.IEventBroker;
@@ -70,6 +69,7 @@ import org.eclipse.pde.internal.core.target.P2TargetUtils;
 import org.eclipse.pde.internal.core.target.TargetDefinition;
 import org.eclipse.pde.internal.core.target.TargetDefinitionPersistenceHelper;
 import org.eclipse.pde.internal.core.target.TargetPlatformService;
+import org.eclipse.pde.internal.core.target.TargetResolveSchedulingRule;
 import org.eclipse.pde.internal.core.target.WorkspaceFileTargetHandle;
 import org.eclipse.pde.internal.ui.IHelpContextIds;
 import org.eclipse.pde.internal.ui.PDEPlugin;
@@ -647,37 +647,6 @@ public class TargetEditor extends FormEditor {
 	}
 
 	/**
-	 * A scheduling rule keyed by a target handle's memento string. Two
-	 * instances with the same key conflict, which serializes resolve jobs for
-	 * the same target handle while leaving resolves of different targets
-	 * independent. This avoids races on the p2 profile lock/unlock pair (see
-	 * issue #310) and the pile-up of cancelled resolve jobs in the Progress
-	 * view. Because the rule carries only a lightweight String key and is not
-	 * cached in a static map, there is no risk of unbounded retention.
-	 */
-	private record TargetResolveRule(String key) implements ISchedulingRule {
-		@Override
-		public boolean contains(ISchedulingRule rule) {
-			return isConflicting(rule);
-		}
-
-		@Override
-		public boolean isConflicting(ISchedulingRule rule) {
-			return rule instanceof TargetResolveRule other && key.equals(other.key);
-		}
-	}
-
-	private static ISchedulingRule getResolveSchedulingRule(ITargetHandle handle) {
-		String key;
-		try {
-			key = handle.getMemento();
-		} catch (CoreException e) {
-			key = String.valueOf(System.identityHashCode(handle));
-		}
-		return new TargetResolveRule(key);
-	}
-
-	/**
 	 * When changes are noticed in the target, this listener will resolve the
 	 * target and update the necessary pages in the editor.
 	 */
@@ -757,7 +726,7 @@ public class TargetEditor extends FormEditor {
 						return family.equals(getJobFamily());
 					}
 				};
-				resolveJob.setRule(getResolveSchedulingRule(getTarget().getHandle()));
+				resolveJob.setRule(TargetResolveSchedulingRule.forHandle(getTarget().getHandle()));
 				resolveJob.addJobChangeListener(new JobChangeAdapter() {
 					@Override
 					public void done(org.eclipse.core.runtime.jobs.IJobChangeEvent event) {


### PR DESCRIPTION
Clicking "Reload Target Platform" on the editor toolbar cancels the in-flight load and immediately schedules a new one, but `Job.cancel` only flips a flag, so the cancelled job keeps running until its next monitor check. Repeated clicks therefore pile up "Load Target Platform (Cancel Requested)" entries in the Progress view, and two loads of the same target can race on the p2 profile lock/unlock pair inside `P2TargetUtils.deleteProfile`.

Commit 37f88d7f16 addressed the same pattern for the editor's resolve job but did not cover the explicit Reload action, which also calls `target.resolve()` internally. This change promotes the per-target-handle scheduling rule from `TargetEditor` into a shared `TargetResolveSchedulingRule` and applies it to both `LoadTargetDefinitionJob` and the editor's resolve job, so loads and resolves of the same target serialize while operations on different targets remain independent.

Planned for 4.41.