### PR TITLE
Fix dead REPLACED check in the sample editor resource listener

### DIFF
--- a/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/SampleEditor.java
+++ b/ui/org.eclipse.pde.ui/src_samples/org/eclipse/pde/internal/ui/samples/SampleEditor.java
@@ -85,7 +85,9 @@ public class SampleEditor extends EditorPart {
 			IResource resource = delta.getResource();
 			if (resource instanceof IFile file) {
 				if (file.equals(((IFileEditorInput) getEditorInput()).getFile())) {
-					if (delta.getKind() == IResourceDelta.REMOVED || delta.getKind() == IResourceDelta.REPLACED) {
+					if (delta.getKind() == IResourceDelta.REMOVED
+							|| (delta.getKind() == IResourceDelta.CHANGED
+									&& (delta.getFlags() & IResourceDelta.REPLACED) != 0)) {
 						close();
 					}
 					return false;


### PR DESCRIPTION
`SampleEditor.InputFileListener` closes the editor when its `sample.properties` input goes away, but the replacement case never worked: `IResourceDelta.REPLACED` is a delta flag, not a delta kind, so `getKind() == IResourceDelta.REPLACED` could never be true. `getKind()` only ever returns `NO_CHANGE`, `ADDED`, `REMOVED`, `CHANGED`, `ADDED_PHANTOM` or `REMOVED_PHANTOM`.

The fix tests `REPLACED` against `getFlags()` on a `CHANGED` delta, which is how `ResourceComparator` actually reports a resource that was deleted and recreated in the same operation. The removal case was already correct and is unchanged.

This is the same class of bug as the one fixed for `TargetEditor` in #2414, found while reviewing it.