### PR TITLE
Organize manifest: do not remove reexported dependencies

### DIFF
--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.runtime; singleton:=true
-Bundle-Version: 3.9.100.qualifier
+Bundle-Version: 3.9.200.qualifier
 Bundle-Activator: org.eclipse.pde.internal.runtime.PDERuntimePlugin
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin

--- a/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.runtime/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.0,4.0.0)";resolution:=optional,
  org.eclipse.jdt.ui;bundle-version="[3.31.0,4.0.0)";resolution:=optional,
  org.eclipse.pde.ui;bundle-version="[3.14.200,4.0.0)";resolution:=optional,
+ org.eclipse.pde.core;bundle-version="[3.21.400,4.0.0)";resolution:=optional,
  org.eclipse.help;bundle-version="[3.10.200,4.0.0)";resolution:=optional
 Export-Package: org.eclipse.pde.internal.runtime;x-internal:=true,
  org.eclipse.pde.internal.runtime.registry;x-internal:=true,

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -36,6 +36,7 @@ import org.eclipse.pde.ui.tests.project.DynamicPluginProjectReferencesTest;
 import org.eclipse.pde.ui.tests.project.PluginRegistryTests;
 import org.eclipse.pde.ui.tests.project.ProjectCreationTests;
 import org.eclipse.pde.ui.tests.runtime.AllPDERuntimeTests;
+import org.eclipse.pde.ui.tests.search.dependencies.GatherUnusedDependenciesOperationTest;
 import org.eclipse.pde.ui.tests.target.AllTargetTests;
 import org.eclipse.pde.ui.tests.views.log.AllLogViewTests;
 import org.eclipse.pde.ui.tests.wizards.AllNewProjectTests;
@@ -72,6 +73,7 @@ import org.junit.platform.suite.api.Suite;
 	BundleErrorReporterTest.class, //
 	AllPDECoreTests.class, //
 	ProjectSmartImportTest.class, //
