### PR TITLE
Deduplicate queued classpath container update requests

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathContainerState.java
@@ -107,11 +107,7 @@ public class ClasspathContainerState {
 			Map<IJavaProject, IClasspathContainer> updateProjects = new LinkedHashMap<>();
 			Map<IProject, IStatus> errorsPerProject = new LinkedHashMap<>();
 
-			java.util.List<UpdateRequest> requests = new java.util.ArrayList<>();
-			UpdateRequest request;
-			while ((request = workQueue.poll()) != null) {
-				requests.add(request);
-			}
+			List<UpdateRequest> requests = drainRequests(workQueue);
 			int count = requests.size();
 			monitor.setWorkRemaining(count * 2);
 
@@ -205,6 +201,24 @@ public class ClasspathContainerState {
 			schedule();
 		}
 
+	}
+
+	/**
+	 * Drains the given queue and deduplicates requests for the same project.
+	 * Multiple requests for one project are queued e.g. when a target platform
+	 * reload triggers classpath updates from several listeners. A request
+	 * without a saved container state forces a container update and therefore
+	 * wins over requests whose update may be skipped when the computed entries
+	 * match the saved state.
+	 */
+	public static List<UpdateRequest> drainRequests(Queue<UpdateRequest> queue) {
+		Map<IProject, UpdateRequest> requests = new LinkedHashMap<>();
+		UpdateRequest request;
+		while ((request = queue.poll()) != null) {
+			requests.merge(request.project(), request,
+					(existing, latest) -> existing.container() == null ? existing : latest);
+		}
+		return List.copyOf(requests.values());
 	}
 
 	private static boolean isPdeContainerProject(IProject project, IPluginModelBase model) {
@@ -325,7 +339,7 @@ public class ClasspathContainerState {
 		fUpdateJob.add(project, savedState);
 	}
 
-	private static record UpdateRequest(IProject project, IClasspathContainer container) {
+	public static record UpdateRequest(IProject project, IClasspathContainer container) {
 
 	}
 }

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -23,6 +23,7 @@ import org.eclipse.pde.core.tests.internal.util.PDESchemaHelperTest;
 import org.eclipse.pde.ui.tests.build.properties.AllValidatorTests;
 import org.eclipse.pde.ui.tests.classpathcontributor.ClasspathContributorTest;
 import org.eclipse.pde.ui.tests.classpathresolver.ClasspathResolverTest;
+import org.eclipse.pde.ui.tests.classpathupdater.ClasspathContainerStateTest;
 import org.eclipse.pde.ui.tests.classpathupdater.ClasspathUpdaterTest;
 import org.eclipse.pde.ui.tests.ee.ExportBundleTests;
 import org.eclipse.pde.ui.tests.imports.AllImportTests;
@@ -64,6 +65,7 @@ import org.junit.platform.suite.api.Suite;
 	RequiredPluginsClasspathContainerPerformanceTest.class, //
 	ChainedReexportPerformanceTest.class, //
 	ClasspathUpdaterTest.class, //
+	ClasspathContainerStateTest.class, //
 	PDESchemaHelperTest.class, //
 	ClasspathContributorTest.class, //
 	DynamicPluginProjectReferencesTest.class, //

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathupdater/ClasspathContainerStateTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/classpathupdater/ClasspathContainerStateTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 Lars Vogel and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.ui.tests.classpathupdater;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.pde.internal.core.ClasspathContainerState;
+import org.eclipse.pde.internal.core.ClasspathContainerState.UpdateRequest;
+import org.eclipse.pde.internal.core.PDECore;
+import org.junit.Test;
+
+/**
+ * Tests that {@link ClasspathContainerState} deduplicates queued classpath
+ * update requests for the same project, see
+ * <a href="https://github.com/eclipse-pde/eclipse.pde/issues/2361">issue
+ * 2361</a>.
+ */
+public class ClasspathContainerStateTest {
+
+	private static final IClasspathContainer SAVED_STATE_1 = container("saved state 1");
+	private static final IClasspathContainer SAVED_STATE_2 = container("saved state 2");
+
+	@Test
+	public void drainsAllRequestsAndPreservesOrder() {
+		Queue<UpdateRequest> queue = new ConcurrentLinkedQueue<>();
+		IProject a = project("a");
+		IProject b = project("b");
+		IProject c = project("c");
+		queue.add(new UpdateRequest(a, null));
+		queue.add(new UpdateRequest(b, null));
+		queue.add(new UpdateRequest(c, null));
+
+		List<UpdateRequest> requests = ClasspathContainerState.drainRequests(queue);
+
+		assertTrue(queue.isEmpty());
+		assertEquals(List.of(a, b, c), requests.stream().map(UpdateRequest::project).toList());
+	}
+
+	@Test
+	public void deduplicatesRequestsForSameProject() {
+		Queue<UpdateRequest> queue = new ConcurrentLinkedQueue<>();
+		IProject a = project("a");
+		IProject b = project("b");
+		queue.add(new UpdateRequest(a, null));
+		queue.add(new UpdateRequest(b, null));
+		queue.add(new UpdateRequest(a, null));
+		queue.add(new UpdateRequest(a, null));
+
+		List<UpdateRequest> requests = ClasspathContainerState.drainRequests(queue);
+
+		assertEquals(List.of(a, b), requests.stream().map(UpdateRequest::project).toList());
+	}
+
+	@Test
+	public void requestWithoutSavedStateWinsOverEarlierSavedState() {
+		Queue<UpdateRequest> queue = new ConcurrentLinkedQueue<>();
+		IProject a = project("a");
+		queue.add(new UpdateRequest(a, SAVED_STATE_1));
+		queue.add(new UpdateRequest(a, null));
+
+		List<UpdateRequest> requests = ClasspathContainerState.drainRequests(queue);
+
+		assertEquals(1, requests.size());
+		assertNull(requests.get(0).container());
+	}
+
+	@Test
+	public void requestWithoutSavedStateWinsOverLaterSavedState() {
+		Queue<UpdateRequest> queue = new ConcurrentLinkedQueue<>();
+		IProject a = project("a");
+		queue.add(new UpdateRequest(a, null));
+		queue.add(new UpdateRequest(a, SAVED_STATE_1));
+
+		List<UpdateRequest> requests = ClasspathContainerState.drainRequests(queue);
+
+		assertEquals(1, requests.size());
+		assertNull(requests.get(0).container());
+	}
+
+	@Test
+	public void latestSavedStateWins() {
+		Queue<UpdateRequest> queue = new ConcurrentLinkedQueue<>();
+		IProject a = project("a");
+		queue.add(new UpdateRequest(a, SAVED_STATE_1));
+		queue.add(new UpdateRequest(a, SAVED_STATE_2));
+
+		List<UpdateRequest> requests = ClasspathContainerState.drainRequests(queue);
+
+		assertEquals(1, requests.size());
+		assertSame(SAVED_STATE_2, requests.get(0).container());
+	}
+
+	@Test
+	public void emptyQueueYieldsNoRequests() {
+		Queue<UpdateRequest> queue = new ConcurrentLinkedQueue<>();
+
+		assertTrue(ClasspathContainerState.drainRequests(queue).isEmpty());
+	}
+
+	private static IProject project(String name) {
+		return ResourcesPlugin.getWorkspace().getRoot().getProject(name);
+	}
+
+	private static IClasspathContainer container(String description) {
+		return new IClasspathContainer() {
+
+			@Override
+			public IClasspathEntry[] getClasspathEntries() {
+				return new IClasspathEntry[0];
+			}
+
+			@Override
+			public String getDescription() {
+				return description;
+			}
+
+			@Override
+			public int getKind() {
+				return IClasspathContainer.K_APPLICATION;
+			}
+
+			@Override
+			public IPath getPath() {
+				return PDECore.REQUIRED_PLUGINS_CONTAINER_PATH;
+			}
+		};
+	}
+}


### PR DESCRIPTION
A target platform reload triggers classpath updates from several listeners, so the work queue of UpdateClasspathsJob frequently contains the same project multiple times. Each occurrence ran the full classpath computation again and inflated the project count in the progress message, e.g. reporting more than 2000 plug-ins for a workspace with 635 plug-ins (see #2361).

This change drains the queue into one request per project before processing. A request without a saved container state forces a container update and therefore wins over requests whose update may be skipped when the computed entries match the saved state. This reduces redundant classpath computations and makes the reported progress count match the actual number of projects. Includes unit tests for the deduplication logic.