### PR TITLE
Revert "Add Select Required and Remove Unresolved actions to validation dialog"

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
@@ -34,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -53,7 +51,6 @@ import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.Launch;
-import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.target.NameVersionDescriptor;
 import org.eclipse.pde.internal.build.IPDEBuildConstants;
@@ -61,7 +58,6 @@ import org.eclipse.pde.internal.core.DependencyManager;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.launching.IPDEConstants;
 import org.eclipse.pde.internal.launching.launcher.BundleLauncherHelper;
-import org.eclipse.pde.internal.launching.launcher.LaunchValidationOperation;
 import org.eclipse.pde.launching.EclipseApplicationLaunchConfiguration;
 import org.eclipse.pde.launching.IPDELauncherConstants;
 import org.eclipse.pde.ui.tests.util.ProjectUtils;
@@ -1060,106 +1056,6 @@ public class PluginBasedLaunchTest extends AbstractLaunchTest {
 		assertEquals("plugin.a*1.0.0@4:true", BundleLauncherHelper.formatBundleEntry(plugin, "4", "true"));
 		assertEquals("plugin.a*1.0.0@4:", BundleLauncherHelper.formatBundleEntry(plugin, "4", ""));
 		assertEquals("plugin.a*1.0.0@:false", BundleLauncherHelper.formatBundleEntry(plugin, null, "false"));
-	}
-
-	// --- test cases for identifying unresolved plug-ins (Remove Unresolved) ---
-
-	@Test
-	public void testUnresolvedPlugins_onlyUnresolvableBundleIsIdentified() throws Exception {
-		var workspacePlugins = ofEntries( //
-				// requires a bundle that is present nowhere -> cannot resolve
-				bundle("plugin.a", "1.0.0", entry(REQUIRE_BUNDLE, "plugin.absent")), //
-				bundle("plugin.b", "1.0.0"));
-		setUpWorkspace(workspacePlugins, Map.of());
-
-		IPluginModelBase unresolvable = workspaceBundle("plugin.a", "1.0.0").findModel();
-		IPluginModelBase resolvable = workspaceBundle("plugin.b", "1.0.0").findModel();
-
-		Set<IPluginModelBase> unresolved = unresolvedModels(Set.of(unresolvable, resolvable));
-
-		assertEquals(Set.of(unresolvable), unresolved);
-	}
-
-	@Test
-	public void testUnresolvedPlugins_transitivelyUnresolvableBundlesAreIdentified() throws Exception {
-		var workspacePlugins = ofEntries( //
-				bundle("plugin.a", "1.0.0", entry(REQUIRE_BUNDLE, "plugin.absent")), //
-				// depends on the unresolvable plugin.a -> also cannot resolve
-				bundle("plugin.b", "1.0.0", entry(REQUIRE_BUNDLE, "plugin.a")), //
-				bundle("plugin.c", "1.0.0"));
-		setUpWorkspace(workspacePlugins, Map.of());
-
-		IPluginModelBase a = workspaceBundle("plugin.a", "1.0.0").findModel();
-		IPluginModelBase b = workspaceBundle("plugin.b", "1.0.0").findModel();
-		IPluginModelBase c = workspaceBundle("plugin.c", "1.0.0").findModel();
-
-		Set<IPluginModelBase> unresolved = unresolvedModels(Set.of(a, b, c));
-
-		assertEquals(Set.of(a, b), unresolved);
-	}
-
-	@Test
-	public void testUnresolvedPlugins_resolvedDuplicateAtSameVersionIsKept() throws Exception {
-		// A workspace and a target bundle share symbolic name and version, but
-		// only the workspace one is broken. The resolved target duplicate must
-		// not be dropped along with it.
-		var workspacePlugins = ofEntries( //
-				bundle("plugin.a", "1.0.0", entry(REQUIRE_BUNDLE, "plugin.absent")));
-		var targetPlugins = ofEntries( //
-				bundle("plugin.a", "1.0.0"));
-		setUpWorkspace(workspacePlugins, targetPlugins);
-
-		IPluginModelBase workspaceA = workspaceBundle("plugin.a", "1.0.0").findModel();
-		IPluginModelBase targetA = targetBundle("plugin.a", "1.0.0").findModel();
-
-		Set<IPluginModelBase> unresolved = unresolvedModels(Set.of(workspaceA, targetA));
-
-		assertEquals(Set.of(workspaceA), unresolved);
-	}
-
-	/**
-	 * Mirrors the selection logic of
-	 * {@code AbstractPluginBlock.removeUnresolvedPlugins()}: repeatedly validates
-	 * the current set of models, drops those whose bundle did not resolve, and
-	 * re-validates the remaining set. A bundle that only becomes unresolvable
-	 * once one of its dependencies has been dropped is therefore picked up in a
-	 * later pass, just like the production loop. Returns every model that was
-	 * dropped, matched by symbolic name, version and location.
-	 */
-	private static Set<IPluginModelBase> unresolvedModels(Set<IPluginModelBase> checkedModels) throws CoreException {
-		Set<IPluginModelBase> remaining = new HashSet<>(checkedModels);
-		Set<IPluginModelBase> unresolved = new HashSet<>();
-		// Bound the loop just like the production code so a pathological
-		// resolver state can't spin forever.
-		int safetyBound = 32;
-		while (safetyBound-- > 0 && !remaining.isEmpty()) {
-			LaunchValidationOperation operation = new LaunchValidationOperation(
-					createPluginLaunchConfig("remove-unresolved-test"), remaining);
-			operation.run(new NullProgressMonitor());
-
-			Set<String> unresolvedKeys = new HashSet<>();
-			for (Object key : operation.getInput().keySet()) {
-				if (key instanceof BundleDescription bd && !bd.isResolved()) {
-					unresolvedKeys.add(bundleKey(bd));
-				}
-			}
-
-			Set<IPluginModelBase> removed = remaining.stream().filter(model -> {
-				BundleDescription bd = model.getBundleDescription();
-				return bd != null && unresolvedKeys.contains(bundleKey(bd));
-			}).collect(Collectors.toSet());
-
-			if (removed.isEmpty()) {
-				break;
-			}
-			unresolved.addAll(removed);
-			remaining.removeAll(removed);
-		}
-		return unresolved;
-	}
-
-	private static String bundleKey(BundleDescription bd) {
-		return bd.getSymbolicName() + '/' + bd.getVersion() + '/' + bd.getLocation();
 	}
 
 	// --- utilities ---

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDEUIMessages.java
@@ -1097,7 +1097,6 @@ public class PDEUIMessages extends NLS {
 	public static String AdvancedLauncherTab_subset;
 	public static String AdvancedLauncherTab_subset_plugins;
 	public static String AdvancedLauncherTab_subset_bundles;
-	public static String AdvancedLauncherTab_removeUnresolved;
 	public static String AdvancedLauncherTab_autoIncludeRequirements_bundles;
 	public static String AdvancedLauncherTab_autoIncludeRequirements_plugins;
 	public static String AdvancedLauncherTab_autoIncludeRequirements_features_withBundles;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/AbstractPluginBlock.java
@@ -905,78 +905,6 @@ public abstract class AbstractPluginBlock {
 		countSelectedModels();
 	}
 
-	private Set<IPluginModelBase> getCheckedPluginModels() {
-		return Arrays.stream(fPluginTreeViewer.getCheckedLeafElements()).filter(IPluginModelBase.class::isInstance)
-				.map(IPluginModelBase.class::cast).collect(Collectors.toSet());
-	}
-
-	/**
-	 * Validates the tree's currently-checked plug-ins and unchecks any whose
-	 * bundle could not be resolved. Validation is repeated against the new
-	 * checked set after each pass, so plug-ins that only become unresolved once
-	 * a dependency has been removed are picked up in the same invocation. The
-	 * change is only made in the tree, not persisted; callers are responsible
-	 * for notifying the tab so the change can be applied.
-	 */
-	protected void removeUnresolvedPlugins() {
-		// Bound the loop so a pathological resolver state can't spin
-		// forever; in practice one or two passes is enough.
-		int safetyBound = 32;
-		while (safetyBound-- > 0) {
-			Set<IPluginModelBase> checkedModels = getCheckedPluginModels();
-			if (checkedModels.isEmpty()) {
-				break;
-			}
-			Set<String> unresolvedKeys;
-			try {
-				LaunchValidationOperation operation = createValidationOperation(checkedModels);
-				operation.run(new NullProgressMonitor());
-				unresolvedKeys = collectUnresolvedKeys(operation);
-			} catch (CoreException e) {
-				PDEPlugin.log(e);
-				return;
-			}
-
-			List<Object> remaining = new ArrayList<>(checkedModels.size());
-			List<IPluginModelBase> removed = new ArrayList<>();
-			for (IPluginModelBase model : checkedModels) {
-				BundleDescription bd = model.getBundleDescription();
-				if (bd != null && unresolvedKeys.contains(bundleKey(bd))) {
-					removed.add(model);
-				} else {
-					remaining.add(model);
-				}
-			}
-
-			if (removed.isEmpty()) {
-				break;
-			}
-			setCheckedElements(remaining.toArray());
-			for (IPluginModelBase model : removed) {
-				resetText(model);
-			}
-		}
-		countSelectedModels();
-	}
-
-	private static Set<String> collectUnresolvedKeys(LaunchValidationOperation operation) {
-		Set<String> keys = new HashSet<>();
-		for (Object key : operation.getInput().keySet()) {
-			if (key instanceof BundleDescription bd && !bd.isResolved()) {
-				keys.add(bundleKey(bd));
-			}
-		}
-		return keys;
-	}
-
-	/**
-	 * Identifies a bundle by symbolic name, version and location, so duplicates
-	 * that share a name and version but differ in location are not conflated.
-	 */
-	private static String bundleKey(BundleDescription bd) {
-		return bd.getSymbolicName() + '/' + bd.getVersion() + '/' + bd.getLocation();
-	}
-
 	protected IPluginModelBase findPlugin(String id) {
 		ModelEntry entry = PluginRegistry.findEntry(id);
 		if (entry != null) {
@@ -1130,7 +1058,6 @@ public abstract class AbstractPluginBlock {
 				if (fOperation.hasErrors()) {
 					fDialog = new PluginStatusDialog(getShell(), SWT.MODELESS | SWT.CLOSE | SWT.BORDER | SWT.TITLE | SWT.RESIZE);
 					fDialog.setInput(fOperation);
-					fDialog.setActions(createDialogActions());
 					fDialog.open();
 					fDialog = null;
 				} else if (fOperation.isEmpty()) {
@@ -1159,54 +1086,6 @@ public abstract class AbstractPluginBlock {
 		}
 	}
 
-	private PluginStatusDialog.PluginStatusDialogActions createDialogActions() {
-		return new PluginStatusDialog.PluginStatusDialogActions() {
-			@Override
-			public void selectRequired() {
-				addRequiredPlugins();
-				notifyTabChanged();
-			}
-
-			@Override
-			public void removeUnresolved() {
-				removeUnresolvedPlugins();
-				notifyTabChanged();
-			}
-
-			@Override
-			public boolean supportsRemoveUnresolved() {
-				return true;
-			}
-
-			@Override
-			public String getSelectRequiredLabel() {
-				return NLS.bind(PDEUIMessages.AdvancedLauncherTab_subset, fTab.getName());
-			}
-
-			@Override
-			public LaunchValidationOperation validate() {
-				try {
-					// Validate the tree's current (unsaved) checked state, not
-					// the persisted launch configuration, so the dialog
-					// reflects the change just made by the action.
-					LaunchValidationOperation operation = createValidationOperation(getCheckedPluginModels());
-					operation.run(new NullProgressMonitor());
-					return operation;
-				} catch (CoreException e) {
-					PDEPlugin.log(e);
-					return null;
-				}
-			}
-		};
-	}
-
-	private void notifyTabChanged() {
-		if (!fIsDisposed) {
-			// Flush the tree change to the working copy and enable Apply.
-			fTab.updateLaunchConfigurationDialog();
-		}
-	}
-
 	protected void setVisible(boolean visible) {
 		if (!visible) {
 			if (fDialog != null) {
@@ -1217,16 +1096,6 @@ public abstract class AbstractPluginBlock {
 	}
 
 	protected abstract LaunchValidationOperation createValidationOperation() throws CoreException;
-
-	/**
-	 * Creates a validation operation against an explicit model set rather than
-	 * the launch configuration's persisted state. Used by
-	 * {@link #removeUnresolvedPlugins()} so iterative validation reflects the
-	 * tree's current (unsaved) checked state.
-	 */
-	protected LaunchValidationOperation createValidationOperation(Set<IPluginModelBase> models) {
-		return new LaunchValidationOperation(fLaunchConfig, models);
-	}
 
 	/**
 	 * Disposing the editor in tree viewer

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/FeatureBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/FeatureBlock.java
@@ -396,7 +396,6 @@ public class FeatureBlock {
 					if (fOperation.hasErrors()) {
 						fDialog = new PluginStatusDialog(getShell(), SWT.MODELESS | SWT.CLOSE | SWT.BORDER | SWT.TITLE | SWT.RESIZE);
 						fDialog.setInput(fOperation);
-						fDialog.setActions(createDialogActions());
 						fDialog.open();
 						fDialog = null;
 					} else if (fOperation.isEmpty()) {
@@ -422,50 +421,6 @@ public class FeatureBlock {
 			} catch (CoreException e) {
 				PDEPlugin.log(e);
 			}
-		}
-
-		private PluginStatusDialog.PluginStatusDialogActions createDialogActions() {
-			return new PluginStatusDialog.PluginStatusDialogActions() {
-				@Override
-				public void selectRequired() {
-					handleAddRequired();
-					if (!fIsDisposed) {
-						fTab.updateLaunchConfigurationDialog();
-					}
-				}
-
-				@Override
-				public void removeUnresolved() {
-					// Not supported for feature-based launches.
-				}
-
-				@Override
-				public boolean supportsRemoveUnresolved() {
-					return false;
-				}
-
-				@Override
-				public String getSelectRequiredLabel() {
-					return PDEUIMessages.FeatureBlock_addRequiredFeatues;
-				}
-
-				@Override
-				public LaunchValidationOperation validate() {
-					try {
-						// selectRequired() has flushed the tree to the working
-						// copy, so the merged bundle map now reflects it.
-						boolean isOSGi = fTab.getId().equals(IPDELauncherConstants.TAB_BUNDLES_ID);
-						Set<IPluginModelBase> models = BundleLauncherHelper.getMergedBundleMap(fLaunchConfig, isOSGi)
-								.keySet();
-						LaunchValidationOperation operation = new LaunchValidationOperation(fLaunchConfig, models);
-						operation.run(new NullProgressMonitor());
-						return operation;
-					} catch (CoreException e) {
-						PDEPlugin.log(e);
-						return null;
-					}
-				}
-			};
 		}
 
 		private Shell getShell() {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginBlock.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginBlock.java
@@ -189,9 +189,4 @@ public class PluginBlock extends AbstractPluginBlock {
 		return new EclipsePluginValidationOperation(fLaunchConfig, models);
 	}
 
-	@Override
-	protected LaunchValidationOperation createValidationOperation(Set<IPluginModelBase> models) {
-		return new EclipsePluginValidationOperation(fLaunchConfig, models);
-	}
-
 }

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginStatusDialog.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/PluginStatusDialog.java
@@ -15,13 +15,9 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.launcher;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.IDebugUIConstants;
@@ -62,10 +58,7 @@ public class PluginStatusDialog extends TrayDialog {
 		@Override
 		public Object[] getChildren(Object parentElement) {
 			if (fInput.containsKey(parentElement)) {
-				Object value = fInput.get(parentElement);
-				if (value instanceof Object[] children) {
-					return children;
-				}
+				return (Object[]) fInput.get(parentElement);
 			}
 			if (parentElement instanceof MultiStatus) {
 				return ((MultiStatus) parentElement).getChildren();
@@ -102,39 +95,6 @@ public class PluginStatusDialog extends TrayDialog {
 	private TreeViewer treeViewer;
 	private ILaunchConfiguration fLaunchConfiguration;
 	private String launchMode;
-	private PluginStatusDialogActions fActions;
-
-	/**
-	 * Callbacks supplied by the owner of the dialog (a launch-configuration
-	 * block) so the dialog can offer in-place fixes for the reported problems.
-	 * The dialog is also shown in contexts without a plug-in tree to modify
-	 * (e.g. at launch time); those simply do not set any actions, so the
-	 * buttons are not created.
-	 */
-	public interface PluginStatusDialogActions {
-		/** Adds the required plug-ins/features to the owning block's selection. */
-		void selectRequired();
-
-		/** Removes the unresolved plug-ins from the owning block's selection. */
-		void removeUnresolved();
-
-		/** Whether the {@link #removeUnresolved()} action is offered. */
-		boolean supportsRemoveUnresolved();
-
-		/** Label for the "select required" button (plug-ins vs. features). */
-		String getSelectRequiredLabel();
-
-		/**
-		 * Re-validates the owning block's current selection and returns the
-		 * operation, or {@code null} if validation failed. Used to refresh the
-		 * dialog after an action.
-		 */
-		LaunchValidationOperation validate();
-	}
-
-	public void setActions(PluginStatusDialogActions actions) {
-		fActions = actions;
-	}
 
 	public PluginStatusDialog(Shell parentShell, int style) {
 		super(parentShell);
@@ -177,45 +137,14 @@ public class PluginStatusDialog extends TrayDialog {
 		return DIALOG_PERSISTSIZE;
 	}
 
-	private static final int SELECT_REQUIRED_ID = IDialogConstants.CLIENT_ID + 1;
-	private static final int REMOVE_UNRESOLVED_ID = IDialogConstants.CLIENT_ID + 2;
-
 	@Override
 	protected void createButtonsForButtonBar(Composite parent) {
 		if (fShowLink) {
 			createLink(parent);
 		}
-		if (fActions != null) {
-			createButton(parent, SELECT_REQUIRED_ID, fActions.getSelectRequiredLabel(), false);
-			if (fActions.supportsRemoveUnresolved()) {
-				createButton(parent, REMOVE_UNRESOLVED_ID, PDEUIMessages.AdvancedLauncherTab_removeUnresolved, false);
-			}
-		}
 		createButton(parent, IDialogConstants.OK_ID, PDEUIMessages.PluginStatusDialog_continueButtonLabel, true);
 		if (fShowCancelButton) {
 			createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
-		}
-	}
-
-	@Override
-	protected void buttonPressed(int buttonId) {
-		if (buttonId == SELECT_REQUIRED_ID) {
-			runAction(PluginStatusDialogActions::selectRequired);
-		} else if (buttonId == REMOVE_UNRESOLVED_ID) {
-			runAction(PluginStatusDialogActions::removeUnresolved);
-		} else {
-			super.buttonPressed(buttonId);
-		}
-	}
-
-	private void runAction(Consumer<PluginStatusDialogActions> action) {
-		if (fActions == null) {
-			return;
-		}
-		action.accept(fActions);
-		LaunchValidationOperation operation = fActions.validate();
-		if (operation != null) {
-			refresh(operation.getInput());
 		}
 	}
 
@@ -280,13 +209,6 @@ public class PluginStatusDialog extends TrayDialog {
 	}
 
 	public void refresh(Map<?, ?> input) {
-		if (input.isEmpty()) {
-			// Keep the field and the viewer input consistent: show a single
-			// "no problems" node once all reported issues have been fixed.
-			Map<String, IStatus> noProblems = new HashMap<>(1);
-			noProblems.put(PDEUIMessages.AbstractLauncherToolbar_noProblems, Status.OK_STATUS);
-			input = noProblems;
-		}
 		fInput = input;
 		treeViewer.setInput(input);
 		treeViewer.refresh();

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/pderesources.properties
@@ -568,7 +568,6 @@ AdvancedPluginExportPage_noAlias=Alias is not set
 AdvancedLauncherTab_subset=Add Re&quired {0}
 AdvancedLauncherTab_subset_bundles=Select Re&quired
 AdvancedLauncherTab_subset_plugins=Select Re&quired
-AdvancedLauncherTab_removeUnresolved=Remove &Unresolved
 AdvancedLauncherTab_autoIncludeRequirements_bundles=Include required Bundles automatically while launching
 AdvancedLauncherTab_autoIncludeRequirements_plugins=Include required Plug-ins automatically while launching
 AdvancedLauncherTab_autoIncludeRequirements_features_withBundles=Include required Features and Bundles automatically while launching


### PR DESCRIPTION
My runtime Eclipse behaves very strange, this is in preparation in case I think a real issue. I now run a full aggregator build to see if my runtime setup is strange or if this commit is not behaving correct. 

Reverts eclipse-pde/eclipse.pde#2351