### PR TITLE
Contribute layout spy key binding via a model processor

### DIFF
--- a/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
@@ -10,7 +10,9 @@ Require-Bundle: org.eclipse.jface.databinding;bundle-version="1.9.0",
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.core.databinding.property;bundle-version="1.6.0",
  org.eclipse.swt;bundle-version="3.135.0",
- org.eclipse.jface;bundle-version="3.40.0"
+ org.eclipse.jface;bundle-version="3.40.0",
+ org.eclipse.e4.ui.model.workbench;bundle-version="[2.4.0,3.0.0)",
+ org.eclipse.e4.ui.workbench;bundle-version="[1.16.0,2.0.0)"
 Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",
  org.eclipse.core.runtime;common=split;version="[3.8.0,4.0.0)",

--- a/ui/org.eclipse.tools.layout.spy/fragment.e4xmi
+++ b/ui/org.eclipse.tools.layout.spy/fragment.e4xmi
@@ -10,13 +10,4 @@
       <persistedState key="persistState" value="false"/>
     </elements>
   </fragments>
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_layoutSpyBindingsFragment" featurename="bindingTables" parentElementId="xpath:/">
-    <elements xsi:type="commands:BindingTable" xmi:id="_layoutSpyBindingTable" elementId="org.eclipse.tools.layout.spy.bindingtable" bindingContext="_layoutSpyDialogAndWindowContext">
-      <persistedState key="persistState" value="false"/>
-      <bindings xmi:id="_layoutSpyKeyBinding" elementId="org.eclipse.tools.layout.spy.keybinding.layoutSpy" keySequence="M1+M2+M3+F9" command="_layoutSpyCommand">
-        <persistedState key="persistState" value="false"/>
-      </bindings>
-    </elements>
-  </fragments>
-  <imports xsi:type="commands:BindingContext" xmi:id="_layoutSpyDialogAndWindowContext" elementId="org.eclipse.ui.contexts.dialogAndWindow"/>
 </fragment:ModelFragments>

--- a/ui/org.eclipse.tools.layout.spy/plugin.xml
+++ b/ui/org.eclipse.tools.layout.spy/plugin.xml
@@ -24,6 +24,10 @@
             apply="always"
             uri="fragment.e4xmi">
       </fragment>
+      <processor
+            beforefragment="false"
+            class="org.eclipse.tools.layout.spy.internal.processors.LayoutSpyBindingProcessor">
+      </processor>
    </extension>
    <extension
          point="org.eclipse.pde.spy.core.spyPart">

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/processors/LayoutSpyBindingProcessor.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/processors/LayoutSpyBindingProcessor.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tools.layout.spy.internal.processors;
+
+import java.util.List;
+
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.commands.MBindingContext;
+import org.eclipse.e4.ui.model.application.commands.MBindingTable;
+import org.eclipse.e4.ui.model.application.commands.MCommand;
+import org.eclipse.e4.ui.model.application.commands.MKeyBinding;
+import org.eclipse.e4.ui.workbench.IWorkbench;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+
+/**
+ * Contributes the {@code M1+M2+M3+F9} key binding for the layout spy command to
+ * the {@code org.eclipse.ui.contexts.dialogAndWindow} binding context.
+ * <p>
+ * The binding is added programmatically rather than through the model fragment
+ * so that the binding context is resolved by object rather than by an
+ * {@code <imports>} element. Importing the context by id is ambiguous because
+ * the legacy binding table generated for that context shares its element id,
+ * which makes the fragment import resolve to the wrong element.
+ */
+public class LayoutSpyBindingProcessor {
+
+	private static final String COMMAND_ID = "org.eclipse.tools.layout.spy.commands.layoutSpyCommand"; //$NON-NLS-1$
+	private static final String BINDING_TABLE_ID = "org.eclipse.tools.layout.spy.bindingtable"; //$NON-NLS-1$
+	private static final String KEY_BINDING_ID = "org.eclipse.tools.layout.spy.keybinding.layoutSpy"; //$NON-NLS-1$
+	private static final String KEY_SEQUENCE = "M1+M2+M3+F9"; //$NON-NLS-1$
+	private static final String DIALOG_AND_WINDOW_CONTEXT_ID = "org.eclipse.ui.contexts.dialogAndWindow"; //$NON-NLS-1$
+
+	@Execute
+	public void process(MApplication application, EModelService modelService) {
+		MCommand command = findCommand(application);
+		if (command == null) {
+			// The command is contributed by fragment.e4xmi; without it there is nothing to bind.
+			return;
+		}
+		MBindingContext context = findContext(application.getRootContext());
+		if (context == null) {
+			context = findContext(application.getBindingContexts());
+		}
+		if (context == null) {
+			return;
+		}
+		MBindingTable table = getOrCreateBindingTable(application, modelService, context);
+		addKeyBinding(table, command, modelService);
+	}
+
+	private static MCommand findCommand(MApplication application) {
+		for (MCommand command : application.getCommands()) {
+			if (COMMAND_ID.equals(command.getElementId())) {
+				return command;
+			}
+		}
+		return null;
+	}
+
+	private static MBindingContext findContext(List<MBindingContext> contexts) {
+		for (MBindingContext context : contexts) {
+			if (DIALOG_AND_WINDOW_CONTEXT_ID.equals(context.getElementId())) {
+				return context;
+			}
+			MBindingContext child = findContext(context.getChildren());
+			if (child != null) {
+				return child;
+			}
+		}
+		return null;
+	}
+
+	private static MBindingTable getOrCreateBindingTable(MApplication application, EModelService modelService,
+			MBindingContext context) {
+		for (MBindingTable table : application.getBindingTables()) {
+			if (BINDING_TABLE_ID.equals(table.getElementId())) {
+				return table;
+			}
+		}
+		MBindingTable table = modelService.createModelElement(MBindingTable.class);
+		table.setElementId(BINDING_TABLE_ID);
+		table.setBindingContext(context);
+		table.getPersistedState().put(IWorkbench.PERSIST_STATE, Boolean.FALSE.toString());
+		application.getBindingTables().add(table);
+		return table;
+	}
+
+	private static void addKeyBinding(MBindingTable table, MCommand command, EModelService modelService) {
+		for (MKeyBinding binding : table.getBindings()) {
+			if (KEY_BINDING_ID.equals(binding.getElementId())) {
+				return;
+			}
+		}
+		MKeyBinding binding = modelService.createModelElement(MKeyBinding.class);
+		binding.setElementId(KEY_BINDING_ID);
+		binding.setKeySequence(KEY_SEQUENCE);
+		binding.setCommand(command);
+		binding.setContributorURI(command.getContributorURI());
+		binding.getPersistedState().put(IWorkbench.PERSIST_STATE, Boolean.FALSE.toString());
+		table.getBindings().add(binding);
+	}
+}


### PR DESCRIPTION
The layout spy contributed its command key binding through an e4 model fragment that imported the `org.eclipse.ui.contexts.dialogAndWindow` binding context.
Because the legacy binding table generated for that context shares the context's element id, the fragment import could resolve to the binding table instead of the context and crash `ModelAssembler.resolveImports` during model assembly, breaking `ResourceHandlerTest` (https://github.com/eclipse-platform/eclipse.platform.ui/issues/4148).
The binding is now contributed by a small e4 model processor that resolves the binding context by object and registers the binding on its own table, matching the existing PDE spy infrastructure.
This removes the ambiguous fragment import and keeps the command usable in plain e4 applications without reintroducing a dependency on org.eclipse.ui.
