### PR TITLE
Build with Java 25 in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 	}
 	stages {
 		stage('Build') {


### PR DESCRIPTION
This is required for the pde.doc bundle, which is already build with Java-25 in I-builds.

See
- https://github.com/eclipse-pde/eclipse.pde/pull/2380#issuecomment-4756835159