### PR TITLE
Guard against null target when setting the load scheduling rule

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java
@@ -83,8 +83,11 @@ public class LoadTargetDefinitionJob extends WorkspaceJob {
 		job.setUser(true);
 		// Serialize loads/resolves of the same target so a new load waits for a
 		// cancelled one to drain, avoiding p2 profile lock races and
-		// Progress-view pile-up.
-		job.setRule(TargetResolveSchedulingRule.forHandle(target.getHandle()));
+		// Progress-view pile-up. A null target represents the empty target
+		// platform, which has no handle to serialize on.
+		if (target != null) {
+			job.setRule(TargetResolveSchedulingRule.forHandle(target.getHandle()));
+		}
 		if (listener != null) {
 			job.addJobChangeListener(listener);
 		}


### PR DESCRIPTION
`LoadTargetDefinitionJob.load` accepts a null target to represent the empty target platform, but the per-handle scheduling rule was looked up via `target.getHandle()` before that case was handled. Calling `load` with a null target therefore threw a NullPointerException, which `TargetPlatformPreferencePage` can trigger.

The rule is now only set when a target is present; the empty target platform has no handle to serialize on.