### PR TITLE
Track UserScope in preference spy

### DIFF
--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/addon/PreferenceSpyAddon.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/addon/PreferenceSpyAddon.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.UserScope;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.e4.core.services.events.IEventBroker;
@@ -53,6 +54,7 @@ public class PreferenceSpyAddon {
 	private final IEclipsePreferences configurationScopePreferences = ConfigurationScope.INSTANCE.getNode("");
 	private final IEclipsePreferences defaultScopePreferences = DefaultScope.INSTANCE.getNode("");
 	private final IEclipsePreferences instanceScopePreferences = InstanceScope.INSTANCE.getNode("");
+	private final IEclipsePreferences userScopePreferences = UserScope.INSTANCE.getNode("");
 
 	private final ChangedPreferenceListener preferenceChangedListener = new ChangedPreferenceListener();
 
@@ -72,6 +74,7 @@ public class PreferenceSpyAddon {
 		addPreferenceListener(configurationScopePreferences);
 		addPreferenceListener(defaultScopePreferences);
 		addPreferenceListener(instanceScopePreferences);
+		addPreferenceListener(userScopePreferences);
 	}
 
 	private void addPreferenceListener(IEclipsePreferences rootPreference) {
@@ -90,6 +93,7 @@ public class PreferenceSpyAddon {
 		removePreferenceListener(configurationScopePreferences);
 		removePreferenceListener(defaultScopePreferences);
 		removePreferenceListener(instanceScopePreferences);
+		removePreferenceListener(userScopePreferences);
 	}
 
 	private void removePreferenceListener(IEclipsePreferences rootPreference) {

--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IPreferenceNodeVisitor;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.UserScope;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -54,6 +55,7 @@ public class ShowAllPreferencesHandler {
 			ConfigurationScope.INSTANCE.getNode("").accept(gatherer);
 			DefaultScope.INSTANCE.getNode("").accept(gatherer);
 			InstanceScope.INSTANCE.getNode("").accept(gatherer);
+			UserScope.INSTANCE.getNode("").accept(gatherer);
 		} catch (BackingStoreException e) {
 			ErrorDialog.openError(shell, "BackingStoreException", e.getLocalizedMessage(),
 					Status.error(e.getMessage()));


### PR DESCRIPTION
**Planned for 4.41**

`UserScope` was added to Equinox preferences in [eclipse-equinox/equinox#446](https://github.com/eclipse-equinox/equinox/pull/446) and stores per-user-global preferences under `<user.home>/.eclipse`. The Preference Spy already watches `BundleDefaults`, `Configuration`, `Default` and `Instance`, so user-scoped changes were silently missed. This PR registers the same change listener on `UserScope` and includes it in the Show All Preferences walker, so anything written there now shows up in the spy.

Independent of #2345 and #2346; touches only `PreferenceSpyAddon` and `ShowAllPreferencesHandler`.

Fixes #2344.