### PR TITLE
Set BREE of pde.doc.user bundle to stabilize generated javadoc output

### DIFF
--- a/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.doc.user; singleton:=true
 Bundle-Version: 3.17.600.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"


### PR DESCRIPTION
Avoids warnings like
```
[WARNING] useJDK=BREE configured, but no BREE is set in bundle. Fail back to currently running execution environment (JavaSE-21)
```
and comparator errors because the javadoc is generated with Java-25 in the context of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3891