### PR TITLE
Keep repeated values in product program arguments

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/product/ProductEditorLaunchingTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/product/ProductEditorLaunchingTest.java
@@ -30,8 +30,10 @@ import java.util.stream.Collectors;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.pde.internal.core.iproduct.IProduct;
 import org.eclipse.pde.internal.core.product.WorkspaceProductModel;
 import org.eclipse.pde.internal.ui.launcher.LaunchAction;
@@ -147,6 +149,36 @@ public class ProductEditorLaunchingTest {
 		Set<String> additionalBundles = Set.of();
 		Set<String> bundles = Set.of("plugin.in.f.a", "plugin.in.f.b", "plugin.in.f.in.f.b", "plugin.in.f.c");
 		assertProductLaunchConfig("featuresWithVersion", USE_FEATURES_LAUNCH, features, additionalBundles, bundles);
+	}
+
+	@Test
+	public void testProductLaunch_programArgumentsWithRepeatedValues() throws Exception {
+		IFile file = project.getFile("programArgs.product");
+		assertTrue(file.exists());
+		WorkspaceProductModel model = new WorkspaceProductModel(file, false);
+		model.load();
+		IProduct product = model.getProduct();
+
+		ILaunchConfiguration config = new LaunchAction(product, file.getFullPath(), ILaunchManager.RUN_MODE)
+				.findLaunchConfiguration();
+
+		String programArgs = config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, "");
+		List<String> arguments = List.of(DebugPlugin.splitArguments(programArgs));
+
+		// A repeated value must be preserved. It was wrongly dropped when it
+		// matched a value contributed by an earlier user argument, turning
+		// "-target testarg -helper testarg" into "-target testarg -helper".
+		assertEquals("-target testarg expected", "testarg", argumentValue(arguments, "-target"));
+		assertEquals("-helper testarg expected", "testarg", argumentValue(arguments, "-helper"));
+		assertEquals("both repeated values must be kept", 2, Collections.frequency(arguments, "testarg"));
+		// A user argument already provided by the initial arguments is not duplicated.
+		assertEquals("-consoleLog must not be duplicated", 1, Collections.frequency(arguments, "-consoleLog"));
+	}
+
+	private static String argumentValue(List<String> arguments, String flag) {
+		int index = arguments.indexOf(flag);
+		assertTrue(flag + " is missing", index >= 0 && index + 1 < arguments.size());
+		return arguments.get(index + 1);
 	}
 
 	private void assertProductLaunchConfig(String productId, boolean useFeatures, Set<String> expectedFeatures,

--- a/ui/org.eclipse.pde.ui.tests/tests/products/programArgs.product
+++ b/ui/org.eclipse.pde.ui.tests/tests/products/programArgs.product
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="programArgs" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>-consoleLog -clearPersistedState -target testarg -helper testarg</programArgs>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="plugin.a"/>
+   </plugins>
+
+   <features>
+      <feature id="feature.a"/>
+   </features>
+
+</product>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/launcher/LaunchAction.java
@@ -276,13 +276,16 @@ public class LaunchAction extends Action {
 			'-' + IEnvironment.P_OS, '-' + IEnvironment.P_WS, '-' + IEnvironment.P_ARCH, '-' + IEnvironment.P_NL);
 
 	private String concatArgs(String initialArgs, String userArgs) {
-		List<String> arguments = new ArrayList<>(Arrays.asList(DebugPlugin.splitArguments(initialArgs)));
+		List<String> initialArgsList = Arrays.asList(DebugPlugin.splitArguments(initialArgs));
+		List<String> arguments = new ArrayList<>(initialArgsList);
 		if (userArgs != null && userArgs.length() > 0) {
 			List<String> userArgsList = Arrays.asList(DebugPlugin.splitArguments(userArgs));
 			boolean previousHasSubArgument = false;
 			for (String userArg : userArgsList) {
 				boolean hasSubArgument = PROGRAM_ARGUMENTS.contains(userArg);
-				if (!arguments.contains(userArg) || hasSubArgument || previousHasSubArgument) {
+				// Compare against the initial arguments, not the growing list,
+				// so repeated user values like "-target testarg -helper testarg" are kept.
+				if (!initialArgsList.contains(userArg) || hasSubArgument || previousHasSubArgument) {
 					arguments.add(userArg);
 				}
 				previousHasSubArgument = hasSubArgument;


### PR DESCRIPTION
Launching a product copied its program arguments into the run configuration through `concatArgs()`, which de-duplicated each user argument against the growing result list rather than against the initial arguments. A repeated value such as `-target test4 -helper test4` lost its second occurrence and became `-target test4 -helper`. The fix compares each user argument against the initial arguments only, so repeated values are kept while flags already provided by the defaults are still not duplicated. A regression test covers the case.