### PR TITLE
Do not hide the workbench window from the layout spy control selector

### DIFF
--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
@@ -81,8 +81,6 @@ public class LayoutSpyDialog {
 	private static final int UNKNOWN = -2;
 	/** The shell owned by the standalone dialog, or {@code null} when hosted in a part. */
 	private Shell shell;
-	/** The composite the spy contents are built into (the owned shell or a hosting part). */
-	private Composite container;
 
 	// Controls
 	private TableViewer childList;
@@ -148,8 +146,6 @@ public class LayoutSpyDialog {
 	}
 
 	private void createContents(Composite container) {
-		this.container = container;
-
 		overlay = new Shell(SWT.ON_TOP | SWT.NO_TRIM);
 		{
 			overlay.addPaintListener(this::paintOverlay);
@@ -415,13 +411,19 @@ public class LayoutSpyDialog {
 	 */
 	private void selectControl() {
 		this.controlSelectorOpen.setValue(true);
-		this.container.getShell().setVisible(false);
+		// Only hide our own dialog; as a part this shell is the workbench window.
+		boolean ownsShell = shell != null;
+		if (ownsShell) {
+			shell.setVisible(false);
+		}
 		new ControlSelector((@Nullable Control control) -> {
 			if (control != null) {
 				openControl(control);
 			}
 			this.controlSelectorOpen.setValue(false);
-			this.container.getShell().setVisible(true);
+			if (ownsShell) {
+				shell.setVisible(true);
+			}
 		});
 	}
 


### PR DESCRIPTION
When the layout spy is hosted as a part (the new e4 spy window) rather than a standalone dialog, its container's shell is the workbench window. The "Select control" action hid that shell so the spy would not obscure the picked control, which instead made the whole application vanish with no way to restore it. The fix only hides the shell when the spy owns its own standalone dialog, leaving the part variant untouched.