### PR TITLE
Consider requirements shared with not-included sibling fragments

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -37,6 +37,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
 import org.osgi.framework.namespace.HostNamespace;
+import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.framework.wiring.BundleWire;
@@ -265,7 +266,8 @@ public class DependencyManager {
 					: namespaces.stream().map(wiring::getRequiredWires).flatMap(List::stream)::iterator;
 			for (BundleWire wire : requiredWires) {
 				BundleRevision declaringBundle = wire.getRequirement().getRevision();
-				if (declaringBundle != bundle && !closure.contains(declaringBundle)) {
+				if (declaringBundle != bundle && !closure.contains(declaringBundle)
+						&& !isAlsoDeclaredByIncludedFragment(bundle, wire, closure)) {
 					// Requirement is declared by an attached fragment, which is
 					// not included into the closure.
 					continue;
@@ -279,6 +281,38 @@ public class DependencyManager {
 			}
 		}
 		return closure;
+	}
+
+	/**
+	 * Returns whether the given wire satisfies a requirement that is declared
+	 * by a fragment of the given host that is part of the closure, although the
+	 * wire's requirement is declared by another revision.
+	 * <p>
+	 * If a host and its attached fragments declare equal requirements, only the
+	 * first one encountered while attaching the fragments becomes a constraint
+	 * of the host, all others are discarded. Consequently the single resulting
+	 * wire only names one of the declaring revisions, which is not necessarily
+	 * one included into the closure.
+	 * </p>
+	 */
+	private static boolean isAlsoDeclaredByIncludedFragment(BundleDescription host, BundleWire wire,
+			Set<BundleDescription> closure) {
+		BundleDescription[] fragments = host.getFragments();
+		if (fragments.length == 0) {
+			return false;
+		}
+		BundleCapability capability = wire.getCapability();
+		String namespace = capability.getNamespace();
+		for (BundleDescription fragment : fragments) {
+			if (closure.contains(fragment)) {
+				for (BundleRequirement requirement : fragment.getDeclaredRequirements(namespace)) {
+					if (requirement.matches(capability)) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
 	}
 
 	private static boolean isNativeFragment(BundleDescription fragment) {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/launcher/PluginBasedLaunchTest.java
@@ -938,6 +938,50 @@ public class PluginBasedLaunchTest extends AbstractLaunchTest {
 	}
 
 	@Test
+	public void testGetMergedBundleMap_automaticallyAddRequirements_requirementSharedWithEarlierSortingSiblingFragment()
+			throws Exception {
+		// Both fragments are attached to 'plugin.host' and both require
+		// 'plugin.shared'. Per OSGi Core spec chapter 3.14 those become hosted
+		// requirements of the host, and ResolverBundle.attachFragment() merges
+		// them by symbolic name only, so the fragment attaching first owns the
+		// single resulting constraint and is named as the wire's requirement
+		// revision (spec chapter 6.4.1).
+		//
+		// PDE resolves with osgi.resolverMode=development, which sorts bundles
+		// by symbolic name before attaching fragments, so
+		// 'fragment.a.sibling' attaches before 'fragment.b.selected' and owns
+		// the 'plugin.shared' constraint. Since only 'fragment.b.selected' is
+		// launched, the sibling is not in the requirement closure, but
+		// 'plugin.shared' must still be added because 'fragment.b.selected'
+		// declares the very same requirement.
+		var workspacePlugins = ofEntries( //
+				bundle("plugin.host", "1.0.0"), //
+				bundle("fragment.b.selected", "1.0.0", //
+						entry(Constants.FRAGMENT_HOST, "plugin.host"), //
+						entry(REQUIRE_BUNDLE, "plugin.only.selected,plugin.shared")), //
+				bundle("fragment.a.sibling", "1.0.0", //
+						entry(Constants.FRAGMENT_HOST, "plugin.host"), //
+						entry(REQUIRE_BUNDLE, "plugin.shared")), //
+				bundle("plugin.only.selected", "1.0.0"), //
+				bundle("plugin.shared", "1.0.0"));
+		var targetPlatformBundles = ofEntries( //
+				bundle("plugin.unrelated", "1.0.0"));
+
+		Consumer<ILaunchConfigurationWorkingCopy> launchConfigSetup = wc -> {
+			wc.setAttribute(IPDELauncherConstants.AUTOMATIC_INCLUDE_REQUIREMENTS, true);
+			wc.setAttribute(IPDELauncherConstants.SELECTED_WORKSPACE_BUNDLES, Set.of("fragment.b.selected*1.0.0"));
+		};
+
+		Set<BundleLocationDescriptor> expectedBundles = Set.of( //
+				workspaceBundle("fragment.b.selected", "1.0.0"), //
+				workspaceBundle("plugin.host", "1.0.0"), //
+				workspaceBundle("plugin.only.selected", "1.0.0"), //
+				workspaceBundle("plugin.shared", "1.0.0"));
+
+		assertGetMergedBundleMap(workspacePlugins, targetPlatformBundles, launchConfigSetup, expectedBundles);
+	}
+
+	@Test
 	public void testTwoVersionsOfSameBundleConfigIni() throws Exception {
 		var workspacePlugins = ofEntries( //
 				bundle("plugin.a", "1.0.0"), //


### PR DESCRIPTION
When a host and its fragments declare equal requirements, only the first one encountered while attaching the fragments becomes a constraint of the host, all others are discarded. The single resulting wire therefore names only one declaring revision, chosen by fragment attachment order, which is sorted by symbolic name since PDE resolves in development mode. If an earlier sorting sibling fragment declares the same requirement as the launched one, the wire names that sibling and the requirement was dropped from the closure silently.

Also check whether a fragment of the host that is part of the closure declares a requirement matching the wire's capability. This covers Import-Package too and still ignores requirements of fragments that are genuinely not included.