### PR TITLE
Fix preference spy correctness bugs

### DIFF
--- a/features/org.eclipse.pde.spies-feature/feature.xml
+++ b/features/org.eclipse.pde.spies-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde.spies"
       label="%featureName"
-      version="1.0.1100.qualifier"
+      version="1.0.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde.spy.preferences/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.preferences;singleton:=true
-Bundle-Version: 0.14.100.qualifier
+Bundle-Version: 0.14.200.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.preferences
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %provider-name

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/model/PreferenceEntry.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/model/PreferenceEntry.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.pde.spy.preferences.model;
 
+import java.util.Objects;
+
 public class PreferenceEntry extends AbstractModelObject {
 
 	public enum Fields {
@@ -42,13 +44,6 @@ public class PreferenceEntry extends AbstractModelObject {
 	}
 
 	public PreferenceEntry(String nodePath, String key, String oldValue, String newValue) {
-		this.nodePath = nodePath;
-		this.key = key;
-		this.oldValue = oldValue;
-		this.newValue = newValue;
-	}
-
-	public PreferenceEntry(PreferenceEntry parent, String nodePath, String key, String oldValue, String newValue) {
 		this.nodePath = nodePath;
 		this.key = key;
 		this.oldValue = oldValue;
@@ -103,17 +98,11 @@ public class PreferenceEntry extends AbstractModelObject {
 		firePropertyChange("recentlyChanged", this.recentlyChanged, this.recentlyChanged = recentlyChanged);
 	}
 
+	// Identity is the (nodePath, key) pair. Mutable fields like oldValue/newValue/recentlyChanged
+	// must not participate, because instances are stored in a WritableSet and mutated in place.
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((key == null) ? 0 : key.hashCode());
-		result = prime * result + ((newValue == null) ? 0 : newValue.hashCode());
-		result = prime * result + ((nodePath == null) ? 0 : nodePath.hashCode());
-		result = prime * result + ((oldValue == null) ? 0 : oldValue.hashCode());
-		result = prime * result + ((parent == null) ? 0 : parent.hashCode());
-		result = prime * result + (recentlyChanged ? 1231 : 1237);
-		return result;
+		return Objects.hash(nodePath, key);
 	}
 
 	@Override
@@ -121,52 +110,11 @@ public class PreferenceEntry extends AbstractModelObject {
 		if (this == obj) {
 			return true;
 		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
+		if (obj == null || getClass() != obj.getClass()) {
 			return false;
 		}
 		PreferenceEntry other = (PreferenceEntry) obj;
-		if (key == null) {
-			if (other.key != null) {
-				return false;
-			}
-		} else if (!key.equals(other.key)) {
-			return false;
-		}
-		if (newValue == null) {
-			if (other.newValue != null) {
-				return false;
-			}
-		} else if (!newValue.equals(other.newValue)) {
-			return false;
-		}
-		if (nodePath == null) {
-			if (other.nodePath != null) {
-				return false;
-			}
-		} else if (!nodePath.equals(other.nodePath)) {
-			return false;
-		}
-		if (oldValue == null) {
-			if (other.oldValue != null) {
-				return false;
-			}
-		} else if (!oldValue.equals(other.oldValue)) {
-			return false;
-		}
-		if (parent == null) {
-			if (other.parent != null) {
-				return false;
-			}
-		} else if (!parent.equals(other.parent)) {
-			return false;
-		}
-		if (recentlyChanged != other.recentlyChanged) {
-			return false;
-		}
-		return true;
+		return Objects.equals(nodePath, other.nodePath) && Objects.equals(key, other.key);
 	}
 
 	public long getTime() {

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/parts/PreferenceSpyPart.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/parts/PreferenceSpyPart.java
@@ -196,9 +196,13 @@ public class PreferenceSpyPart {
 			@UIEventTopic(PreferenceSpyEventTopics.PREFERENCESPY_PREFERENCE_ENTRIES_DELETE) List<PreferenceEntry> preferenceEntries) {
 		if (preferenceEntries != null && !preferenceEntries.isEmpty()) {
 			for (PreferenceEntry preferenceEntry : preferenceEntries) {
-				preferenceEntryManager.removeChildren(preferenceEntry);
+				PreferenceEntry parent = preferenceEntry.getParent();
+				if (parent instanceof PreferenceNodeEntry parentNode) {
+					parentNode.removeChildren(preferenceEntry);
+				} else {
+					preferenceEntryManager.removeChildren(preferenceEntry);
+				}
 			}
-			preferenceEntryManager.removeChildren(preferenceEntries);
 			filteredTree.getViewer().refresh();
 		}
 	}

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceEntryViewerComparator.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceEntryViewerComparator.java
@@ -35,7 +35,7 @@ public class PreferenceEntryViewerComparator extends ViewerComparator {
 			long time2 = entry2.getTime();
 
 			if (time != 0 && time2 != 0) {
-				return (int) (time2 - time);
+				return Long.compare(time2, time);
 			}
 		}
 


### PR DESCRIPTION
**Planned for 4.41**

Fixes four real correctness issues in the Preference Spy: PreferenceEntry's equals/hashCode included mutable fields while instances live in a WritableSet that mutates them in place, which silently broke Set lookups; PreferenceEntryViewerComparator cast a long time delta to int and could overflow; the DeletePreferenceEntries handler removed entries from the root manager instead of their PreferenceNodeEntry parent, making the action a no-op for non-root rows; and a buggy 5-arg constructor accepted a parent argument that it never assigned. Identity is now (nodePath, key), comparator uses Long.compare, delete walks to the actual parent, and the dead constructor is gone.

Preparation for #2344.