+	GatherUnusedDependenciesOperationTest.class, //
 })
 public class AllPDETests {
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/search/dependencies/GatherUnusedDependenciesOperationTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/search/dependencies/GatherUnusedDependenciesOperationTest.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.pde.ui.tests.search.dependencies;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.pde.core.plugin.IPluginImport;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.core.project.IBundleClasspathEntry;
+import org.eclipse.pde.core.project.IBundleProjectDescription;
+import org.eclipse.pde.core.project.IBundleProjectService;
+import org.eclipse.pde.core.project.IPackageExportDescription;
+import org.eclipse.pde.core.project.IRequiredBundleDescription;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.ui.search.dependencies.GatherUnusedDependenciesOperation;
+import org.eclipse.pde.ui.tests.runtime.TestUtils;
+import org.eclipse.pde.ui.tests.util.ProjectUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.osgi.framework.VersionRange;
+
+public class GatherUnusedDependenciesOperationTest {
+
+	@ClassRule
+	public static final TestRule CLEAR_WORKSPACE = ProjectUtils.DELETE_ALL_WORKSPACE_PROJECTS_BEFORE_AND_AFTER;
+
+	@Test
+	public void testDirectlyUsedDependencyReexportedByOtherDependencyIsNotFlaggedAsUnused() throws Exception {
+		// Bundle C: exports a package that is used directly by bundle B
+		String bundleC = "bundle.c";
+		String packageC = bundleC + ".pkg";
+		IProject projectC = createJavaPluginProject(bundleC);
+		addExportedPackage(projectC, packageC);
+		createJavaSource(projectC, packageC, "C", """
+				public class C {
+				}
+				""");
+
+		// Bundle A: requires and reexports C, but is otherwise unrelated to B
+		String bundleA = "bundle.a";
+		IProject projectA = createManifestOnlyPluginProject(bundleA);
+		addReexportedBundle(projectA, bundleC);
+
+		// Bundle B: directly requires both A and C, and directly uses C's API
+		String bundleB = "bundle.b";
+		IProject projectB = createJavaPluginProject(bundleB);
+		addRequiredBundle(projectB, bundleA);
+		addRequiredBundle(projectB, bundleC);
+		createJavaSource(projectB, bundleB, "UsesC", """
+				public class UsesC {
+					%s.C field;
+				}
+				""".formatted(packageC));
+
+		buildProjects();
+		List<String> unusedPlugins = gatherUnusedDependencies(projectB);
+		assertFalse(
+				"Direct, used dependency to bundle C must not be flagged as unused just because bundle A reexports it",
+				unusedPlugins.contains(bundleC));
+	}
+
+	private static IProject createManifestOnlyPluginProject(String symbolicName) throws Exception {
+		IBundleProjectService service = acquireBundleProjectService();
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(symbolicName);
+		IBundleProjectDescription description = service.getDescription(project);
+		description.setSymbolicName(symbolicName);
+		description.setNatureIds(new String[] { IBundleProjectDescription.PLUGIN_NATURE });
+		description.apply(null);
+		return project;
+	}
+
+	private static IProject createJavaPluginProject(String symbolicName) throws Exception {
+		IBundleProjectService service = acquireBundleProjectService();
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(symbolicName);
+		IBundleProjectDescription description = service.getDescription(project);
+		description.setSymbolicName(symbolicName);
+		description.setNatureIds(new String[] { IBundleProjectDescription.PLUGIN_NATURE, JavaCore.NATURE_ID });
+		IBundleClasspathEntry classpathEntry = service.newBundleClasspathEntry(IPath.fromOSString("src"), null,
+				IPath.fromOSString("."));
+		description.setBundleClasspath(new IBundleClasspathEntry[] { classpathEntry });
+		description.apply(null);
+		return project;
+	}
+
+	private static void addExportedPackage(IProject project, String packageName) throws Exception {
+		IBundleProjectService service = acquireBundleProjectService();
+		IBundleProjectDescription description = service.getDescription(project);
+		IPackageExportDescription[] presentExports = description.getPackageExports();
+		IPackageExportDescription addedExport = service.newPackageExport(packageName, null, true, List.of());
+		description.setPackageExports(Stream
+				.concat(presentExports != null ? Arrays.stream(presentExports) : Stream.empty(), Stream.of(addedExport))
+				.toArray(IPackageExportDescription[]::new));
+		description.apply(null);
+	}
+
+	private static void addRequiredBundle(IProject project, String symbolicName) throws CoreException {
+		addRequiredBundle(project, symbolicName, false);
+	}
+
+	private static void addReexportedBundle(IProject project, String symbolicName) throws CoreException {
+		addRequiredBundle(project, symbolicName, true);
+	}
+
+	private static void addRequiredBundle(IProject project, String symbolicName, boolean reexported)
+			throws CoreException {
+		IBundleProjectService service = acquireBundleProjectService();
+		IBundleProjectDescription description = service.getDescription(project);
+		IRequiredBundleDescription[] presentBundles = description.getRequiredBundles();
+		IRequiredBundleDescription addedBundle = service.newRequiredBundle(symbolicName, (VersionRange) null, false,
+				reexported);
+		description.setRequiredBundles(Stream
+				.concat(presentBundles != null ? Arrays.stream(presentBundles) : Stream.empty(), Stream.of(addedBundle))
+				.toArray(IRequiredBundleDescription[]::new));
+		description.apply(null);
+	}
+
+	private static void createJavaSource(IProject project, String packageName, String typeName, String body)
+			throws CoreException {
+		IPath packagePath = IPath.fromOSString("src").append(packageName.replace('.', '/'));
+		IFolder packageFolder = project.getFolder(packagePath);
+		if (!packageFolder.exists()) {
+			IFolder parent = project.getFolder(IPath.fromOSString("src"));
+			for (String segment : packageName.split("\\.")) {
+				parent = parent.getFolder(segment);
+				if (!parent.exists()) {
+					parent.create(true, true, null);
+				}
+			}
+		}
+		IFile javaFile = packageFolder.getFile(typeName + ".java");
+		String content = """
+				package %s;
+
+				%s""".formatted(packageName, body);
+		javaFile.create(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), true, null);
+	}
+
+	private static IBundleProjectService acquireBundleProjectService() {
+		return PDECore.getDefault().acquireService(IBundleProjectService.class);
+	}
+
+	private static void buildProjects() throws CoreException {
+		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+		TestUtils.waitForJobs(GatherUnusedDependenciesOperationTest.class.getName(), 100, 10000);
+	}
+
+	private static List<String> gatherUnusedDependencies(IProject project)
+			throws InvocationTargetException, InterruptedException {
+		IPluginModelBase model = PluginRegistry.findModel(project);
+		assertNotNull("Plug-in model for bundle " + project.getName() + " not found", model);
+
+		GatherUnusedDependenciesOperation operation = new GatherUnusedDependenciesOperation(model);
+		operation.run(new NullProgressMonitor());
+
+		return operation.getList().stream().filter(IPluginImport.class::isInstance).map(IPluginImport.class::cast)
+				.map(IPluginImport::getId).toList();
+	}
+
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
@@ -16,7 +16,6 @@
 package org.eclipse.pde.internal.ui.search.dependencies;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,7 +50,6 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.pde.core.plugin.IPluginImport;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
-import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.ClasspathUtilCore;
 import org.eclipse.pde.internal.core.bnd.PdeProjectAnalyzer;
 import org.eclipse.pde.internal.core.ibundle.IBundle;
@@ -362,37 +360,7 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 			}
 		}
 
