### PR TITLE
Improve handling of unresolved bundles for feature-launches #2367

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/BundleLauncherHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -66,6 +66,7 @@ import org.eclipse.pde.internal.build.BundleHelper;
 import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.FeatureModelManager;
+import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.PluginModelManager;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
@@ -352,10 +353,20 @@ public class BundleLauncherHelper {
 	private static final Predicate<IPluginModelBase> ENABLED_VALID_PLUGIN_FILTER = p -> p.getBundleDescription() != null && p.isEnabled();
 	private static final Function<IPluginModelBase, String> GET_PLUGIN_VERSION = m -> m.getPluginBase().getVersion();
 	private static final Comparator<IPluginModelBase> COMPARE_PLUGIN_RESOLVED = comparing(p -> p.getBundleDescription().isResolved());
+	private static final BiPredicate<IPluginModelBase, Version> EXACT_PLUGIN_VERSION = (e, v) -> Version.parseVersion(GET_PLUGIN_VERSION.apply(e)).equals(v);
 
 	private static IPluginModelBase getIncludedPlugin(String id, String version, String pluginLocation) {
 		List<List<IPluginModelBase>> plugins = getPlugins(id, pluginLocation);
-		return getIncluded(plugins, ENABLED_VALID_PLUGIN_FILTER, GET_PLUGIN_VERSION, COMPARE_PLUGIN_RESOLVED, version);
+		return getIncluded(plugins, ENABLED_VALID_PLUGIN_FILTER, GET_PLUGIN_VERSION, getIncludedPluginComparator(version), version);
+	}
+
+	private static Comparator<IPluginModelBase> getIncludedPluginComparator(String versionString) {
+		if (ICoreConstants.DEFAULT_VERSION.equals(versionString)) {
+			return COMPARE_PLUGIN_RESOLVED;
+		}
+		Version version = Version.parseVersion(versionString);
+		return Comparator.<IPluginModelBase, Boolean> comparing(e -> EXACT_PLUGIN_VERSION.test(e, version)) // false < true
+				.thenComparing(COMPARE_PLUGIN_RESOLVED);
 	}
 
 	private static IPluginModelBase getRequiredPlugin(String id, String version, int versionMatchRule, String pluginLocation) {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/FeatureBasedLaunchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019, 2022 Julian Honnen and others.
+ *  Copyright (c) 2019, 2026 Julian Honnen and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -820,6 +820,32 @@ public class FeatureBasedLaunchTest extends AbstractLaunchTest {
 
 			assertGetMergedBundleMap("pluginResolution workspace no match", lc, Set.of());
 		}
+	}
+
+	@Test
+	public void testGetMergedBundleMap_requiredPluginWithSpecificVersion3() throws Throwable {
+		var targetBundles = ofEntries( //
+				bundle("plugin.a", "1.0.0", entry(IMPORT_PACKAGE, "test;version=\"1.0.0\""),
+						entry(EXPORT_PACKAGE, "test;version=\"1.0.0\"")), //
+				bundle("plugin.a", "2.0.0", entry(IMPORT_PACKAGE, "test;version=\"2.0.0\""),
+						entry(EXPORT_PACKAGE, "test;version=\"2.0.0\"")), //
+				bundle("plugin.b", "1.0.0", entry(IMPORT_PACKAGE, "test;version=\"[1.0.0,2.0.0)\"")), //
+				bundle("plugin.b", "2.0.0", entry(IMPORT_PACKAGE, "test;version=\"[2.0.0,3.0.0)\"")));
+
+		var targetFeatures = List.of( //
+				targetFeature("feature.a", "1.0.0", f -> {
+					addIncludedPlugin(f, "plugin.a", "1.0.0");
+					addIncludedPlugin(f, "plugin.b", "1.0.0");
+				}));
+
+		setTargetPlatform(targetBundles, targetFeatures);
+
+		ILaunchConfigurationWorkingCopy lc = createFeatureLaunchConfig();
+		lc.setAttribute(IPDELauncherConstants.FEATURE_DEFAULT_LOCATION, IPDELauncherConstants.LOCATION_WORKSPACE);
+		lc.setAttribute(IPDELauncherConstants.SELECTED_FEATURES, Set.of("feature.a:default"));
+
+		assertGetMergedBundleMap("featureResolution workspace", lc,
+				Set.of(targetBundle("plugin.a", "1.0.0"), targetBundle("plugin.b", "1.0.0")));
 	}
 
 	// --- required/imported feature dependencies ---


### PR DESCRIPTION
The logic for calculating the included plug-ins for a feature-based launch configuration assigns resolved bundles a higher priority than bundles, that perfectly match the version in a feature.xml.

This means that even though the user configured their application to run with a specific version of a plug-in, PDE might decide to silently update it to its latest version, simply because it conflicts with a different plug-in in the IDE (which might not even be included in the app).

With this change, the logic has been adapted to first check for a version match, before checking the resolution state. So if a version matches perfectly, it will always be chosen first, even if it's not resolved.

Closes https://github.com/eclipse-pde/eclipse.pde/issues/2367