### PR TITLE
Fix typos in docs

### DIFF
--- a/org.eclipse.pde.doc.user/guide/tools/editors/manifest_editor/access_rules.htm
+++ b/org.eclipse.pde.doc.user/guide/tools/editors/manifest_editor/access_rules.htm
@@ -212,7 +212,7 @@
     </p>
 
     <p>
-      In the example below, the the <em>org.eclipse.pde.ui</em>
+      In the example below, the <em>org.eclipse.pde.ui</em>
       friend plug-in has full access to the
       <em>org.eclipse.pde.internal.core.bundle</em> package from
       the <em>org.eclipse.pde.core</em> plug-in.

--- a/org.eclipse.pde.doc.user/guide/tools/editors/manifest_editor/overview.htm
+++ b/org.eclipse.pde.doc.user/guide/tools/editors/manifest_editor/overview.htm
@@ -22,7 +22,7 @@
 <p>A <strong>Version</strong> is mandatory and must be of the form <em>major.minor.micro.qualifier</em> (e.g. 1.3.0).</p>
 <p>A<strong> Name</strong> is the translatable presentation name of the plug-in. This field is required. </p>
 <p>A<strong> Vendor</strong> is the translatable name of the plug-in vendor. This field is optional. </p>
-<p>A <strong>Platform filter</strong> is a valid LDAP string that must evaluate to true in a running system for the the plug-in to run. For example, the following filter indicates that the plug-in is designed to only run on platforms with a <em>win32</em> windowing system:  <strong>Eclipse-PlatformFilter: (ws=win32)</strong>.  If a   user attempts to run Eclipse on a platform that does not meet this requirement,   the plug-in will be silently ignored by the runtime. </p>
+<p>A <strong>Platform filter</strong> is a valid LDAP string that must evaluate to true in a running system for the plug-in to run. For example, the following filter indicates that the plug-in is designed to only run on platforms with a <em>win32</em> windowing system:  <strong>Eclipse-PlatformFilter: (ws=win32)</strong>.  If a   user attempts to run Eclipse on a platform that does not meet this requirement,   the plug-in will be silently ignored by the runtime. </p>
 <p>An <strong>Activator</strong> is a Java class that controls the plug-in's life cycle. It is only needed if you require work to be done on the startup or shutdown of your plug-in. </p>
 
 <h2>Execution Environments </h2>

--- a/org.eclipse.pde.doc.user/guide/tools/editors/target_editor/environment_page.htm
+++ b/org.eclipse.pde.doc.user/guide/tools/editors/target_editor/environment_page.htm
@@ -12,7 +12,7 @@
 <body>
 <h1>Environment Page</h1>
 
-<p>The <strong>Enviroment Page</strong> in the <a href="./target_editor.htm">Target Definition Editor</a> is used to edit many settings  in the definition affecting how the target will be compiled and run.</p>
+<p>The <strong>Environment Page</strong> in the <a href="./target_editor.htm">Target Definition Editor</a> is used to edit many settings  in the definition affecting how the target will be compiled and run.</p>
 
 <img src="../../../images/target_editor/environment_page.png" alt="Environment Page">
 

--- a/org.eclipse.pde.doc.user/guide/tools/preference_pages/editors.htm
+++ b/org.eclipse.pde.doc.user/guide/tools/preference_pages/editors.htm
@@ -20,7 +20,7 @@
 
 <h2>XML Highlighting Preference </h2>
 <p>The XML Highlighting tab allows you to set the color and font for comments, constant strings, processing instructions, tags and text.</p>
-<p>To customize the font and color for each element, select the element in the the left viewer and make changes using the buttons located on the right. The Preview pane automatically updates to reflect the changes you make. </p>
+<p>To customize the font and color for each element, select the element in the left viewer and make changes using the buttons located on the right. The Preview pane automatically updates to reflect the changes you make. </p>
 <p>This preference affects all plug-in development and user assistance editor source pages. </p>
 <p><img src="../../images/preferences/editors_xml.png" alt="XML Syntax Highlighting" ></p>
 

--- a/org.eclipse.pde.doc.user/reference/api-tooling/applications/analysis-application.htm
+++ b/org.eclipse.pde.doc.user/reference/api-tooling/applications/analysis-application.htm
@@ -27,7 +27,7 @@ the application can be started with commands like:</p>
   </tr>
 <tr>
 <td valign="top">project</td>
-<td valign="top">This attribute specifies the location of the project to analyze. The project must be the a valid Eclipse Plugin project,
+<td valign="top">This attribute specifies the location of the project to analyze. The project must be a valid Eclipse Plugin project,
 that is a project with typical <code>.project</code>, <code>MANIFEST.MF</code>... files. 
 </td>
 <td align="center" valign="top">Yes</td>

--- a/org.eclipse.pde.doc.user/tasks/pde_feature_generating_antcommandline.htm
+++ b/org.eclipse.pde.doc.user/tasks/pde_feature_generating_antcommandline.htm
@@ -353,7 +353,7 @@ which to base the generated feature.<br>
           </td>
           <td style="vertical-align: top;">Whether or not to use the
 resolver to verify that the provided plug-ins and features are
-available.&nbsp; This also determines whether or not the the feature
+available.&nbsp; This also determines whether or not the feature
 will be able to correctly handle platform specific fragments and
 plug-ins that will be JARed.&nbsp; If all the elements to be included
 in the feature are available locally, then verify should be set to


### PR DESCRIPTION
* Duplicate "the"
* Enviroment - Environment