### PR TITLE
Remove vestigial org.w3c.css.sac import from CSS spy bundle

### DIFF
--- a/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.css/META-INF/MANIFEST.MF
@@ -18,8 +18,7 @@ Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",
  org.eclipse.e4.core.contexts,
  org.eclipse.e4.core.di.annotations,
- org.eclipse.e4.ui.services,
- org.w3c.css.sac;version="1.3.0"
+ org.eclipse.e4.ui.services
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"


### PR DESCRIPTION
PR #2385 removed the last code use of the SAC (org.w3c.css.sac) API from the CSS spy, but left the Import-Package declaration in the bundle manifest. Nothing in org.eclipse.pde.spy.css references SAC anymore, so this drops the now-unused package import. Removing it clears leftover cruft and removes the last reason for the bundle to pull in the SAC package at all.