### PR TITLE
 Fix: Update name-relative fields even when project name is empty

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/wizards/AbstractFeatureSpecPageTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/wizards/AbstractFeatureSpecPageTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.pde.ui.tests.wizards;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.pde.internal.ui.wizards.feature.AbstractFeatureSpecPage;
+import org.eclipse.pde.internal.ui.wizards.feature.FeatureData;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractFeatureSpecPageTest {
+
+	private static final String FEATURE_ID = "test.feature.id"; //$NON-NLS-1$
+	private static final String PROJECT_NAME = "test.project.name"; //$NON-NLS-1$
+
+	private Shell fShell;
+
+	@Before
+	public void setUp() {
+		fShell = new Shell(Display.getDefault());
+	}
+
+	@After
+	public void tearDown() {
+		if (fShell != null && !fShell.isDisposed()) {
+			fShell.dispose();
+		}
+	}
+
+	@Test
+	public void testUpdateNameRelativeFields_calledIfPageIsNotValid() {
+		AtomicBoolean updateNameCalled = new AtomicBoolean(false);
+		boolean isValid = buildAndValidatePage(null, updateNameCalled);
+
+		assertFalse("page should not be valid", isValid);
+		assertTrue("updateNameRelativeFields() should be called when page is not valid", updateNameCalled.get());
+	}
+
+	@Test
+	public void testUpdateNameRelativeFields_calledIfPageIsValid() {
+		AtomicBoolean updateNameCalled = new AtomicBoolean(false);
+		boolean isValid = buildAndValidatePage(PROJECT_NAME, updateNameCalled);
+
+		assertTrue("page should be valid", isValid);
+		assertTrue("updateNameRelativeFields() should be called when page is valid", updateNameCalled.get());
+	}
+
+	private boolean buildAndValidatePage(String projectName, AtomicBoolean updateNameCalled) {
+		TestableFeatureSpecPage page = new TestableFeatureSpecPage(updateNameCalled);
+		page.setInitialProjectName(projectName);
+		page.setInitialId(FEATURE_ID);
+		page.createContents(fShell);
+		page.initialize();
+		page.createControl(fShell);
+		return page.validatePagePublic();
+	}
+
+	private static class TestableFeatureSpecPage extends AbstractFeatureSpecPage {
+
+		private final AtomicBoolean updateNameCalled;
+
+		TestableFeatureSpecPage(AtomicBoolean updateNameCalled) {
+			this.updateNameCalled = updateNameCalled;
+		}
+
+		@Override
+		protected void updateNameRelativeFields() {
+			updateNameCalled.set(true);
+		}
+
+		@Override
+		protected void createContents(Composite container) {
+			createCommonInput(container);
+			createInstallHandlerText(container);
+		}
+
+		@Override
+		protected void initialize() {
+			fFeatureNameText.setText("Test Feature"); //$NON-NLS-1$
+			fFeatureVersionText.setText("1.0.0"); //$NON-NLS-1$
+		}
+
+		@Override
+		protected void attachListeners(ModifyListener listener) {
+			// No listeners needed for this test
+		}
+
+		@Override
+		protected String getHelpId() {
+			return ""; //$NON-NLS-1$
+		}
+
+		@Override
+		protected void saveSettings(IDialogSettings settings) {
+			// No settings to save for this test
+		}
+
+		@Override
+		protected String validateContent() {
+			return null;
+		}
+
+		@Override
+		protected String getFeatureId() {
+			return FEATURE_ID;
+		}
+
+		@Override
+		public FeatureData getFeatureData() {
+			FeatureData data = new FeatureData();
+			data.id = getFeatureId();
+			data.name = fFeatureNameText.getText();
+			data.version = fFeatureVersionText.getText();
+			return data;
+		}
+
+		public boolean validatePagePublic() {
+			return validatePage();
+		}
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/feature/AbstractFeatureSpecPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/feature/AbstractFeatureSpecPage.java
@@ -92,11 +92,11 @@ public abstract class AbstractFeatureSpecPage extends WizardNewProjectCreationPa
 	@Override
 	protected boolean validatePage() {
 		boolean valid = super.validatePage();
-		if (!valid) {
-			return valid;
-		}
 		if (fUpdateName) {
 			updateNameRelativeFields();
+		}
+		if (!valid) {
+			return valid;
 		}
 		return validateBaseContent(false);
 	}


### PR DESCRIPTION
### Problem

When the project name field was left empty (or otherwise invalid), the feature name and version fields were not being updated automatically. This broke the "auto-fill" behaviour that derives name-relative field values from the project name during the initial wizard state.

<img width="508" height="578" alt="before" src="https://github.com/user-attachments/assets/3149802d-0883-4166-9d0c-a140a152965c" />

### Fix

Moved the `updateNameRelativeFields()` call to before the early-return guard, so that name-relative fields are always refreshed when `fUpdateName` is true, regardless of whether the rest of the page is currently valid.

<img width="526" height="572" alt="after" src="https://github.com/user-attachments/assets/cb937ca9-e2bf-46a9-9064-02dcd401f61f" />