-		Iterator<String> it = usedPlugins.keySet().iterator();
-		ArrayDeque<String> plugins = new ArrayDeque<>();
-		while (it.hasNext()) {
-			plugins.push(it.next().toString());
-		}
-		SubMonitor subMonitor = SubMonitor.convert(monitor);
-		while (!(plugins.isEmpty())) {
-			String pluginId = plugins.pop();
-			IPluginModelBase base = PluginRegistry.findModel(pluginId);
-			if (base == null) {
-				continue;
-			}
-			IPluginImport[] imports = base.getPluginBase().getImports();
-			SubMonitor iterationMonitor = subMonitor.setWorkRemaining(Math.max(plugins.size() + 1, 5)).split(1)
-					.setWorkRemaining(imports.length);
-			for (IPluginImport imp : imports) {
-				if (imp.isReexported()) {
-					String reExportedId = imp.getId();
-					if (reExportedId != null && reExportedId.equals(pluginId)) {
-						continue;
-					}
-					Object pluginImport = usedPlugins.remove(imp.getId());
-					if (pluginImport != null) {
-						fList.add(pluginImport);
-						updateMonitor(iterationMonitor, fList.size());
-					}
-					plugins.push(reExportedId);
-				}
-				iterationMonitor.worked(1);
-			}
-		}
+		monitor.done();
 	}
 
 	private static class Requestor extends SearchRequestor {


### PR DESCRIPTION
## What it does
Removes the "Organize Manifest" logic that dropped a direct dependency on bundle B whenever some other used bundle A already reexported B, and restores the `org.eclipse.pde.core` dependency that this logic had incorrectly stripped from `org.eclipse.pde.runtime`.

## Why
`org.eclipse.pde.runtime` uses `org.eclipse.pde.core` API directly but only optionally depends on `org.eclipse.pde.ui`, which reexports `org.eclipse.pde.core`. "Organize Manifest" saw `pde.core` as reachable transitively through the reexport and removed the direct, optional dependency — which breaks the runtime plug-in whenever `pde.ui` is not installed.

In an first attempt, we tried to fix this narrowly by keeping the direct dependency only when the reexporting bundle is optional:
- #2403 
 
Discussion on that PR showed the assumption doesn't hold even for mandatory reexports: a reexport is a promise about API visibility, not a substitute for a bundle's own declared dependency, and there's no general way to prove it's safe to drop the direct one. This PR removes the cleanup heuristic altogether instead of trying to special-case it further

Supercedes and thus closes #2403