### PR TITLE
Remove dead NLS message constants and an orphaned key

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui;singleton:=true
-Bundle-Version: 4.9.200.qualifier
+Bundle-Version: 4.9.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.e4.tools.emf.ui</artifactId>
-  <version>4.9.200-SNAPSHOT</version>
+  <version>4.9.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/messages.properties
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/messages.properties
@@ -4,4 +4,3 @@ TitleAreaFilterDialogWithEmptyOptions_excludeEmptyValues=Exclude Empty Values
 TitleAreaFilterDialogWithEmptyOptions_includeEmptyValues=Include Empty Values
 TitleAreaFilterDialogWithEmptyOptions_onlyEmptyValues=Only Empty Values
 EmfUtil_ex_attribute_not_found=Attribute not found
-XmiTab_TypeTextToSearch=Type text to search

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/imp/Messages.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/imp/Messages.java
@@ -8,7 +8,6 @@ public class Messages extends NLS {
 	public static String ModelImportPage1_Description;
 	public static String ModelImportPage1_Go;
 	public static String ModelImportPage1_Import;
-	public static String ModelImportPage1_Import1;
 	public static String ModelImportPage1_SelectPlugInAndElementsToImport;
 	public static String ModelImportPage1_ToImport;
 	public static String ModelImportPage1_WizardPage;

--- a/features/org.eclipse.e4.core.tools.feature/feature.xml
+++ b/features/org.eclipse.e4.core.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.e4.core.tools.feature"
       label="%featureName"
-      version="4.30.1000.qualifier"
+      version="4.30.1100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.pde.spies-feature/feature.xml
+++ b/features/org.eclipse.pde.spies-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.pde.spies"
       label="%featureName"
-      version="1.0.1200.qualifier"
+      version="1.0.1300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.spy.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.spy.core;singleton:=true
-Bundle-Version: 1.1.700.qualifier
+Bundle-Version: 1.1.800.qualifier
 Automatic-Module-Name: org.eclipse.pde.spy.core
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/ui/org.eclipse.pde.spy.core/src/org/eclipse/pde/spy/core/Messages.java
+++ b/ui/org.eclipse.pde.spy.core/src/org/eclipse/pde/spy/core/Messages.java
@@ -5,7 +5,6 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
 	public static String SpyHandler_Open;
-	public static String SpyProcessor_category;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);


### PR DESCRIPTION
Three NLS resources are dead. `Messages.SpyProcessor_category` in `org.eclipse.pde.spy.core` and `Messages.ModelImportPage1_Import1` in `org.eclipse.e4.tools.emf.ui` are declared but have no entry in their `messages.properties` and are read nowhere, so `NLS.initializeMessages` currently logs a "NLS missing message" warning for each on class initialization. Removing them silences that noise.

The third is the reverse case: the key `XmiTab_TypeTextToSearch` in `internal/common/component/tabs/messages.properties` has no matching field in the sibling `Messages` class. `XmiTab` imports `org.eclipse.e4.tools.emf.ui.internal.Messages` instead and reads the value through its injected instance field, so that entry is never loaded and the visible text is unaffected.

Note that only the two field removals are compile-verified; the orphaned key is bound reflectively, so it was checked by reading the code. Built locally with `mvn verify -pl :org.eclipse.pde.spy.core,:org.eclipse.e4.tools.emf.ui`.