### PR TITLE
Revert "Set BREE of pde.doc.user bundle to stabilize generated javadoc output"

### DIFF
--- a/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.doc.user; singleton:=true
 Bundle-Version: 3.17.600.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
+++ b/org.eclipse.pde.doc.user/forceQualifierUpdate.txt
@@ -1,4 +1,1 @@
-Javadoc generation options have changed for 4.38
-Removed non reference method from public API class
-Regen javadoc to fix verification build
-New deprecations
+Consider changes due to build with Java-25


### PR DESCRIPTION
This reverts 
- https://github.com/eclipse-pde/eclipse.pde/pull/2365

It turned out that the BREE is not considered when selecting the JDK to generate JavaDoc output (it's just the JDK running the build).

Instead Enforces qualifier update on doc bundles due to build with Java-25