### PR TITLE
Make CSS spy selector handling API-version agnostic

### DIFF
--- a/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.css;singleton:=true
-Bundle-Version: 0.14.100.qualifier
+Bundle-Version: 0.14.200.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.css
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CssSpyPart.java
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CssSpyPart.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -99,7 +100,6 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
-import org.w3c.css.sac.SelectorList;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.css.CSSRule;
@@ -969,9 +969,17 @@ public class CssSpyPart {
 
 			CSSEngine engine = getCSSEngine(root);
 			try {
-				SelectorList selectors = engine.parseSelectors(text);
+				var selectors = engine.parseSelectors(text);
+				Predicate<CSSStylableElement> matcher = el -> {
+					for (int i = 0; i < selectors.getLength(); i++) {
+						if (engine.matches(selectors.item(i), el, null)) {
+							return true;
+						}
+					}
+					return false;
+				};
 				subMonitor.split(2);
-				processCSSSearch(subMonitor.split(8), engine, selectors, element, null, results);
+				processCSSSearch(subMonitor.split(8), matcher, element, results);
 			} catch (Exception e) {
 				System.out.println(e.toString());
 			}
@@ -979,27 +987,21 @@ public class CssSpyPart {
 		monitor.done();
 	}
 
-	private void processCSSSearch(IProgressMonitor monitor, CSSEngine engine, SelectorList selectors,
-			CSSStylableElement element, String pseudo, Collection<Widget> results) {
+	private void processCSSSearch(IProgressMonitor monitor, Predicate<CSSStylableElement> matcher,
+			CSSStylableElement element, Collection<Widget> results) {
 
 		if (monitor.isCanceled()) {
 			return;
 		}
 		NodeList children = element.getChildNodes();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.CssSpyPart_Searching, 5 + 5 * children.getLength());
-		boolean matched = false;
-		for (int i = 0; i < selectors.getLength(); i++) {
-			if (matched = engine.matches(selectors.item(i), element, pseudo)) {
-				break;
-			}
-		}
-		if (matched) {
+		if (matcher.test(element)) {
 			results.add((Widget) element.getNativeWidget());
 		}
 		subMonitor.split(5);
 		for (int i = 0; i < children.getLength(); i++) {
-			processCSSSearch(subMonitor.split(5), engine, selectors,
-					(CSSStylableElement) children.item(i), pseudo, results);
+			processCSSSearch(subMonitor.split(5), matcher,
+					(CSSStylableElement) children.item(i), results);
 		}
 	}
 
@@ -1196,7 +1198,7 @@ public class CssSpyPart {
 					continue;
 				}
 				try {
-					SelectorList selectors = engine.parseSelectors(styleRule.getSelectorText());
+					var selectors = engine.parseSelectors(styleRule.getSelectorText());
 					boolean matched = false;
 					for (int k = 0; k < selectors.getLength(); k++) {
 						if (engine.matches(selectors.item(k), element, null)) {


### PR DESCRIPTION
The CSS spy referenced `org.w3c.css.sac.SelectorList` and `Selector` directly, which breaks once eclipse.platform.ui [#4051](https://github.com/eclipse-platform/eclipse.platform.ui/pull/4051) switches `CSSEngine.parseSelectors()` and `matches()` to an internal `Selectors` AST.

Since both the old and new selector list types expose the same `getLength()`/`item(int)` and round-trip cleanly through `engine.matches(...)`, the spy no longer needs to name the type at all. The parsed selectors are now held in `var` locals and the recursive search takes a `Predicate<CSSStylableElement>` instead of a typed selector-list parameter (which also drops the always-null `pseudo` argument). The result compiles against both the current and the post-#4051 target platform, so it can merge independently of the platform change.