### PR TITLE
Warn about placeholder and part elementId mismatch

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui;singleton:=true
-Bundle-Version: 4.9.100.qualifier
+Bundle-Version: 4.9.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.e4.tools.emf.ui</artifactId>
-  <version>4.9.100-SNAPSHOT</version>
+  <version>4.9.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.java
@@ -330,6 +330,7 @@ public class Messages {
 	public String PlaceholderEditor_Label;
 	public String PlaceholderEditor_Descriptor;
 	public String PlaceholderEditor_Reference;
+	public String PlaceholderEditor_ReferenceIdMismatch;
 	public String PlaceholderEditor_Closeable;
 	public String PlaceholderEditor_ContainerData;
 

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.properties
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.properties
@@ -297,6 +297,7 @@ PerspectiveStackEditor_AddPerspective=Perspective
 PlaceholderEditor_Label=Placeholder
 PlaceholderEditor_Descriptor=Placeholder 
 PlaceholderEditor_Reference=&Reference\:
+PlaceholderEditor_ReferenceIdMismatch=The placeholder id does not match the referenced element id ''{0}''.
 PlaceholderEditor_Closeable=Closeable
 PlaceholderEditor_ContainerData=Container &Data\:
 

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/PlaceholderEditor.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/PlaceholderEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 BestSolution.at and others.
+ * Copyright (c) 2010, 2026 BestSolution.at and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,13 @@
  ******************************************************************************/
 package org.eclipse.e4.tools.emf.ui.internal.common.component;
 
+import java.text.MessageFormat;
+import java.util.Objects;
+
 import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.core.databinding.conversion.Converter;
 import org.eclipse.core.databinding.observable.list.IObservableList;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.WritableValue;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.e4.core.di.annotations.Optional;
@@ -42,6 +46,9 @@ import org.eclipse.emf.databinding.FeaturePath;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.databinding.swt.IWidgetValueProperty;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
@@ -227,6 +234,22 @@ public class PlaceholderEditor extends AbstractComponentEditor<MPlaceholder> {
 			context.bindValue(textProp.observe(t), E4Properties.ref(getEditingDomain()).observeDetail(getMaster()),
 					t2m, m2t);
 
+			final ControlDecoration refIdMismatchDecoration = new ControlDecoration(t, SWT.LEFT | SWT.TOP);
+			final FieldDecoration warningDecoration = FieldDecorationRegistry.getDefault()
+					.getFieldDecoration(FieldDecorationRegistry.DEC_WARNING);
+			refIdMismatchDecoration.setImage(warningDecoration.getImage());
+			refIdMismatchDecoration.hide();
+
+			final Runnable refIdMismatchUpdater = () -> updateReferenceIdMismatch(refIdMismatchDecoration);
+			final IObservableValue<String> elementIdObservable = E4Properties.elementId(getEditingDomain())
+					.observeDetail(getMaster());
+			elementIdObservable.addValueChangeListener(event -> refIdMismatchUpdater.run());
+			final IObservableValue<MUIElement> refObservable = E4Properties.ref(getEditingDomain())
+					.observeDetail(getMaster());
+			refObservable.addValueChangeListener(event -> refIdMismatchUpdater.run());
+			getMaster().addValueChangeListener(event -> refIdMismatchUpdater.run());
+			refIdMismatchUpdater.run();
+
 			Button b = ControlFactory.createFindButton(parent, resourcePool);
 			b.addSelectionListener(new SelectionAdapter() {
 				@Override
@@ -263,6 +286,38 @@ public class PlaceholderEditor extends AbstractComponentEditor<MPlaceholder> {
 		folder.setSelection(0);
 
 		return folder;
+	}
+
+	private void updateReferenceIdMismatch(ControlDecoration decoration) {
+		if (decoration.getControl() == null || decoration.getControl().isDisposed()) {
+			return;
+		}
+		final MPlaceholder placeholder = getMaster().getValue();
+		if (!hasReferenceIdMismatch(placeholder)) {
+			decoration.hide();
+			return;
+		}
+		final String referencedId = placeholder.getRef().getElementId();
+		decoration.setDescriptionText(
+				MessageFormat.format(Messages.PlaceholderEditor_ReferenceIdMismatch,
+						referencedId == null ? "" : referencedId)); //$NON-NLS-1$
+		decoration.show();
+	}
+
+	/**
+	 * Returns whether the given placeholder references a shared element whose
+	 * {@code elementId} differs from the placeholder's own {@code elementId}.
+	 *
+	 * @param placeholder
+	 *            the placeholder to check, may be {@code null}
+	 * @return {@code true} if the placeholder has a reference whose elementId does
+	 *         not equal the placeholder's elementId
+	 */
+	public static boolean hasReferenceIdMismatch(MPlaceholder placeholder) {
+		if (placeholder == null || placeholder.getRef() == null) {
+			return false;
+		}
+		return !Objects.equals(placeholder.getElementId(), placeholder.getRef().getElementId());
 	}
 
 	private void createUITreeInspection(CTabFolder folder) {

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/.classpath
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/.project
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.e4.tools.emf.ui.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/META-INF/MANIFEST.MF
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests
+Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui.tests
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: org.eclipse.e4.tools.emf.ui;bundle-version="4.9.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Require-Bundle: org.junit;bundle-version="4.0.0"
+Automatic-Module-Name: org.eclipse.e4.tools.emf.ui.tests

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/build.properties
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/src/org/eclipse/e4/tools/emf/ui/tests/PlaceholderEditorTest.java
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/src/org/eclipse/e4/tools/emf/ui/tests/PlaceholderEditorTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Aleksandar Kurtakov and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package org.eclipse.e4.tools.emf.ui.tests;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.e4.tools.emf.ui.internal.common.component.PlaceholderEditor;
+import org.eclipse.e4.ui.model.application.ui.advanced.MAdvancedFactory;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
+import org.eclipse.e4.ui.model.application.ui.basic.MBasicFactory;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.junit.Test;
+
+/**
+ * Tests {@link PlaceholderEditor#hasReferenceIdMismatch(MPlaceholder)}, which
+ * detects placeholders whose {@code elementId} does not match the referenced
+ * element's {@code elementId}.
+ */
+public class PlaceholderEditorTest {
+
+	private static final String ID = "org.eclipse.example.part"; //$NON-NLS-1$
+	private static final String OTHER_ID = "org.eclipse.example.Part"; //$NON-NLS-1$
+
+	private static MPlaceholder placeholder(String placeholderId, MPart ref) {
+		final MPlaceholder placeholder = MAdvancedFactory.INSTANCE.createPlaceholder();
+		placeholder.setElementId(placeholderId);
+		placeholder.setRef(ref);
+		return placeholder;
+	}
+
+	private static MPart part(String partId) {
+		final MPart part = MBasicFactory.INSTANCE.createPart();
+		part.setElementId(partId);
+		return part;
+	}
+
+	@Test
+	public void testNullPlaceholder() {
+		assertFalse(PlaceholderEditor.hasReferenceIdMismatch(null));
+	}
+
+	@Test
+	public void testNoReference() {
+		assertFalse(PlaceholderEditor.hasReferenceIdMismatch(placeholder(ID, null)));
+	}
+
+	@Test
+	public void testMatchingIds() {
+		assertFalse(PlaceholderEditor.hasReferenceIdMismatch(placeholder(ID, part(ID))));
+	}
+
+	@Test
+	public void testMismatchingIds() {
+		assertTrue(PlaceholderEditor.hasReferenceIdMismatch(placeholder(OTHER_ID, part(ID))));
+	}
+
+	@Test
+	public void testCaseSensitiveMismatch() {
+		assertTrue(PlaceholderEditor.hasReferenceIdMismatch(
+				placeholder("foo.filterDistribution", part("foo.filterdistribution")))); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void testBothIdsNull() {
+		assertFalse(PlaceholderEditor.hasReferenceIdMismatch(placeholder(null, part(null))));
+	}
+
+	@Test
+	public void testPlaceholderIdNullButReferenceIdSet() {
+		assertTrue(PlaceholderEditor.hasReferenceIdMismatch(placeholder(null, part(ID))));
+	}
+
+	@Test
+	public void testReferenceIdNullButPlaceholderIdSet() {
+		assertTrue(PlaceholderEditor.hasReferenceIdMismatch(placeholder(ID, part(null))));
+	}
+}

--- a/features/org.eclipse.e4.core.tools.feature/feature.xml
+++ b/features/org.eclipse.e4.core.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.e4.core.tools.feature"
       label="%featureName"
-      version="4.30.900.qualifier"
+      version="4.30.1000.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Make the e4xmi editor warn when placecholder and part elementId mismatch. As per
https://github.com/eclipse-platform/eclipse.platform.ui/blob/4e3be89f02f4d30e6f8d0415b798675bd85b9ff9/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PlaceholderResolver.java#L32 "resolver that expects the id of the placeholder to match the id of a PartDescriptor" .
It is not a problem on initial load as the ref is there but if one tries to dynamically reset/load/etc. manipulate e4 model the code at https://github.com/eclipse-platform/eclipse.platform.ui/blob/4e3be89f02f4d30e6f8d0415b798675bd85b9ff9/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PlaceholderResolver.java#L53 will fail if the elementId is not matching.