### PR TITLE
Remove redundant progress monitor done() calls

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.1200.qualifier
+Bundle-Version: 1.3.1300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiModelFactory.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiModelFactory.java
@@ -251,74 +251,18 @@ public class ApiModelFactory {
 	public static IApiComponent[] addComponents(IApiBaseline baseline, String installLocation, IProgressMonitor monitor) throws CoreException {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.configuring_baseline, 50);
 		IApiComponent[] result = null;
-		try {
-			// Acquire the service
-			ITargetPlatformService service = null;
-			ApiPlugin plugin = ApiPlugin.getDefault();
-			if (plugin != null) {
-				service = ApiPlugin.getDefault().acquireService(ITargetPlatformService.class);
-				subMonitor.split(1);
-				ITargetLocation container = service.newProfileLocation(installLocation, null);
-				ITargetDefinition definition = service.newTarget();
-				subMonitor.subTask(Messages.resolving_target_definition);
-				container.resolve(definition, subMonitor.split(30));
-				subMonitor.split(1);
-				TargetBundle[] bundles = container.getBundles();
-				List<IApiComponent> components = new ArrayList<>();
-				if (bundles.length > 0) {
-					subMonitor.setWorkRemaining(bundles.length);
-					for (TargetBundle bundle : bundles) {
-						subMonitor.split(1);
-						if (!bundle.isSourceBundle()) {
-							IApiComponent component = ApiModelFactory.newApiComponent(baseline, URIUtil.toFile(bundle.getBundleInfo().getLocation()).getAbsolutePath());
-							if (component != null) {
-								subMonitor.subTask(NLS.bind(Messages.adding_component__0, component.getSymbolicName()));
-								components.add(component);
-							}
-						}
-					}
-				}
-				result = components.toArray(new IApiComponent[components.size()]);
-			} else {
-				// The target platform service is unavailable (OSGi isn't
-				// running), add components by searching the plug-ins directory
-				File dir = new File(installLocation);
-				if (dir.exists()) {
-					File[] files = dir.listFiles();
-					if (files == null) {
-						return NO_COMPONENTS;
-					}
-					List<IApiComponent> components = new ArrayList<>();
-					for (File bundle : files) {
-						IApiComponent component = ApiModelFactory.newApiComponent(baseline, bundle.getAbsolutePath());
-						if (component != null) {
-							components.add(component);
-						}
-					}
-					result = components.toArray(new IApiComponent[components.size()]);
-				}
-			}
-			if (result != null) {
-				baseline.addApiComponents(result);
-				return result;
-			}
-			return NO_COMPONENTS;
-		} finally {
-			subMonitor.done();
-		}
-	}
-
-	public static IApiBaseline newApiBaselineFromTarget(String name, ITargetDefinition definition, IProgressMonitor monitor) throws CoreException {
-		IApiBaseline baseline = new ApiBaseline(name);
-
-		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.configuring_baseline, 50);
-		try {
-			IStatus result = definition.resolve(subMonitor.split(30));
-			if (!result.isOK()) {
-				throw new CoreException(result);
-			}
+		// Acquire the service
+		ITargetPlatformService service = null;
+		ApiPlugin plugin = ApiPlugin.getDefault();
+		if (plugin != null) {
+			service = ApiPlugin.getDefault().acquireService(ITargetPlatformService.class);
 			subMonitor.split(1);
-			TargetBundle[] bundles = definition.getBundles();
+			ITargetLocation container = service.newProfileLocation(installLocation, null);
+			ITargetDefinition definition = service.newTarget();
+			subMonitor.subTask(Messages.resolving_target_definition);
+			container.resolve(definition, subMonitor.split(30));
+			subMonitor.split(1);
+			TargetBundle[] bundles = container.getBundles();
 			List<IApiComponent> components = new ArrayList<>();
 			if (bundles.length > 0) {
 				subMonitor.setWorkRemaining(bundles.length);
@@ -333,12 +277,60 @@ public class ApiModelFactory {
 					}
 				}
 			}
-			baseline.addApiComponents(components.toArray(new IApiComponent[components.size()]));
-			baseline.setLocation(generateTargetLocation(definition));
-			return baseline;
-		} finally {
-			subMonitor.done();
+			result = components.toArray(new IApiComponent[components.size()]);
+		} else {
+			// The target platform service is unavailable (OSGi isn't
+			// running), add components by searching the plug-ins directory
+			File dir = new File(installLocation);
+			if (dir.exists()) {
+				File[] files = dir.listFiles();
+				if (files == null) {
+					return NO_COMPONENTS;
+				}
+				List<IApiComponent> components = new ArrayList<>();
+				for (File bundle : files) {
+					IApiComponent component = ApiModelFactory.newApiComponent(baseline, bundle.getAbsolutePath());
+					if (component != null) {
+						components.add(component);
+					}
+				}
+				result = components.toArray(new IApiComponent[components.size()]);
+			}
 		}
