### PR TITLE
Add missing descriptions to Colours and Fonts theme entries in Preferences

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.genericeditor.extension/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.genericeditor.extension;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface.text,

--- a/ui/org.eclipse.pde.genericeditor.extension/plugin.properties
+++ b/ui/org.eclipse.pde.genericeditor.extension/plugin.properties
@@ -20,6 +20,7 @@ command.name = Update IU Versions from Repositories
 command.category.source.name = Target Definition Source
 command.category.source.description = Target Definition Source Page actions
 themeElementCategory.label = Target file editor
+themeElementCategory.description= Colors and fonts used in the Target Definition Editor
 colorDefinition.tag = Tag
 colorDefinition.attribute = Attribute
 colorDefinition.header = Header

--- a/ui/org.eclipse.pde.genericeditor.extension/plugin.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension/plugin.xml
@@ -98,6 +98,9 @@
       <themeElementCategory
             id="org.eclipse.pde.genericeditor.target.extension.presentation"
             label="%themeElementCategory.label">
+            <description>
+            %themeElementCategory.description
+            </description>
       </themeElementCategory>
       <colorDefinition
             categoryId="org.eclipse.pde.genericeditor.target.extension.presentation"


### PR DESCRIPTION
Refs : https://github.com/eclipse-platform/eclipse.platform.ui/pull/3666, https://github.com/eclipse-platform/eclipse.platform/pull/2453, https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2799

This change adds description for the Target file editor entry in PDE to display in the description for Colors and Fonts entries This is to ensure the area is not left empty without any description.

The main change pertaining to this PR has been merged via https://github.com/eclipse-platform/eclipse.platform.ui/pull/3666. Few of the remaining changes are addressed here.