### PR TITLE
Provision the schema converter from the SDK repository

### DIFF
--- a/org.eclipse.pde.doc.user/pom.xml
+++ b/org.eclipse.pde.doc.user/pom.xml
@@ -138,6 +138,13 @@
                         <goal>schema-to-html</goal>
                     </goals>
                     <configuration>
+                        <!-- Without this Tycho provisions the schema converter from its
+                             hardcoded TychoConstants.ECLIPSE_LATEST simrel repository, which
+                             is mirrored and therefore prone to transient download failures. -->
+                        <pdeToolsRepository>
+                            <id>eclipse</id>
+                            <url>${eclipse-sdk-repo}</url>
+                        </pdeToolsRepository>
                         <manifests>
                             <manifest>${eclipse.pde.ui.ui}/org.eclipse.ui.trace/plugin.xml</manifest>
                             <manifest>${eclipse.pde.ui.ui}/org.eclipse.pde.core/plugin.xml</manifest>


### PR DESCRIPTION
The `schema-to-html` execution in `org.eclipse.pde.doc.user` never set `pdeToolsRepository`, so Tycho fell back to its hardcoded `TychoConstants.ECLIPSE_LATEST`, which is currently the 2025-12 simultaneous release. That repository is served through the Eclipse mirror system, and provisioning it intermittently produces mirror retry warnings (the recurring `bcpg 1.82.0` one, for example). Because the Jenkinsfile gates on new Maven console warnings, those transient hiccups turn the Maven check red on unrelated PRs.

Pointing the goal at `${eclipse-sdk-repo}` fixes that. The SDK integration build repository is served directly from download.eclipse.org with no mirror redirection, and it already contains `org.eclipse.pde.core`. As a bonus the converter is now provisioned from the stream actually being built instead of a release that is over half a year old.

Verified locally with `mvn process-resources -pl org.eclipse.pde.doc.user -Pbuild-individual-bundles`: the log now reads `Adding repository https://download.eclipse.org/eclipse/updates/4.41-I-builds` and the build succeeds.