### PR TITLE
Prevent Target Editor reverts for marker-only resource changes

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/targetdefinition/TargetEditor.java
@@ -586,15 +586,15 @@ public class TargetEditor extends FormEditor {
 				if (delta != null) {
 					if (delta.getKind() == IResourceDelta.REMOVED) {
 						TargetEditor.this.close(false);
-					} else if (delta.getKind() == IResourceDelta.CHANGED || delta.getKind() == IResourceDelta.REPLACED) {
-						if (!fSaving) {
-							Display display = getSite().getShell().getDisplay();
-							display.asyncExec(() -> {
-								if (getActivePage() != -1) {
-									TargetEditor.this.doRevert();
-								}
-							});
-						}
+					} else if (delta.getKind() == IResourceDelta.CHANGED
+						&& (delta.getFlags() & (IResourceDelta.CONTENT | IResourceDelta.REPLACED)) != 0
+						&& !fSaving) {
+						Display display = getSite().getShell().getDisplay();
+						display.asyncExec(() -> {
+							if (getActivePage() != -1) {
+								TargetEditor.this.doRevert();
+							}
+						});
 					}
 				}
 			}


### PR DESCRIPTION
### Summary

The issue first surfaced with the m2e PDE integration, which triggers marker updates while editing a `.target` definition. These marker updates cause `TargetEditor` to revert the editor, discarding unsaved source-page input.

The behavior is not specific to m2e. Creating a bookmark on the open `.target` file also produces a marker-only resource delta and triggers the same revert.

For example, enter any unsaved XML change in the source page and then create a bookmark on the `.target` file. The Target Editor discards the working copy although the file content remains unchanged.

This change prevents the Target Editor from reverting unsaved source-page edits when the workspace reports a marker-only change for the opened `.target` file.

### Background

Commit 68642a19c8e4173b4ca240e635c80d0cd2cb3b2a extended `TargetEditor.doRevert()` to also revert dirty text-editor pages.

`TargetEditor.InputHandler.resourceChanged()` currently invokes `doRevert()` for every `IResourceDelta.CHANGED` delta on the target file. This includes marker-only deltas, although they do not alter the target definition content.

With the m2e PDE integration installed, workspace refreshes and marker updates trigger such deltas. While editing the XML source page, typing a character such as `<` then discards the unsaved working copy.

### Before
<img width="1377" height="617" alt="Target_Editor_Before" src="https://github.com/user-attachments/assets/a018c19d-fdbe-4b46-a69d-11ddff6e8a64" />

### After
<img width="1377" height="617" alt="Target_Editor_After" src="https://github.com/user-attachments/assets/0de53711-e13e-42d5-ad86-640a91b1b642" />

