### PR TITLE
Delete target p2 profile only when a reload is forced

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -707,11 +707,15 @@ public class TargetEditor extends FormEditor {
 				Job resolveJob = new Job(NLS.bind(PDEUIMessages.TargetEditor_1, name)) {
 					@Override
 					protected IStatus run(IProgressMonitor monitor) {
-						// delete profile
-						SafeRunner.run(() -> {
-							P2TargetUtils.forceCheckTarget(getTarget());
-							P2TargetUtils.deleteProfile(getTarget().getHandle());
-						});
+						if (forceResolve) {
+							// delete the profile so the target is provisioned from
+							// scratch; a plain resolve reuses the profile while it
+							// is still in sync with the definition
+							SafeRunner.run(() -> {
+								P2TargetUtils.forceCheckTarget(getTarget());
+								P2TargetUtils.deleteProfile(getTarget().getHandle());
+							});
+						}
 						getTarget().resolve(monitor);
 						if (monitor.isCanceled()) {
 							return Status.CANCEL_STATUS;


### PR DESCRIPTION
The resolve job in the target editor's TargetChangedListener deleted the p2 profile before every resolve it triggered, including opening the editor on a not-yet-resolved target or adding and editing a location. This forced a full re-provisioning with repository metadata loads and artifact downloads even when the profile was still in sync with the target definition, which made these actions take minutes for large remote targets.

With this change the profile is only deleted when a forced resolve is requested. Plain resolves go through P2TargetUtils.synchronize, which reuses a valid profile offline and still recreates it whenever the target content actually changed. The explicit Reload and Update actions keep their cache-busting behavior, which Update relies on so that IUs declared with an unspecific version (0.0.0) pick up newer versions from the repository.