### PR TITLE
Clean up preference spy

### DIFF
--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/PreferenceSpyConfiguration.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/PreferenceSpyConfiguration.java
@@ -21,14 +21,13 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
  */
 public class PreferenceSpyConfiguration {
 
-	private static String bundleId = "org.eclipse.pde.spy.preferences";
+	private static final String BUNDLE_ID = "org.eclipse.pde.spy.preferences";
 
 	private static IEclipsePreferences preferenceStore;
 
 	public static IEclipsePreferences getPreferenceStore() {
-		// Create the preference store lazily.
 		if (preferenceStore == null) {
-			preferenceStore = 	InstanceScope.INSTANCE.getNode(bundleId);;
+			preferenceStore = InstanceScope.INSTANCE.getNode(BUNDLE_ID);
 		}
 		return preferenceStore;
 	}

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/addon/PreferenceSpyAddon.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/addon/PreferenceSpyAddon.java
@@ -60,7 +60,7 @@ public class PreferenceSpyAddon {
 
 	@Inject
 	@Optional
-	public void initialzePreferenceSpy(
+	public void initializePreferenceSpy(
 			@Preference(value = PreferenceConstants.TRACE_PREFERENCES) boolean tracePreferences) {
 		if (tracePreferences) {
 			registerVisitors();

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/CollapseAllHandler.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/CollapseAllHandler.java
@@ -21,9 +21,8 @@ public class CollapseAllHandler {
 
 	@Execute
 	public void execute(MPart part) {
-		Object partImpl = part.getObject();
-		if (partImpl instanceof PreferenceSpyPart) {
-			((PreferenceSpyPart) partImpl).getViewer().collapseAll();
+		if (part.getObject() instanceof PreferenceSpyPart spy) {
+			spy.getViewer().collapseAll();
 		}
 	}
 

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ExpandAllHandler.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ExpandAllHandler.java
@@ -21,9 +21,8 @@ public class ExpandAllHandler {
 
 	@Execute
 	public void execute(MPart part) {
-		Object partImpl = part.getObject();
-		if (partImpl instanceof PreferenceSpyPart) {
-			((PreferenceSpyPart) partImpl).getViewer().expandAll();
+		if (part.getObject() instanceof PreferenceSpyPart spy) {
+			spy.getViewer().expandAll();
 		}
 	}
 

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
@@ -33,6 +33,9 @@ import org.eclipse.swt.widgets.Shell;
 import org.osgi.service.prefs.BackingStoreException;
 
 public class ShowAllPreferencesHandler {
+
+	private static final String DEFAULT_VALUE_MARKER = "*default*";
+
 	@Execute
 	public void execute(Shell shell, IEventBroker eventBroker) {
 		Map<String, PreferenceNodeEntry> preferenceEntries = new HashMap<>();
@@ -45,7 +48,7 @@ public class ShowAllPreferencesHandler {
 			PreferenceNodeEntry preferenceNodeEntry = preferenceEntries.computeIfAbsent(node.absolutePath(),
 					PreferenceNodeEntry::new);
 			for (String key : keys) {
-				String value = node.get(key, "*default*");
+				String value = node.get(key, DEFAULT_VALUE_MARKER);
 				preferenceNodeEntry.addChildren(new PreferenceEntry(node.absolutePath(), key, value, value));
 			}
 			return true;

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/model/PreferenceEntryManager.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/model/PreferenceEntryManager.java
@@ -27,10 +27,6 @@ public class PreferenceEntryManager extends PreferenceNodeEntry {
 		return recentPreferenceEntries.get(nodePath);
 	}
 
-	public PreferenceNodeEntry removeRecentPreferenceNodeEntry(String nodePath) {
-		return recentPreferenceEntries.remove(nodePath);
-	}
-
 	public void clearRecentPreferenceNodeEntry() {
 		recentPreferenceEntries.clear();
 	}

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/model/PreferenceNodeEntry.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/model/PreferenceNodeEntry.java
@@ -21,7 +21,7 @@ import org.eclipse.core.databinding.observable.set.WritableSet;
 
 public class PreferenceNodeEntry extends PreferenceEntry {
 
-	private IObservableSet<Object> preferenceEntries = new WritableSet<>();
+	private final IObservableSet<PreferenceEntry> preferenceEntries = new WritableSet<>();
 
 	public PreferenceNodeEntry() {
 		super();
@@ -32,27 +32,23 @@ public class PreferenceNodeEntry extends PreferenceEntry {
 	}
 
 	public void addChildren(Collection<PreferenceEntry> entries) {
-		getPreferenceEntries().addAll(entries);
+		preferenceEntries.addAll(entries);
 	}
 
 	public boolean addChildren(PreferenceEntry... entry) {
-		return getPreferenceEntries().addAll(Arrays.asList(entry));
+		return preferenceEntries.addAll(Arrays.asList(entry));
 	}
 
 	public void removeChildren(Collection<PreferenceEntry> entries) {
-		getPreferenceEntries().removeAll(entries);
+		preferenceEntries.removeAll(entries);
 	}
 
 	public void removeChildren(PreferenceEntry... entry) {
-		getPreferenceEntries().removeAll(Arrays.asList(entry));
+		preferenceEntries.removeAll(Arrays.asList(entry));
 	}
 
-	public IObservableSet<Object> getPreferenceEntries() {
+	public IObservableSet<PreferenceEntry> getPreferenceEntries() {
 		return preferenceEntries;
-	}
-
-	public void setPreferenceEntries(IObservableSet<Object> preferenceEntries) {
-		this.preferenceEntries = preferenceEntries;
 	}
 
 }

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/parts/PreferenceSpyPart.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/parts/PreferenceSpyPart.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.Realm;
-import org.eclipse.core.databinding.observable.set.IObservableSet;
 import org.eclipse.core.databinding.property.Properties;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.e4.core.di.annotations.Optional;
@@ -32,7 +31,6 @@ import org.eclipse.e4.ui.workbench.modeling.ESelectionService;
 import org.eclipse.jface.databinding.swt.DisplayRealm;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
-import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.TreeViewerColumn;
@@ -77,10 +75,8 @@ public class PreferenceSpyPart {
 		table.setLinesVisible(true);
 
 		filteredTree.getViewer().addSelectionChangedListener(event -> {
-			ISelection selection = event.getSelection();
-			if (selection instanceof IStructuredSelection) {
-				ArrayList<PreferenceEntry> preferenceEntries = new ArrayList<>(
-						((IStructuredSelection) selection).toList());
+			if (event.getSelection() instanceof IStructuredSelection structured) {
+				ArrayList<PreferenceEntry> preferenceEntries = new ArrayList<>(structured.toList());
 				selectionService.setSelection(preferenceEntries);
 			}
 		});
@@ -146,7 +142,6 @@ public class PreferenceSpyPart {
 			preferenceNodeEntry.addChildren(preferenceEntry);
 			preferenceEntry.setParent(preferenceNodeEntry);
 			preferenceEntryManager.addChildren(preferenceNodeEntry);
-			filteredTree.getViewer().setInput(preferenceEntryManager);
 			preferenceEntryManager.putRecentPreferenceEntry(event.getNode().absolutePath(), preferenceNodeEntry);
 		} else {
 			preferenceEntry.setParent(preferenceNodeEntry);
@@ -168,14 +163,10 @@ public class PreferenceSpyPart {
 	}
 
 	private PreferenceEntry findPreferenceEntry(PreferenceEntry preferenceEntry) {
-		PreferenceEntry parent = preferenceEntry.getParent();
-		if (parent instanceof PreferenceNodeEntry) {
-			IObservableSet<Object> preferenceEntries = ((PreferenceNodeEntry) parent).getPreferenceEntries();
-			for (Object object : preferenceEntries) {
-				if (object instanceof PreferenceEntry existingPreferenceEntry) {
-					if (existingPreferenceEntry.getKey().equals(preferenceEntry.getKey())) {
-						return existingPreferenceEntry;
-					}
+		if (preferenceEntry.getParent() instanceof PreferenceNodeEntry parentNode) {
+			for (PreferenceEntry existing : parentNode.getPreferenceEntries()) {
+				if (existing.equals(preferenceEntry)) {
+					return existing;
 				}
 			}
 		}
@@ -192,7 +183,7 @@ public class PreferenceSpyPart {
 
 	@Inject
 	@Optional
-	public void DeletePreferenceEntries(
+	public void deletePreferenceEntries(
 			@UIEventTopic(PreferenceSpyEventTopics.PREFERENCESPY_PREFERENCE_ENTRIES_DELETE) List<PreferenceEntry> preferenceEntries) {
 		if (preferenceEntries != null && !preferenceEntries.isEmpty()) {
 			for (PreferenceEntry preferenceEntry : preferenceEntries) {
@@ -209,7 +200,7 @@ public class PreferenceSpyPart {
 
 	@Inject
 	@Optional
-	public void DeleteAllPreferenceEntries(
+	public void deleteAllPreferenceEntries(
 			@UIEventTopic(PreferenceSpyEventTopics.PREFERENCESPY_PREFERENCE_ENTRIES_DELETE_ALL) List<PreferenceEntry> preferenceEntries) {
 		if (preferenceEntryManager != null) {
 			preferenceEntryManager.clearRecentPreferenceNodeEntry();

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceEntriesContentProvider.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/viewer/PreferenceEntriesContentProvider.java
@@ -17,18 +17,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.databinding.observable.masterdetail.IObservableFactory;
-import org.eclipse.core.databinding.observable.set.IObservableSet;
 import org.eclipse.jface.databinding.viewers.ObservableSetTreeContentProvider;
 import org.eclipse.jface.databinding.viewers.TreeStructureAdvisor;
 import org.eclipse.pde.spy.preferences.model.PreferenceEntry;
 import org.eclipse.pde.spy.preferences.model.PreferenceNodeEntry;
 
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class PreferenceEntriesContentProvider extends ObservableSetTreeContentProvider {
 
 	private boolean hierarchicalLayout;
 
-	@SuppressWarnings("unchecked")
 	public PreferenceEntriesContentProvider(IObservableFactory setFactory, TreeStructureAdvisor structureAdvisor) {
 		super(setFactory, structureAdvisor);
 	}
@@ -43,20 +41,19 @@ public class PreferenceEntriesContentProvider extends ObservableSetTreeContentPr
 		List<PreferenceEntry> childList = new ArrayList<>();
 
 		for (Object object : children) {
-			getChildren(object, childList);
+			collectLeaves(object, childList);
 		}
 
 		return childList.toArray();
 	}
 
-	private void getChildren(Object element, List<PreferenceEntry> childList) {
-		if (element instanceof PreferenceNodeEntry) {
-			IObservableSet preferenceEntries = ((PreferenceNodeEntry) element).getPreferenceEntries();
-			for (Object object : preferenceEntries) {
-				getChildren(object, childList);
+	private void collectLeaves(Object element, List<PreferenceEntry> childList) {
+		if (element instanceof PreferenceNodeEntry nodeEntry) {
+			for (PreferenceEntry child : nodeEntry.getPreferenceEntries()) {
+				collectLeaves(child, childList);
 			}
-		} else if (element instanceof PreferenceEntry) {
-			childList.add((PreferenceEntry) element);
+		} else if (element instanceof PreferenceEntry preferenceEntry) {
+			childList.add(preferenceEntry);
 		}
 	}
 


### PR DESCRIPTION
**Planned for 4.41**

Modernizes and tidies the Preference Spy bundle on top of the bug-fix PR (#2345): fixes the `initialze` typo, gives `DeletePreferenceEntries`/`DeleteAllPreferenceEntries` proper camelCase names, turns `bundleId` into a static final `BUNDLE_ID` and drops a stray double semicolon, applies pattern-matching `instanceof`, types `PreferenceNodeEntry.preferenceEntries` as `IObservableSet<PreferenceEntry>` (which collapses the manual `instanceof` walks in the content provider and `findPreferenceEntry`), removes a redundant `setInput` call that propagates for free through the observable set, drops two unused setters, and extracts the `"*default*"` marker into a constant.

Depends on #2345; will be rebased onto master after that lands.

Preparation for #2344.