+		if (result != null) {
+			baseline.addApiComponents(result);
+			return result;
+		}
+		return NO_COMPONENTS;
+	}
+
+	public static IApiBaseline newApiBaselineFromTarget(String name, ITargetDefinition definition, IProgressMonitor monitor) throws CoreException {
+		IApiBaseline baseline = new ApiBaseline(name);
+
+		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.configuring_baseline, 50);
+		IStatus result = definition.resolve(subMonitor.split(30));
+		if (!result.isOK()) {
+			throw new CoreException(result);
+		}
+		subMonitor.split(1);
+		TargetBundle[] bundles = definition.getBundles();
+		List<IApiComponent> components = new ArrayList<>();
+		if (bundles.length > 0) {
+			subMonitor.setWorkRemaining(bundles.length);
+			for (TargetBundle bundle : bundles) {
+				subMonitor.split(1);
+				if (!bundle.isSourceBundle()) {
+					IApiComponent component = ApiModelFactory.newApiComponent(baseline, URIUtil.toFile(bundle.getBundleInfo().getLocation()).getAbsolutePath());
+					if (component != null) {
+						subMonitor.subTask(NLS.bind(Messages.adding_component__0, component.getSymbolicName()));
+						components.add(component);
+					}
+				}
+			}
+		}
+		baseline.addApiComponents(components.toArray(new IApiComponent[components.size()]));
+		baseline.setLocation(generateTargetLocation(definition));
+		return baseline;
 	}
 
 	/**

--- a/features/org.eclipse.pde.unittest.junit-feature/feature.xml
+++ b/features/org.eclipse.pde.unittest.junit-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde.unittest.junit"
       label="%featureName"
-      version="1.0.1300.qualifier"
+      version="1.0.1400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Generic UI components related to BND
 Bundle-SymbolicName: org.eclipse.pde.bnd.ui;singleton:=true
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 1.2.600.qualifier
+Bundle-Version: 1.2.700.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.bnd.ui.autocomplete;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.plugins;x-internal:=true,

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/RefreshFileJob.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/RefreshFileJob.java
@@ -55,7 +55,6 @@ public class RefreshFileJob extends WorkspaceJob {
 				progress.worked(1);
 			}
 		}
-		progress.done();
 		return Status.OK_STATUS;
 	}
 }

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/wizards/AddFilesToRepositoryWizard.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/wizards/AddFilesToRepositoryWizard.java
@@ -123,7 +123,6 @@ public class AddFilesToRepositoryWizard extends Wizard {
 				if (refreshJob.needsToSchedule()) {
 					refreshJob.schedule();
 				}
-				progress.done();
 				return status;
 			}
 		};

--- a/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.core; singleton:=true
-Bundle-Version: 3.21.300.qualifier
+Bundle-Version: 3.21.400.qualifier
 Bundle-Activator: org.eclipse.pde.internal.core.PDECore
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/AbstractBundleContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/AbstractBundleContainer.java
@@ -104,11 +104,6 @@ public abstract class AbstractBundleContainer extends PlatformObject implements 
 			fFeatures = new TargetFeature[0];
 			fResolutionStatus = e.getStatus();
 			PDECore.log(e.getStatus());
-		} finally {
-			subMonitor.done();
-			if (monitor != null) {
-				monitor.done();
-			}
 		}
 		return fResolutionStatus;
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetDefinition.java
@@ -417,7 +417,6 @@ public class TargetDefinition implements ITargetDefinition {
 		} finally {
 			// keep a list of resolved targets with key as handle
 			TargetPlatformHelper.addTargetDefinitionMap(this);
-			subMonitor.done();
 		}
 	}
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/CoreUtility.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/CoreUtility.java
@@ -142,8 +142,6 @@ public class CoreUtility {
 				}
 			}
 			fileToDelete.delete();
-
-			subMon.done();
 		}
 	}
 

--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.13.700.qualifier
+Bundle-Version: 3.13.800.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/launching/JUnitLaunchConfigurationDelegate.java
@@ -584,8 +584,6 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
 		if (configuration.getAttribute(IPDELauncherConstants.CONFIG_CLEAR_AREA, false)) {
 			CoreUtility.deleteContent(getConfigurationDirectory(configuration), subMon.split(25));
 		}
-
-		subMon.done();
 	}
 
 	/**

--- a/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.ui; singleton:=true
-Bundle-Version: 3.16.500.qualifier
+Bundle-Version: 3.16.600.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ui.PDEPlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/TargetPlatformPreferencePage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/preferences/TargetPlatformPreferencePage.java
@@ -33,7 +33,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
@@ -318,14 +317,9 @@ public class TargetPlatformPreferencePage extends PreferencePage implements IWor
 		public TargetDefinition defaultTarget;
 		@Override
 		public IStatus run(IProgressMonitor monitor) {
-			SubMonitor subMon = SubMonitor.convert(monitor);
 			ITargetPlatformService service = getTargetService();
 			if (service != null) {
 				defaultTarget = (TargetDefinition) service.newDefaultTarget();
-			}
-			subMon.done();
-			if (monitor != null) {
-				monitor.done();
 			}
 			return Status.OK_STATUS;
 		}

--- a/ui/org.eclipse.pde.unittest.junit/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.pde.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.unittest.junit;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.400.qualifier
 Bundle-Activator: org.eclipse.pde.unittest.junit.JUnitPluginTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
+++ b/ui/org.eclipse.pde.unittest.junit/src/org/eclipse/pde/unittest/junit/launcher/JUnitPluginLaunchConfigurationDelegate.java
@@ -1208,8 +1208,6 @@ public class JUnitPluginLaunchConfigurationDelegate extends AbstractJavaLaunchCo
 		if (configuration.getAttribute(IPDELauncherConstants.CONFIG_CLEAR_AREA, false)) {
 			CoreUtility.deleteContent(getConfigurationDirectory(configuration), subMon.split(25));
 		}
-
-		subMon.done();
 	}
 
 	/**


### PR DESCRIPTION
`SubMonitor.done()` is effectively a no-op in well-formed code because the parent `SubMonitor.convert` call already manages parent ticks. Where the only purpose of a `try/finally` block was to call `done()`, the block has been removed and the body de-indented.

Calling `done()` on the raw `IProgressMonitor` parameter is also an antipattern: only the code that created the monitor is supposed to call `done()` on it. That covers `Job.run` overrides (the Jobs framework already does it) and methods that receive a monitor from a caller (the caller owns its lifecycle). In `TargetPlatformPreferencePage.LoadDefaultTargetJob` the `SubMonitor` was created but never used to report progress, so the `convert` call and its now-unused import are removed too.

Reference: https://www.eclipse.org/articles/Article-Progress-Monitors/article.html

**Planned for 4.41**