### PR TITLE
Fix CSS Spy for the e4 engine's SAC removal

### DIFF
--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CSSScratchPadPart.java
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CSSScratchPadPart.java
@@ -36,7 +36,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.w3c.css.sac.CSSParseException;
 import org.w3c.dom.stylesheets.StyleSheet;
 import org.w3c.dom.stylesheets.StyleSheetList;
 
@@ -153,9 +152,8 @@ public class CSSScratchPadPart {
 
 				long nanoDiff = System.nanoTime() - start;
 				sb.append(MessageFormat.format("\n{0}", MessageFormat.format(Messages.CSSScratchPadPart_Time_ms, nanoDiff / 1000000))); //$NON-NLS-1$
-			} catch (CSSParseException e) {
-				sb.append(MessageFormat.format("\n{0}", MessageFormat.format(Messages.CSSScratchPadPart_Error_line_col, e.getLineNumber(), e.getColumnNumber(), e.getLocalizedMessage()))); //$NON-NLS-1$
-			} catch (IOException e) {
+			} catch (IOException | RuntimeException e) {
+				// e4's parser throws an unchecked CssParseException whose message already carries line and column.
 				sb.append(MessageFormat.format("\n{0}", MessageFormat.format(Messages.CSSScratchPadPart_Error, e.getLocalizedMessage()))); //$NON-NLS-1$
 			}
 		}

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CssSpyPart.java
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/CssSpyPart.java
@@ -1180,7 +1180,8 @@ public class CssSpyPart {
 	 */
 	private Map<String, String> getCSSRuleSources(CSSEngine engine, CSSStylableElement element) {
 		Map<String, String> sources = new HashMap<>();
-		if (!(engine instanceof DocumentCSS docCSS)) {
+		DocumentCSS docCSS = engine.getDocumentCSS();
+		if (docCSS == null) {
 			return sources;
 		}
 		StyleSheetList sheets = docCSS.getStyleSheets();

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/Messages.java
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/Messages.java
@@ -16,7 +16,6 @@ public class Messages extends NLS {
 	public static String CSSScratchPadPart_Close;
 	public static String CSSScratchPadPart_Engine;
 	public static String CSSScratchPadPart_Error;
-	public static String CSSScratchPadPart_Error_line_col;
 	public static String CSSScratchPadPart_No_theme_engine_available;
 	public static String CSSScratchPadPart_Time_ms;
 	public static String CssSpyPart_actual_values;

--- a/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/messages.properties
+++ b/ui/org.eclipse.pde.spy.css/src/org/eclipse/pde/spy/css/messages.properties
@@ -2,7 +2,6 @@ CSSScratchPadPart_Apply=Apply
 CSSScratchPadPart_Close=Close
 CSSScratchPadPart_Engine=Engine[{0}]
 CSSScratchPadPart_Error=Error: {0}
-CSSScratchPadPart_Error_line_col=Error: line {0} col {1}: {2}
 CSSScratchPadPart_No_theme_engine_available=No theme engine available!
 CSSScratchPadPart_Time_ms=Time: {0}ms
 CssSpyPart_actual_values=actual values


### PR DESCRIPTION
After the e4 CSS engine dropped SAC, the CSS Spy's scratch pad still caught `org.w3c.css.sac.CSSParseException`, which is no longer thrown and is no longer shipped.
A syntax error therefore threw the engine's unchecked `CssParseException` uncaught instead of showing the error. This catches it generically; the line and column still appear because they are part of the exception message.

It also repairs the spy's matched-rule lookup, which tested the engine with `instanceof DocumentCSS`. The engine only implements `CSSEngine` now, so that test was always false and the rule-source column stayed empty; it uses `getDocumentCSS()` instead.

Both changes use only API present on the current platform, so the bundle builds against the released target (verified with `mvn verify`).