### PR TITLE
Organize manifest: do not remove reexported optional dependency

### DIFF
--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.runtime; singleton:=true
-Bundle-Version: 3.9.100.qualifier
+Bundle-Version: 3.9.200.qualifier
 Bundle-Activator: org.eclipse.pde.internal.runtime.PDERuntimePlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.0,4.0.0)";resolution:=optional,
  org.eclipse.jdt.ui;bundle-version="[3.31.0,4.0.0)";resolution:=optional,
  org.eclipse.pde.ui;bundle-version="[3.14.200,4.0.0)";resolution:=optional,
+ org.eclipse.pde.core;bundle-version="[3.21.200,4.0.0)";resolution:=optional,
  org.eclipse.help;bundle-version="[3.10.200,4.0.0)";resolution:=optional
 Export-Package: org.eclipse.pde.internal.runtime;x-internal:=true,
  org.eclipse.pde.internal.runtime.registry;x-internal:=true,

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
@@ -371,7 +371,11 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 		while (!(plugins.isEmpty())) {
 			String pluginId = plugins.pop();
 			IPluginModelBase base = PluginRegistry.findModel(pluginId);
-			if (base == null) {
+			// Do not remove a transitive dependency via an optional dependency,
+			// as it allows to just have the transitive dependency present
+			// without this one
+			boolean isPluginOptional = usedPlugins.containsKey(pluginId) && usedPlugins.get(pluginId).isOptional();
+			if (base == null || isPluginOptional) {
 				continue;
 			}
 			IPluginImport[] imports = base.getPluginBase().getImports();


### PR DESCRIPTION
When a bundle has an optional dependency to A and an optional dependency to B while A depends on B, the "Organize manifest" tool removes the optional dependency to B. While this makes sense when the dependencies are not optional (as A is transitively required by B), this is not reasonable when the dependency to A is optional. In that case, A may be missing at runtime, still it might be reasonable to require B (optional or non-optional) to allow the usage of functionality that just depends on B.

This change enhances the cleanup logic to not remove transitive dependencies of optional dependencies.

It avoids the error that was introduced with this automated cleanup and readds the dependency that was erroneously removed:
- https://github.com/eclipse-pde/eclipse.pde/pull/2235

That cleanup effectively reverted this change:
- https://github.com/eclipse-pde/eclipse.pde/pull/2213

With this change, the `org.eclipse.pde.core` dependency is not removed on manifest cleanup whereas is was removed without this change:
<img width="588" height="175" alt="image" src="https://github.com/user-attachments/assets/15c55452-2cae-4a35-b779-951f2a848049" />
