### PR TITLE
Convert the layout spy command into an e4 handler

### DIFF
--- a/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
@@ -9,9 +9,13 @@ Require-Bundle: org.eclipse.jface.databinding;bundle-version="1.9.0",
  org.eclipse.core.databinding.observable,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.core.databinding.property;bundle-version="1.6.0",
- org.eclipse.ui;bundle-version="3.208.0"
+ org.eclipse.swt;bundle-version="3.135.0",
+ org.eclipse.jface;bundle-version="3.40.0"
 Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
- org.eclipse.core.runtime;version="[3.7.0,4)",
+ jakarta.inject;version="[2.0.0,3.0.0)",
+ org.eclipse.core.runtime;common=split;version="[3.8.0,4.0.0)",
+ org.eclipse.e4.core.di.annotations,
+ org.eclipse.e4.ui.services,
  org.eclipse.osgi.util,
  org.osgi.framework;version="[1.10.0,2.0.0)"
 Bundle-Vendor: %provider-name

--- a/ui/org.eclipse.tools.layout.spy/build.properties
+++ b/ui/org.eclipse.tools.layout.spy/build.properties
@@ -18,6 +18,7 @@ bin.includes = META-INF/,\
                .,\
                plugin.properties,\
                plugin.xml,\
+               fragment.e4xmi,\
                about.html,\
                icons/
 src.includes = about.html

--- a/ui/org.eclipse.tools.layout.spy/fragment.e4xmi
+++ b/ui/org.eclipse.tools.layout.spy/fragment.e4xmi
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ASCII"?>
+<fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:commands="http://www.eclipse.org/ui/2010/UIModel/application/commands" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_layoutSpyFragmentRoot">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_layoutSpyCommandsFragment" featurename="commands" parentElementId="xpath:/">
+    <elements xsi:type="commands:Command" xmi:id="_layoutSpyCommand" elementId="org.eclipse.tools.layout.spy.commands.layoutSpyCommand" commandName="%spy-layout-command.name" description="%spy-layout-command.description">
+      <persistedState key="persistState" value="false"/>
+    </elements>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_layoutSpyHandlersFragment" featurename="handlers" parentElementId="xpath:/">
+    <elements xsi:type="commands:Handler" xmi:id="_layoutSpyHandler" elementId="org.eclipse.tools.layout.spy.handler.layoutSpy" contributionURI="bundleclass://org.eclipse.tools.layout.spy/org.eclipse.tools.layout.spy.internal.handlers.LayoutSpyHandler" command="_layoutSpyCommand">
+      <persistedState key="persistState" value="false"/>
+    </elements>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_layoutSpyBindingsFragment" featurename="bindingTables" parentElementId="xpath:/">
+    <elements xsi:type="commands:BindingTable" xmi:id="_layoutSpyBindingTable" elementId="org.eclipse.tools.layout.spy.bindingtable" bindingContext="_layoutSpyDialogAndWindowContext">
+      <persistedState key="persistState" value="false"/>
+      <bindings xmi:id="_layoutSpyKeyBinding" elementId="org.eclipse.tools.layout.spy.keybinding.layoutSpy" keySequence="M1+M2+M3+F9" command="_layoutSpyCommand">
+        <persistedState key="persistState" value="false"/>
+      </bindings>
+    </elements>
+  </fragments>
+  <imports xsi:type="commands:BindingContext" xmi:id="_layoutSpyDialogAndWindowContext" elementId="org.eclipse.ui.contexts.dialogAndWindow"/>
+</fragment:ModelFragments>

--- a/ui/org.eclipse.tools.layout.spy/plugin.xml
+++ b/ui/org.eclipse.tools.layout.spy/plugin.xml
@@ -18,40 +18,12 @@
 
 <!-- Extensions -->
    <extension
-         point="org.eclipse.ui.commands">
-      <category
-            id="org.eclipse.pde.runtime.spy.commands.category"
-            name="%spy-category.name">
-      </category>
-      <command
-            categoryId="org.eclipse.pde.runtime.spy.commands.category"
-            description="%spy-layout-command.description"
-            id="org.eclipse.tools.layout.spy.commands.layoutSpyCommand"
-            name="%spy-layout-command.name">
-      </command>
-   </extension>
-   <extension
-         point="org.eclipse.ui.commandImages">
-      <image
-            commandId="org.eclipse.tools.layout.spy.commands.layoutSpyCommand"
-            icon="$nl$/icons/obj16/layoutspy_obj.svg">
-      </image>
-   </extension>
-   <extension
-         point="org.eclipse.ui.bindings">
-      <key
-            commandId="org.eclipse.tools.layout.spy.commands.layoutSpyCommand"
-            contextId="org.eclipse.ui.contexts.dialogAndWindow"
-            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+M2+M3+F9">
-      </key>
-   </extension>
-   <extension
-         point="org.eclipse.ui.handlers">
-      <handler
-            class="org.eclipse.tools.layout.spy.internal.handlers.LayoutSpyHandler"
-            commandId="org.eclipse.tools.layout.spy.commands.layoutSpyCommand">
-      </handler>
+         id="org.eclipse.tools.layout.spy.fragment"
+         point="org.eclipse.e4.workbench.model">
+      <fragment
+            apply="always"
+            uri="fragment.e4xmi">
+      </fragment>
    </extension>
    <extension
          point="org.eclipse.pde.spy.core.spyPart">

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/handlers/LayoutSpyHandler.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/handlers/LayoutSpyHandler.java
@@ -14,38 +14,25 @@
  *******************************************************************************/
 package org.eclipse.tools.layout.spy.internal.handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.tools.layout.spy.internal.dialogs.LayoutSpyDialog;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.handlers.HandlerUtil;
 
-public class LayoutSpyHandler extends AbstractHandler {
+import jakarta.inject.Named;
+
+public class LayoutSpyHandler {
 	private LayoutSpyDialog popupDialog;
 
-	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
+	@Execute
+	public void execute(@Named(IServiceConstants.ACTIVE_SHELL) Shell shell) {
 		if (popupDialog != null) {
 			popupDialog.close();
-		}
-
-		Shell shell = HandlerUtil.getActiveShell(event);
-		if (shell == null || shell.isDisposed()) {
-			// The active shell may have been disposed since the user initiated the command,
-			// such as when it was started via Find Actions dialog whose shell is disposed
-			// as a side effect of launching this handler
-			IWorkbenchWindow activeWorkbenchWindow = HandlerUtil.getActiveWorkbenchWindow(event);
-			if (activeWorkbenchWindow != null) {
-				shell = activeWorkbenchWindow.getShell();
-			}
 		}
 		if (shell != null && !shell.isDisposed()) {
 			popupDialog = new LayoutSpyDialog(shell);
 			popupDialog.open();
 		}
-		return null;
 	}
 
 }


### PR DESCRIPTION
Rewrites LayoutSpyHandler as a dependency-injected e4 handler and contributes its command, handler and M1+M2+M3+F9 key binding through a model fragment instead of the org.eclipse.ui command, handler and binding extension points. This removes the layout spy command's dependency on the 3.x compatibility workbench, so it can be used in plain e4 applications while the existing keystroke and behavior stay the same. The org.eclipse.core.runtime package is now consumed via Require-Bundle, since the equinox.common split-package export cannot satisfy a plain Import-Package once org.eclipse.ui is no longer pulled in transitively.