### PR TITLE
Remove unnecessary single quotes for links

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -1345,7 +1345,7 @@ ShowBundlesDialog_Close=&Close
 ShowBundlesDialog_LaunchBundles=Launch Bundles
 
 # DO NOT TRANSLATE "org.eclipse.ui.preferencePages.GeneralTextEditor" and "org.eclipse.ui.preferencePages.ColorsAndFonts"
-EditorPreferencePage_link=See <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">'Text Editors'</a> for general text editor preferences and <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">'Colors and Fonts'</a> to configure the font.
+EditorPreferencePage_link=See <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">Text Editors</a> for general text editor preferences and <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">Colors and Fonts</a> to configure the font.
 
 EditorPreferencePage_string=Constant strings
 EditorUtilities_noImageData=The specified file contains no image data


### PR DESCRIPTION
This change removes the unnecessary quotes around `Text Editors` and `Colors and Fonts` in the properties strings.

The single quotes around the placeholder text in the preference page were likely added following older UI conventions. Quotes often differentiate literal text or placeholders from the rest of the message. Since the text already appears as a blue clickable link, the additional quotes are unnecessary. Removing them keeps the link still clickable while making the message cleaner and consistent with other preference links across the UI, where such quotes are not used.
The PR changes the link like other links provided in other areas in Preference page like `File Associations`.
As an example ->
<img width="925" height="491" alt="image" src="https://github.com/user-attachments/assets/3065d5ba-b4e6-49c0-be9e-d8399c577f2d" />

Before pr ->
<img width="1002" height="617" alt="image" src="https://github.com/user-attachments/assets/d1c3cce9-8b3d-4eef-8273-ce8d1d9584e0" />


After pr -> 
<img width="961" height="633" alt="image" src="https://github.com/user-attachments/assets/d9bd8245-e6a1-4fde-b651-8d39e6391578" />
