### PR TITLE
Never resolve the target platform from PDELabelProvider

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/BackgroundInitialization.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/BackgroundInitialization.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+
+/**
+ * Helper for model managers whose initialization resolves the target platform
+ * and therefore must never run on the UI thread.
+ */
+final class BackgroundInitialization {
+
+	private BackgroundInitialization() {
+	}
+
+	/**
+	 * Schedules the given job unless {@code initialized} already reports success,
+	 * and runs {@code callback} exactly once, either right away or once the job
+	 * has finished, successfully or not.
+	 */
+	static void whenInitialized(Job job, BooleanSupplier initialized, Runnable callback) {
+		if (initialized.getAsBoolean()) {
+			callback.run();
+			return;
+		}
+		AtomicBoolean notified = new AtomicBoolean();
+		job.addJobChangeListener(new JobChangeAdapter() {
+			@Override
+			public void done(IJobChangeEvent event) {
+				event.getJob().removeJobChangeListener(this);
+				if (notified.compareAndSet(false, true)) {
+					callback.run();
+				}
+			}
+		});
+		job.schedule();
+		// the job may already have finished before the listener was attached
+		if (initialized.getAsBoolean() && notified.compareAndSet(false, true)) {
+			callback.run();
+		}
+	}
+}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/FeatureModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/FeatureModelManager.java
@@ -23,9 +23,11 @@ import java.util.Set;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.pde.core.IModel;
 import org.eclipse.pde.core.IModelProviderEvent;
 import org.eclipse.pde.core.IModelProviderListener;
@@ -58,11 +60,25 @@ public class FeatureModelManager {
 
 	private ExternalFeatureModelManager fExternalManager;
 
-	private boolean fReloadExternalNeeded = false;
+	private volatile boolean fReloadExternalNeeded = false;
+
+	/**
+	 * Set once {@link #init()} has completed; {@link #fActiveModels} is assigned
+	 * much earlier.
+	 */
+	private volatile boolean fModelsAvailable = false;
 
 	private final WorkspaceFeatureModelManager fWorkspaceManager;
 
 	private IModelProviderListener fProviderListener;
+
+	/**
+	 * only access synchronized with fInitializationJobLock, which must never be
+	 * held while the target platform is resolved
+	 **/
+	private Job fInitializationJob;
+
+	private final Object fInitializationJobLock = new Object();
 
 	/**
 	 * List of IFeatureModelListener
@@ -83,56 +99,99 @@ public class FeatureModelManager {
 		}
 	}
 
+	/**
+	 * Returns whether the feature models can be queried without reading the
+	 * external features, which resolves the target platform.
+	 */
 	public boolean isInitialized() {
-		return (fActiveModels != null && !fReloadExternalNeeded);
+		// not synchronized: init() holds the instance monitor while it resolves
+		return fModelsAvailable && !fReloadExternalNeeded;
+	}
+
+	/**
+	 * Initializes the feature models in a background job unless they are
+	 * available already, and runs the given callback as soon as they are.
+	 */
+	public void initializeInBackground(Runnable whenInitialized) {
+		Job job;
+		// not the instance monitor: init() holds it while it resolves, and this
+		// method is called from the UI thread
+		synchronized (fInitializationJobLock) {
+			if (fInitializationJob == null) {
+				fInitializationJob = Job.create(PDECoreMessages.FeatureModelManager_initializingFeatureTargetPlatform,
+						(ICoreRunnable) monitor -> init());
+				fInitializationJob.setPriority(Job.LONG);
+			}
+			job = fInitializationJob;
+		}
+		BackgroundInitialization.whenInitialized(job, this::isInitialized, whenInitialized);
 	}
 
 	private synchronized void init() {
 		if (fActiveModels != null) {
 			if (fReloadExternalNeeded) {
+				fModelsAvailable = false;
 				fReloadExternalNeeded = false;
-				fExternalManager.initialize();
+				readExternalFeatures();
 			}
 			return;
 		}
 
 		fActiveModels = new FeatureTable();
-		fInactiveModels = new FeatureTable();
-
-		fProviderListener = this::handleModelsChanged;
-		fWorkspaceManager.addModelProviderListener(fProviderListener);
-
-		IFeatureModel[] models = fWorkspaceManager.getFeatureModels();
-		for (IFeatureModel model : models) {
-			// add all workspace models, including invalid or duplicate (save
-			// id, ver)
-			fActiveModels.add(model);
-		}
-
-		fExternalManager = new ExternalFeatureModelManager();
-		fExternalManager.addModelProviderListener(fProviderListener);
-		fReloadExternalNeeded = false;
-
-		ITargetDefinition unresolvedRepoBasedtarget = null;
 		try {
-			unresolvedRepoBasedtarget = TargetPlatformHelper.getUnresolvedRepositoryBasedWorkspaceTarget();
-		} catch (CoreException e) {
-			PDECore.log(e);
-		}
-		if (unresolvedRepoBasedtarget != null && !P2TargetUtils.isProfileValid(unresolvedRepoBasedtarget)) {
+			fInactiveModels = new FeatureTable();
 
-			WorkspaceJob initializeExternalManager = new WorkspaceJob(PDECoreMessages.FeatureModelManager_initializingFeatureTargetPlatform) {
-				@Override
-				public IStatus runInWorkspace(IProgressMonitor monitor) {
-					fExternalManager.initialize();
-					return Status.OK_STATUS;
-				}
-			};
-			initializeExternalManager.schedule();
-		} else {
+			fProviderListener = this::handleModelsChanged;
+			fWorkspaceManager.addModelProviderListener(fProviderListener);
+
+			IFeatureModel[] models = fWorkspaceManager.getFeatureModels();
+			for (IFeatureModel model : models) {
+				// add all workspace models, including invalid or duplicate (save
+				// id, ver)
+				fActiveModels.add(model);
+			}
+
+			fExternalManager = new ExternalFeatureModelManager();
+			fExternalManager.addModelProviderListener(fProviderListener);
+			fReloadExternalNeeded = false;
+
+			ITargetDefinition unresolvedRepoBasedtarget = null;
+			try {
+				unresolvedRepoBasedtarget = TargetPlatformHelper.getUnresolvedRepositoryBasedWorkspaceTarget();
+			} catch (CoreException e) {
+				PDECore.log(e);
+			}
+			if (unresolvedRepoBasedtarget != null && !P2TargetUtils.isProfileValid(unresolvedRepoBasedtarget)) {
+
+				WorkspaceJob initializeExternalManager = new WorkspaceJob(PDECoreMessages.FeatureModelManager_initializingFeatureTargetPlatform) {
+					@Override
+					public IStatus runInWorkspace(IProgressMonitor monitor) {
+						fExternalManager.initialize();
+						return Status.OK_STATUS;
+					}
+				};
+				initializeExternalManager.schedule();
+			} else {
+				readExternalFeatures();
+			}
+		} finally {
+			// init() fast-returns once fActiveModels is set, so a failure on the way
+			// out must not leave isInitialized() false for good
+			fModelsAvailable = true;
+		}
+	}
+
+	/**
+	 * Reads the external features. Even if that fails the models count as
+	 * available, otherwise {@link #init()} would fast-return forever and leave
+	 * {@link #isInitialized()} false for good.
+	 */
+	private void readExternalFeatures() {
+		try {
 			fExternalManager.initialize();
+		} finally {
+			fModelsAvailable = true;
 		}
-
 	}
 
 	/*

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/PluginModelManager.java
@@ -39,6 +39,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.service.resolver.BundleDelta;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.HostSpecification;
@@ -117,9 +118,11 @@ public class PluginModelManager implements IModelProviderListener {
 	private PDEState fState; // keeps the combined view of the target and workspace
 
 	/**
-	 * only access synchronized with fEntriesSynchronizer
+	 * Only modify synchronized with fEntriesSynchronizer, and only assign a fully
+	 * populated table. Volatile so that {@link #isInitialized()} can read it
+	 * without that lock.
 	 **/
-	private Map<String, LocalModelEntry> fEntries; // a master table keyed by plugin ID and the value is a ModelEntry
+	private volatile Map<String, LocalModelEntry> fEntries; // a master table keyed by plugin ID and the value is a ModelEntry
 	/**
 	 * used to synchronize all public methods which (indirectly) use fEntries
 	 **/
@@ -128,6 +131,14 @@ public class PluginModelManager implements IModelProviderListener {
 	private ArrayList<IPluginModelListener> fListeners; // a list of listeners interested in changes to the plug-in models
 	private ArrayList<IStateDeltaListener> fStateListeners; // a list of listeners interested in changes to the PDE/resolver State
 	private boolean fCancelled = false;
+
+	/**
+	 * only access synchronized with fInitializationJobLock, which must never be
+	 * held while the target platform is resolved
+	 **/
+	private Job fInitializationJob;
+
+	private final Object fInitializationJobLock = new Object();
 
 	/**
 	 * Initialize the workspace and external (target) model manager
@@ -397,9 +408,28 @@ public class PluginModelManager implements IModelProviderListener {
 	 * 		<code>false</code> otherwise.
 	 */
 	public boolean isInitialized() {
-		synchronized (fEntriesSynchronizer) {
-			return fEntries != null;
+		// not synchronized: fEntriesSynchronizer is held while the target
+		// platform is resolved
+		return fEntries != null;
+	}
+
+	/**
+	 * Initializes the master table in a background job unless it is initialized
+	 * already, and runs the given callback as soon as the table is available.
+	 */
+	public void initializeInBackground(Runnable whenInitialized) {
+		Job job;
+		// not fEntriesSynchronizer: that lock is held while the target platform
+		// is resolved, and this method is called from the UI thread
+		synchronized (fInitializationJobLock) {
+			if (fInitializationJob == null) {
+				fInitializationJob = Job.create(PDECoreMessages.PluginModelManager_InitializingPluginModels,
+						this::initialize);
+				fInitializationJob.setPriority(Job.LONG);
+			}
+			job = fInitializationJob;
 		}
+		BackgroundInitialization.whenInitialized(job, this::isInitialized, whenInitialized);
 	}
 
 	/**

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/AllPDECoreTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/AllPDECoreTests.java
@@ -11,6 +11,7 @@ import org.junit.platform.suite.api.Suite;
 	StaleDependencyResolutionTest.class, //
 	WorkspaceModelManagerTest.class, //
 	WorkspaceProductModelManagerTest.class, //
+	ModelManagerBackgroundInitializationTest.class, //
 })
 public class AllPDECoreTests {
 }

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/ModelManagerBackgroundInitializationTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/ModelManagerBackgroundInitializationTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.core.tests.internal;
+
+import org.eclipse.pde.internal.core.FeatureModelManager;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.PluginModelManager;
+import org.eclipse.pde.ui.tests.util.ConcurrencyUtil;
+import org.junit.Test;
+
+/**
+ * Verifies that scheduling the model initialization never waits for the lock
+ * that is held while the target platform is resolved.
+ */
+public class ModelManagerBackgroundInitializationTest {
+
+	private static final long TEST_TIMEOUT_MS = 60_000;
+
+	/**
+	 * init() holds the instance monitor while it reads the external features.
+	 */
+	@Test(timeout = TEST_TIMEOUT_MS)
+	public void testFeatureManagerSchedulesWithoutTakingTheInitMonitor() throws Exception {
+		FeatureModelManager manager = PDECore.getDefault().getFeatureModelManager();
+		ConcurrencyUtil.assertReturnsWhileLockIsHeld("initializeInBackground waited for the lock to be released", //$NON-NLS-1$
+				manager, () -> manager.initializeInBackground(() -> {
+				}));
+		// the scheduled job resolves the target platform, finish it here so it
+		// does not race the target of whatever test comes next
+		manager.getModels();
+	}
+
+	/**
+	 * initializeTable() holds fEntriesSynchronizer while it resolves the target.
+	 */
+	@Test(timeout = TEST_TIMEOUT_MS)
+	public void testPluginManagerSchedulesWithoutTakingTheEntriesLock() throws Exception {
+		PluginModelManager manager = PDECore.getDefault().getModelManager();
+		Object entriesLock = ConcurrencyUtil.readLock(manager, "fEntriesSynchronizer"); //$NON-NLS-1$
+		ConcurrencyUtil.assertReturnsWhileLockIsHeld("initializeInBackground waited for the lock to be released", //$NON-NLS-1$
+				entriesLock, () -> manager.initializeInBackground(() -> {
+				}));
+		// the scheduled job resolves the target platform, finish it here so it
+		// does not race the target of whatever test comes next
+		manager.getAllModels();
+	}
+}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -38,6 +38,7 @@ import org.eclipse.pde.ui.tests.project.ProjectCreationTests;
 import org.eclipse.pde.ui.tests.runtime.AllPDERuntimeTests;
 import org.eclipse.pde.ui.tests.search.dependencies.GatherUnusedDependenciesOperationTest;
 import org.eclipse.pde.ui.tests.target.AllTargetTests;
+import org.eclipse.pde.ui.tests.util.PDELabelProviderTest;
 import org.eclipse.pde.ui.tests.views.log.AllLogViewTests;
 import org.eclipse.pde.ui.tests.wizards.AllNewProjectTests;
 import org.eclipse.ui.tests.smartimport.ProjectSmartImportTest;
@@ -74,6 +75,7 @@ import org.junit.platform.suite.api.Suite;
 	AllPDECoreTests.class, //
 	ProjectSmartImportTest.class, //
 	GatherUnusedDependenciesOperationTest.class, //
+	PDELabelProviderTest.class, //
 })
 public class AllPDETests {
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/ConcurrencyUtil.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/ConcurrencyUtil.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.ui.tests.util;
+
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Helpers for asserting that a call does not wait for a lock that is held while
+ * the target platform is resolved.
+ */
+public class ConcurrencyUtil {
+
+	/**
+	 * Releases the held lock even if the call under test blocks, so a regression
+	 * fails the test instead of wedging the rest of the suite.
+	 */
+	private static final long RELEASE_TIMEOUT_MS = 15_000;
+
+	private ConcurrencyUtil() {
+	}
+
+	/**
+	 * Runs the given call while another thread holds the given lock and asserts
+	 * that it returned before that thread released it.
+	 */
+	public static void assertReturnsWhileLockIsHeld(String message, Object lock, Runnable call)
+			throws InterruptedException {
+		CountDownLatch acquired = new CountDownLatch(1);
+		CountDownLatch release = new CountDownLatch(1);
+		AtomicBoolean stillHeld = new AtomicBoolean();
+		Thread holder = new Thread(() -> {
+			synchronized (lock) {
+				stillHeld.set(true);
+				acquired.countDown();
+				try {
+					release.await(RELEASE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				stillHeld.set(false);
+			}
+		}, "lock holder"); //$NON-NLS-1$
+		holder.setDaemon(true);
+		holder.start();
+		try {
+			assertTrue("the holder thread never acquired the lock", //$NON-NLS-1$
+					acquired.await(RELEASE_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+			call.run();
+			assertTrue(message, stillHeld.get());
+		} finally {
+			release.countDown();
+			holder.join();
+		}
+	}
+
+	/**
+	 * Returns the value of the named field, to reach a lock that is not visible
+	 * to the test.
+	 */
+	public static Object readLock(Object owner, String name) throws ReflectiveOperationException {
+		Field field = owner.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		return field.get(owner);
+	}
+}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/PDELabelProviderTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/PDELabelProviderTest.java
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.ui.tests.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.pde.core.plugin.IPluginElement;
+import org.eclipse.pde.core.plugin.IPluginExtension;
+import org.eclipse.pde.core.plugin.PluginRegistry;
+import org.eclipse.pde.internal.core.FeatureModelManager;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.feature.WorkspaceFeatureModel;
+import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
+import org.eclipse.pde.internal.core.ifeature.IFeaturePlugin;
+import org.eclipse.pde.internal.core.iproduct.IProductFeature;
+import org.eclipse.pde.internal.core.isite.ISiteFeature;
+import org.eclipse.pde.internal.core.plugin.ImportObject;
+import org.eclipse.pde.internal.core.plugin.PluginImport;
+import org.eclipse.pde.internal.core.plugin.WorkspacePluginModel;
+import org.eclipse.pde.internal.core.product.WorkspaceProductModel;
+import org.eclipse.pde.internal.core.site.WorkspaceSiteModel;
+import org.eclipse.pde.internal.ui.PDELabelProvider;
+import org.eclipse.pde.internal.ui.PDEPluginImages;
+import org.eclipse.swt.graphics.Image;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+/**
+ * Verifies that {@link PDELabelProvider} does not resolve the target platform
+ * while decorating labels.
+ */
+public class PDELabelProviderTest {
+
+	private static final String UNRESOLVED_ID = "org.eclipse.pde.tests.does.not.exist"; //$NON-NLS-1$
+	private static final String VERSION = "1.0.0"; //$NON-NLS-1$
+
+	@ClassRule
+	public static final TestRule RESTORE_TARGET_DEFINITION = TargetPlatformUtil.RESTORE_CURRENT_TARGET_DEFINITION_AFTER;
+
+	@Rule
+	public final TestRule deleteCreatedProjectsAfter = ProjectUtils.DELETE_CREATED_WORKSPACE_PROJECTS_AFTER;
+
+	private ImportObject fUnresolvedImport;
+
+	@Before
+	public void setUp() {
+		WorkspacePluginModel model = new WorkspacePluginModel(null, false);
+		fUnresolvedImport = new ImportObject(new PluginImport(model, UNRESOLVED_ID));
+	}
+
+	/**
+	 * Once the models are available an unresolved import must still be decorated
+	 * with the error overlay.
+	 */
+	@Test
+	public void testUnresolvedImportIsDecoratedWhenModelsAreAvailable() {
+		PluginRegistry.findEntry(UNRESOLVED_ID);
+		assertTrue("plug-in models should be initialized", //$NON-NLS-1$
+				PDECore.getDefault().getModelManager().isInitialized());
+
+		PDELabelProvider labelProvider = new PDELabelProvider();
+		try {
+			Image plain = labelProvider.get(PDEPluginImages.DESC_REQ_PLUGIN_OBJ);
+			assertNotSame("unresolved import should be decorated", plain, //$NON-NLS-1$
+					labelProvider.getImage(fUnresolvedImport));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * As long as the models are not available the plain image must be returned
+	 * instead of querying the plug-in registry.
+	 */
+	@Test
+	public void testImportIsUndecoratedWhileModelsAreUnavailable() {
+		PDELabelProvider labelProvider = newProviderWithoutPluginModels();
+		try {
+			Image plain = labelProvider.get(PDEPluginImages.DESC_REQ_PLUGIN_OBJ);
+			assertSame("import must not be decorated before the models are known", plain, //$NON-NLS-1$
+					labelProvider.getImage(fUnresolvedImport));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * The image of a feature plug-in must not wait for the plug-in models, which
+	 * isFragment() resolves just like the error overlay does.
+	 */
+	@Test
+	public void testFeaturePluginImageDoesNotWaitForPluginModels() throws Exception {
+		IFeaturePlugin featurePlugin = createFeaturePlugin(UNRESOLVED_ID);
+		Object entriesLock = ConcurrencyUtil.readLock(PDECore.getDefault().getModelManager(),
+				"fEntriesSynchronizer"); //$NON-NLS-1$
+
+		PDELabelProvider labelProvider = newProviderWithoutPluginModels();
+		try {
+			ConcurrencyUtil.assertReturnsWhileLockIsHeld(
+					"feature plug-in image must not wait for the plug-in models", entriesLock, //$NON-NLS-1$
+					() -> labelProvider.getImage(featurePlugin));
+			Image plain = labelProvider.get(PDEPluginImages.DESC_PLUGIN_OBJ);
+			assertSame("feature plug-in must not be decorated before the models are known", plain, //$NON-NLS-1$
+					labelProvider.getImage(featurePlugin));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * Once the feature models are available a feature that cannot be found must
+	 * still be decorated with the error overlay.
+	 */
+	@Test
+	public void testUnresolvedFeatureIsDecoratedWhenModelsAreAvailable() {
+		FeatureModelManager manager = PDECore.getDefault().getFeatureModelManager();
+		manager.getModels();
+		assertTrue("feature models should be initialized", manager.isInitialized()); //$NON-NLS-1$
+
+		PDELabelProvider labelProvider = new PDELabelProvider();
+		try {
+			Image plain = labelProvider.get(PDEPluginImages.DESC_FEATURE_OBJ);
+			assertNotSame("unresolved feature should be decorated", plain, //$NON-NLS-1$
+					labelProvider.getImage(createProductFeature(UNRESOLVED_ID)));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * As long as the feature models are not available the plain image must be
+	 * returned instead of querying the feature model manager.
+	 */
+	@Test
+	public void testFeatureIsUndecoratedWhileModelsAreUnavailable() {
+		PDELabelProvider labelProvider = newProviderWithoutFeatureModels();
+		try {
+			Image plain = labelProvider.get(PDEPluginImages.DESC_FEATURE_OBJ);
+			assertSame("feature must not be decorated before the models are known", plain, //$NON-NLS-1$
+					labelProvider.getImage(createProductFeature(UNRESOLVED_ID)));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * The label of a site feature falls back to its URL while the feature models
+	 * are unavailable.
+	 */
+	@Test
+	public void testSiteFeatureFallsBackToUrlWhileModelsAreUnavailable() throws Exception {
+		ISiteFeature siteFeature = createSiteFeature(UNRESOLVED_ID);
+
+		PDELabelProvider labelProvider = newProviderWithoutFeatureModels();
+		try {
+			assertEquals("site feature must not be resolved before the models are known", siteFeature.getURL(), //$NON-NLS-1$
+					labelProvider.getObjectText(siteFeature));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * Once the feature models are available the site feature is labeled with the
+	 * feature it points to, not with its URL.
+	 */
+	@Test
+	public void testSiteFeatureIsResolvedWhenModelsAreAvailable() throws Exception {
+		TargetPlatformUtil.setRunningPlatformAsTarget();
+		String id = "org.eclipse.pde.tests.label.feature"; //$NON-NLS-1$
+		ProjectUtils.createFeatureProject(id, VERSION, f -> {
+		});
+		IFeatureModel featureModel = PDECore.getDefault().getFeatureModelManager().findFeatureModel(id, VERSION);
+		assertNotNull("feature model should be known to the manager", featureModel); //$NON-NLS-1$
+
+		ISiteFeature siteFeature = createSiteFeature(id);
+
+		PDELabelProvider labelProvider = new PDELabelProvider();
+		try {
+			assertEquals("site feature should be labeled with the resolved feature", //$NON-NLS-1$
+					labelProvider.getObjectText(featureModel), labelProvider.getObjectText(siteFeature));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	/**
+	 * The image of an extension element must not wait for the plug-in models,
+	 * which the schema lookup builds the extension registry from.
+	 */
+	@Test
+	public void testExtensionElementImageDoesNotWaitForPluginModels() throws Exception {
+		IPluginElement element = createExtensionElement("org.eclipse.ui.views"); //$NON-NLS-1$
+		Object entriesLock = ConcurrencyUtil.readLock(PDECore.getDefault().getModelManager(),
+				"fEntriesSynchronizer"); //$NON-NLS-1$
+
+		PDELabelProvider labelProvider = newProviderWithoutPluginModels();
+		try {
+			ConcurrencyUtil.assertReturnsWhileLockIsHeld(
+					"extension element image must not wait for the plug-in models", entriesLock, //$NON-NLS-1$
+					() -> labelProvider.getImage(element));
+		} finally {
+			labelProvider.dispose();
+		}
+	}
+
+	private static IPluginElement createExtensionElement(String point) throws Exception {
+		WorkspacePluginModel model = new WorkspacePluginModel(null, false);
+		model.setEnabled(true);
+		IPluginExtension extension = model.getFactory().createExtension();
+		extension.setPoint(point);
+		IPluginElement element = model.getFactory().createElement(extension);
+		element.setName("view"); //$NON-NLS-1$
+		extension.add(element);
+		return element;
+	}
+
+	private static PDELabelProvider newProviderWithoutPluginModels() {
+		return new PDELabelProvider() {
+			@Override
+			public boolean arePluginModelsAvailable() {
+				return false;
+			}
+		};
+	}
+
+	private static IFeaturePlugin createFeaturePlugin(String id) throws Exception {
+		IFeaturePlugin plugin = new WorkspaceFeatureModel().getFactory().createPlugin();
+		plugin.setId(id);
+		plugin.setVersion(VERSION);
+		return plugin;
+	}
+
+	private static PDELabelProvider newProviderWithoutFeatureModels() {
+		return new PDELabelProvider() {
+			@Override
+			public boolean areFeatureModelsAvailable() {
+				return false;
+			}
+		};
+	}
+
+	private static IProductFeature createProductFeature(String id) {
+		IProductFeature feature = new WorkspaceProductModel(null, false).getFactory().createFeature();
+		feature.setId(id);
+		feature.setVersion(VERSION);
+		return feature;
+	}
+
+	private static ISiteFeature createSiteFeature(String id) throws Exception {
+		ISiteFeature feature = new WorkspaceSiteModel(null).getFactory().createFeature();
+		feature.setId(id);
+		feature.setVersion(VERSION);
+		feature.setURL("features/" + id + '_' + VERSION + ".jar"); //$NON-NLS-1$ //$NON-NLS-2$
+		return feature;
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDELabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/PDELabelProvider.java
@@ -17,6 +17,7 @@
 package org.eclipse.pde.internal.ui;
 
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -25,6 +26,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ResolverError;
 import org.eclipse.osgi.util.NLS;
@@ -44,8 +46,10 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginObject;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.plugin.VersionMatchRule;
+import org.eclipse.pde.internal.core.FeatureModelManager;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.pde.internal.core.PluginModelManager;
 import org.eclipse.pde.internal.core.TargetPlatformHelper;
 import org.eclipse.pde.internal.core.WorkspaceModelManager;
 import org.eclipse.pde.internal.core.builders.CompilerFlags;
@@ -90,6 +94,7 @@ import org.eclipse.pde.internal.ui.elements.NamedElement;
 import org.eclipse.pde.internal.ui.util.SWTUtil;
 import org.eclipse.pde.internal.ui.util.SharedLabelProvider;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.framework.Version;
 import org.osgi.resource.Resource;
@@ -97,7 +102,90 @@ import org.osgi.resource.Resource;
 public class PDELabelProvider extends SharedLabelProvider {
 	private static final String SYSTEM_BUNDLE = "system.bundle"; //$NON-NLS-1$
 
+	private final AtomicBoolean fPluginInitializationScheduled = new AtomicBoolean();
+	private final AtomicBoolean fFeatureInitializationScheduled = new AtomicBoolean();
+
+	/**
+	 * Cached because the accessors are synchronized on PDECore, whose monitor is
+	 * held across a target resolution in getHostPlugins(); the guards below run
+	 * for every label.
+	 */
+	private volatile PluginModelManager fPluginModelManager;
+
+	private volatile FeatureModelManager fFeatureModelManager;
+
 	public PDELabelProvider() {
+	}
+
+	/**
+	 * Returns whether the plug-in models can be queried without resolving the
+	 * target platform, and schedules a background initialization if they cannot.
+	 * Every lookup in the plug-in registry must be guarded by this check, and
+	 * labels are refreshed once the initialization has finished.
+	 */
+	public boolean arePluginModelsAvailable() {
+		PluginModelManager manager = getPluginModelManager();
+		if (manager.isInitialized()) {
+			return true;
+		}
+		if (fPluginInitializationScheduled.compareAndSet(false, true)) {
+			manager.initializeInBackground(() -> {
+				// on failure the flag stays set, so a failing job is not rescheduled forever
+				if (manager.isInitialized()) {
+					fPluginInitializationScheduled.set(false);
+				}
+				refreshLabels();
+			});
+		}
+		return false;
+	}
+
+	/**
+	 * Same contract as {@link #arePluginModelsAvailable()}, for the feature
+	 * models.
+	 */
+	public boolean areFeatureModelsAvailable() {
+		FeatureModelManager manager = getFeatureModelManager();
+		if (manager.isInitialized()) {
+			return true;
+		}
+		if (fFeatureInitializationScheduled.compareAndSet(false, true)) {
+			manager.initializeInBackground(() -> {
+				if (manager.isInitialized()) {
+					fFeatureInitializationScheduled.set(false);
+				}
+				refreshLabels();
+			});
+		}
+		return false;
+	}
+
+	private PluginModelManager getPluginModelManager() {
+		PluginModelManager manager = fPluginModelManager;
+		if (manager == null) {
+			manager = PDECore.getDefault().getModelManager();
+			fPluginModelManager = manager;
+		}
+		return manager;
+	}
+
+	private FeatureModelManager getFeatureModelManager() {
+		FeatureModelManager manager = fFeatureModelManager;
+		if (manager == null) {
+			manager = PDECore.getDefault().getFeatureModelManager();
+			fFeatureModelManager = manager;
+		}
+		return manager;
+	}
+
+	private void refreshLabels() {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return;
+		}
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		if (!display.isDisposed()) {
+			display.asyncExec(() -> fireLabelProviderChanged(new LabelProviderChangedEvent(this)));
+		}
 	}
 
 	@Override
@@ -209,8 +297,14 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	private String getSystemBundleInfo() {
-		IPluginBase systemBundle = PluginRegistry.findModel(SYSTEM_BUNDLE).getPluginBase();
-		return NLS.bind(" [{0}]", systemBundle.getId()); //$NON-NLS-1$
+		if (!arePluginModelsAvailable()) {
+			return ""; //$NON-NLS-1$
+		}
+		IPluginModelBase model = PluginRegistry.findModel(SYSTEM_BUNDLE);
+		if (model == null) {
+			return ""; //$NON-NLS-1$
+		}
+		return NLS.bind(" [{0}]", model.getPluginBase().getId()); //$NON-NLS-1$
 	}
 
 	private String preventNull(String text) {
@@ -253,7 +347,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 
 	public String getObjectText(BundleDescription bundle) {
 		String id = bundle.getSymbolicName();
-		if (isFullNameModeEnabled()) {
+		if (isFullNameModeEnabled() && arePluginModelsAvailable()) {
 			IPluginModelBase model = PluginRegistry.findModel((Resource) bundle);
 			if (model != null) {
 				return model.getPluginBase().getTranslatedName();
@@ -264,7 +358,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	public String getObjectText(IPluginImport obj) {
-		if (isFullNameModeEnabled()) {
+		if (isFullNameModeEnabled() && arePluginModelsAvailable()) {
 			String id = obj.getId();
 			IPluginModelBase model = PluginRegistry.findModel(obj.getId());
 			if (model != null) {
@@ -314,7 +408,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	public String getObjectText(FeaturePlugin obj) {
-		String name = isFullNameModeEnabled() ? obj.getLabel() : obj.getId();
+		String name = isFullNameModeEnabled() && arePluginModelsAvailable() ? obj.getLabel() : obj.getId();
 		String version = obj.getVersion();
 
 		String text;
@@ -330,12 +424,12 @@ public class PDELabelProvider extends SharedLabelProvider {
 	public String getObjectText(FeatureImport obj) {
 		int type = obj.getType();
 		if (type == IFeatureImport.PLUGIN) {
-			IPlugin plugin = obj.getPlugin();
+			IPlugin plugin = arePluginModelsAvailable() ? obj.getPlugin() : null;
 			if (plugin != null && isFullNameModeEnabled()) {
 				return preventNull(plugin.getTranslatedName());
 			}
 		} else if (type == IFeatureImport.FEATURE) {
-			IFeature feature = obj.getFeature();
+			IFeature feature = areFeatureModelsAvailable() ? obj.getFeature() : null;
 			if (feature != null && isFullNameModeEnabled()) {
 				return preventNull(feature.getTranslatableLabel());
 			}
@@ -385,9 +479,12 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	public String getObjectText(ISiteFeature obj) {
-		IFeatureModel model = PDECore.getDefault().getFeatureModelManager().findFeatureModel(obj.getId(), obj.getVersion() != null ? obj.getVersion() : ICoreConstants.DEFAULT_VERSION);
-		if (model != null) {
-			return getObjectText(model);
+		if (areFeatureModelsAvailable()) {
+			IFeatureModel model = PDECore.getDefault().getFeatureModelManager().findFeatureModel(obj.getId(),
+					obj.getVersion() != null ? obj.getVersion() : ICoreConstants.DEFAULT_VERSION);
+			if (model != null) {
+				return getObjectText(model);
+			}
 		}
 		String url = obj.getURL();
 		if (url != null) {
@@ -397,10 +494,12 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	public String getObjectText(ISiteBundle obj) {
-		IPluginModelBase modelBase = PluginRegistry.findModel(obj.getId(), obj.getVersion(),
-				VersionMatchRule.COMPATIBLE);
-		if (modelBase != null) {
-			return getObjectText(modelBase.getPluginBase());
+		if (arePluginModelsAvailable()) {
+			IPluginModelBase modelBase = PluginRegistry.findModel(obj.getId(), obj.getVersion(),
+					VersionMatchRule.COMPATIBLE);
+			if (modelBase != null) {
+				return getObjectText(modelBase.getPluginBase());
+			}
 		}
 		return preventNull(obj.getId());
 	}
@@ -484,6 +583,10 @@ public class PDELabelProvider extends SharedLabelProvider {
 			return getObjectImage((ISchemaAttribute) obj);
 		}
 		if (obj instanceof ISchemaInclude) {
+			// a schema:// include is looked up in the plug-in registry
+			if (!arePluginModelsAvailable()) {
+				return get(PDEPluginImages.DESC_PAGE_OBJ);
+			}
 			ISchema schema = ((ISchemaInclude) obj).getIncludedSchema();
 			return get(PDEPluginImages.DESC_PAGE_OBJ, schema == null || !schema.isValid() ? F_ERROR : 0);
 		}
@@ -644,7 +747,9 @@ public class PDELabelProvider extends SharedLabelProvider {
 	private Image getObjectImage(ImportObject iobj) {
 		int flags = 0;
 		IPluginImport iimport = iobj.getImport();
-		if (!iobj.isResolved()) {
+		// The resolved state is only known once the target platform is available
+		boolean modelsAvailable = arePluginModelsAvailable();
+		if (modelsAvailable && !iobj.isResolved()) {
 			flags = iimport.isOptional() ? F_WARNING : F_ERROR;
 		} else if (iimport.isReexported()) {
 			flags = F_EXPORT;
@@ -652,7 +757,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 		if (iimport.isOptional()) {
 			flags |= F_OPTIONAL;
 		}
-		IPlugin plugin = iobj.getPlugin();
+		IPlugin plugin = modelsAvailable ? iobj.getPlugin() : null;
 		if (plugin != null) {
 			IPluginModelBase model = plugin.getPluginModel();
 			flags |= getModelFlags(model);
@@ -670,7 +775,8 @@ public class PDELabelProvider extends SharedLabelProvider {
 		while (parent != null && !(parent instanceof IPluginExtension)) {
 			parent = parent.getParent();
 		}
-		if (parent != null) {
+		// the schema lookup builds the extension registry, which resolves
+		if (parent != null && arePluginModelsAvailable()) {
 			String point = ((IPluginExtension) parent).getPoint();
 			SchemaRegistry registry = PDECore.getDefault().getSchemaRegistry();
 			ISchema schema = registry.getSchema(point);
@@ -712,6 +818,9 @@ public class PDELabelProvider extends SharedLabelProvider {
 	}
 
 	private Image getObjectImage(IProductPlugin obj) {
+		if (!arePluginModelsAvailable()) {
+			return get(PDEPluginImages.DESC_PLUGIN_OBJ);
+		}
 		Version version = (obj.getVersion() != null && obj.getVersion().length() > 0 && !obj.getVersion().equals(ICoreConstants.DEFAULT_VERSION)) ? Version.parseVersion(obj.getVersion()) : null;
 		BundleDescription desc = TargetPlatformHelper.getState().getBundle(obj.getId(), version);
 		if (desc != null) {
@@ -781,7 +890,9 @@ public class PDELabelProvider extends SharedLabelProvider {
 
 	private Image getObjectImage(IFeaturePlugin plugin) {
 		int flags = 0;
-		if (((FeaturePlugin) plugin).getPluginBase() == null) {
+		// isFragment() resolves the plug-in as well, so it needs the same guard
+		boolean modelsAvailable = arePluginModelsAvailable();
+		if (modelsAvailable && ((FeaturePlugin) plugin).getPluginBase() == null) {
 			int cflag = CompilerFlags.getFlag(null, CompilerFlags.F_UNRESOLVED_PLUGINS);
 			if (cflag == CompilerFlags.ERROR) {
 				flags = F_ERROR;
@@ -789,7 +900,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 				flags = F_WARNING;
 			}
 		}
-		if (plugin.isFragment()) {
+		if (modelsAvailable && plugin.isFragment()) {
 			return get(PDEPluginImages.DESC_FRAGMENT_OBJ, flags);
 		}
 		return get(PDEPluginImages.DESC_PLUGIN_OBJ, flags);
@@ -797,7 +908,7 @@ public class PDELabelProvider extends SharedLabelProvider {
 
 	private Image getObjectImage(IFeatureChild feature) {
 		int flags = 0;
-		if (((FeatureChild) feature).getReferencedFeature() == null) {
+		if (areFeatureModelsAvailable() && ((FeatureChild) feature).getReferencedFeature() == null) {
 			int cflag = CompilerFlags.getFlag(null, CompilerFlags.F_UNRESOLVED_FEATURES);
 			if (cflag == CompilerFlags.ERROR) {
 				flags = F_ERROR;
@@ -811,8 +922,8 @@ public class PDELabelProvider extends SharedLabelProvider {
 	private Image getObjectImage(IProductFeature feature) {
 		int flags = 0;
 		String version = feature.getVersion().length() > 0 ? feature.getVersion() : ICoreConstants.DEFAULT_VERSION;
-		IFeatureModel model = PDECore.getDefault().getFeatureModelManager().findFeatureModel(feature.getId(), version);
-		if (model == null) {
+		if (areFeatureModelsAvailable()
+				&& PDECore.getDefault().getFeatureModelManager().findFeatureModel(feature.getId(), version) == null) {
 			flags = F_ERROR;
 		}
 		return get(PDEPluginImages.DESC_FEATURE_OBJ, flags);
@@ -835,14 +946,12 @@ public class PDELabelProvider extends SharedLabelProvider {
 
 		if (type == IFeatureImport.FEATURE) {
 			base = PDEPluginImages.DESC_FEATURE_OBJ;
-			IFeature feature = iimport.getFeature();
-			if (feature == null) {
+			if (areFeatureModelsAvailable() && iimport.getFeature() == null) {
 				flags = F_ERROR;
 			}
 		} else {
 			base = PDEPluginImages.DESC_REQ_PLUGIN_OBJ;
-			IPlugin plugin = iimport.getPlugin();
-			if (plugin == null) {
+			if (arePluginModelsAvailable() && iimport.getPlugin() == null) {
 				flags = F_ERROR;
 			}
 		}
@@ -907,7 +1016,8 @@ public class PDELabelProvider extends SharedLabelProvider {
 			if (importPackageObject.isOptional()) {
 				flags |= F_OPTIONAL;
 			}
-			if (!importPackageObject.isResolved()) {
+			// The resolved state is only known once the target platform is available
+			if (arePluginModelsAvailable() && !importPackageObject.isResolved()) {
 				flags |= importPackageObject.isOptional() ? F_WARNING : F_ERROR;
 			}
 		}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryLabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/category/CategoryLabelProvider.java
@@ -16,7 +16,9 @@
  ******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.category;
 
+import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.plugin.VersionMatchRule;
 import org.eclipse.pde.internal.core.PDECore;
@@ -32,6 +34,8 @@ import org.eclipse.ui.forms.editor.IFormPage;
 class CategoryLabelProvider extends LabelProvider {
 
 	private final PDELabelProvider fSharedProvider;
+
+	private final ILabelProviderListener fSharedProviderListener;
 
 	private Image fSiteFeatureImage;
 	private Image fMissingSiteFeatureImage;
@@ -49,6 +53,9 @@ class CategoryLabelProvider extends LabelProvider {
 		fPageImage = PDEPluginImages.DESC_PAGE_OBJ.createImage();
 		fSharedProvider = PDEPlugin.getDefault().getLabelProvider();
 		fSharedProvider.connect(this);
+		// the shared provider repaints once the models are there, this viewer must follow
+		fSharedProviderListener = event -> fireLabelProviderChanged(new LabelProviderChangedEvent(this));
+		fSharedProvider.addListener(fSharedProviderListener);
 	}
 
 	@Override
@@ -60,14 +67,19 @@ class CategoryLabelProvider extends LabelProvider {
 			return getImage(((SiteCategoryDefinitionAdapter) element).category);
 		}
 		if (element instanceof SiteFeatureAdapter) {
-			if (PDECore.getDefault().getFeatureModelManager().findFeatureModelRelaxed(((SiteFeatureAdapter) element).feature.getId(), ((SiteFeatureAdapter) element).feature.getVersion()) == null) {
+			// the lookup resolves the target platform, so it has to wait for the models
+			if (fSharedProvider.areFeatureModelsAvailable()
+					&& PDECore.getDefault().getFeatureModelManager().findFeatureModelRelaxed(
+							((SiteFeatureAdapter) element).feature.getId(),
+							((SiteFeatureAdapter) element).feature.getVersion()) == null) {
 				return fMissingSiteFeatureImage;
 			}
 			return fSiteFeatureImage;
 		}
 		if (element instanceof SiteBundleAdapter) {
 			ISiteBundle bundle = ((SiteBundleAdapter) element).bundle;
-			if (PluginRegistry.findModel(bundle.getId(), bundle.getVersion(), VersionMatchRule.COMPATIBLE) == null) {
+			if (fSharedProvider.arePluginModelsAvailable() && PluginRegistry.findModel(bundle.getId(),
+					bundle.getVersion(), VersionMatchRule.COMPATIBLE) == null) {
 				return this.fMissingSiteBundleImage;
 			}
 			return this.fSiteBundleImage;
@@ -102,6 +114,7 @@ class CategoryLabelProvider extends LabelProvider {
 
 	@Override
 	public void dispose() {
+		fSharedProvider.removeListener(fSharedProviderListener);
 		fSharedProvider.disconnect(this);
 		// Dispose of images
 		if ((fCatDefImage != null) && (fCatDefImage.isDisposed() == false)) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/SiteLabelProvider.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/site/SiteLabelProvider.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.pde.internal.ui.editor.site;
 
+import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.isite.ISiteCategoryDefinition;
 import org.eclipse.pde.internal.core.isite.ISiteFeature;
@@ -26,6 +28,8 @@ import org.eclipse.ui.forms.editor.IFormPage;
 class SiteLabelProvider extends LabelProvider {
 
 	private final PDELabelProvider fSharedProvider;
+
+	private final ILabelProviderListener fSharedProviderListener;
 
 	/**
 	 * Comment for <code>fLabelProvider</code>
@@ -45,6 +49,9 @@ class SiteLabelProvider extends LabelProvider {
 		fPageImage = PDEPluginImages.DESC_PAGE_OBJ.createImage();
 		fSharedProvider = PDEPlugin.getDefault().getLabelProvider();
 		fSharedProvider.connect(this);
+		// the shared provider repaints once the models are there, this viewer must follow
+		fSharedProviderListener = event -> fireLabelProviderChanged(new LabelProviderChangedEvent(this));
+		fSharedProvider.addListener(fSharedProviderListener);
 	}
 
 	@Override
@@ -53,7 +60,11 @@ class SiteLabelProvider extends LabelProvider {
 			return fCatDefImage;
 		}
 		if (element instanceof SiteFeatureAdapter) {
-			if (PDECore.getDefault().getFeatureModelManager().findFeatureModelRelaxed(((SiteFeatureAdapter) element).feature.getId(), ((SiteFeatureAdapter) element).feature.getVersion()) == null) {
+			// the lookup resolves the target platform, so it has to wait for the models
+			if (fSharedProvider.areFeatureModelsAvailable()
+					&& PDECore.getDefault().getFeatureModelManager().findFeatureModelRelaxed(
+							((SiteFeatureAdapter) element).feature.getId(),
+							((SiteFeatureAdapter) element).feature.getVersion()) == null) {
 				return fMissingSiteFeatureImage;
 			}
 			return fSiteFeatureImage;
@@ -81,6 +92,7 @@ class SiteLabelProvider extends LabelProvider {
 
 	@Override
 	public void dispose() {
+		fSharedProvider.removeListener(fSharedProviderListener);
 		fSharedProvider.disconnect(this);
 		// Dispose of images
 		if ((fCatDefImage != null) && (fCatDefImage.isDisposed() == false)) {


### PR DESCRIPTION
Label providers run on the UI thread, so they must not ask a question whose answer requires resolving the target platform.
`PDELabelProvider` did, through both `PluginModelManager` and `FeatureModelManager`, and either one can freeze the IDE for a long time when the target contains an m2e Maven location, because resolution runs a full `MavenExecutionContext` and bnd-wraps every transitive artifact while holding the manager's monitor.

Sampling the main thread every 500 ms during IDE startup, with a Category Definition editor restored from the previous session, put 10 consecutive samples, roughly 8 seconds, inside target resolution reached from `getObjectText(ISiteFeature)`.
The originally reported manifest editor freeze is the same shape through the other manager, from `getObjectImage(ImportObject)`.

Both are guarded now, building on the `isInitialized()` fast paths the two managers already had.
While the models are unknown the plain label is returned and initialization is scheduled in a background job; when it finishes the label provider fires a `LabelProviderChangedEvent`, so every viewer sharing it repaints with the resolved state.
Unresolved imports and missing features still get their error overlay once the models are available.

The two managers are two doors into the same room: whichever is opened first pays for the full resolution and caches the resolved target.
That is visible in the sampled run, which never entered `initializeTable` at all because the feature manager had already paid.
Guarding only one door would not have changed what the user sees, which is why both are in this change.

```
"main" #1 prio=6 elapsed=61.84s runnable
   java.lang.Thread.State: RUNNABLE
	at org.eclipse.m2e.core.internal.embedder.PlexusContainerManager.newPlexusContainer(PlexusContainerManager.java:207)
	at org.eclipse.m2e.core.internal.embedder.PlexusContainerManager.aquire(PlexusContainerManager.java:139)
	- locked <a java.util.HashMap>
	at org.eclipse.m2e.core.internal.embedder.MavenImpl.getSettings(MavenImpl.java:320)
	at org.eclipse.m2e.core.internal.embedder.MavenImpl.getArtifactRepositories(MavenImpl.java:851)
	at org.eclipse.m2e.pde.target.MavenTargetLocation.getAvailableArtifactRepositories(MavenTargetLocation.java:496)
	at org.eclipse.m2e.pde.target.MavenTargetLocation.resolveArtifacts(MavenTargetLocation.java:179)
	- locked <a org.eclipse.m2e.pde.target.MavenTargetLocation>
	at org.eclipse.m2e.pde.target.MavenTargetLocation.resolveBundles(MavenTargetLocation.java:169)
	at org.eclipse.pde.internal.core.target.AbstractBundleContainer.resolve(AbstractBundleContainer.java:96)
	at org.eclipse.pde.internal.core.target.TargetDefinition.resolve(TargetDefinition.java:379)
	at org.eclipse.pde.internal.core.TargetPlatformHelper.getWorkspaceTargetResolved(TargetPlatformHelper.java:558)
	at org.eclipse.pde.internal.core.ExternalFeatureModelManager.getExternalModels(ExternalFeatureModelManager.java:124)
	at org.eclipse.pde.internal.core.ExternalFeatureModelManager.initialize(ExternalFeatureModelManager.java:98)
	- locked <a org.eclipse.pde.internal.core.ExternalFeatureModelManager>
	at org.eclipse.pde.internal.core.FeatureModelManager.init(FeatureModelManager.java:133)
	- locked <a org.eclipse.pde.internal.core.FeatureModelManager>
	at org.eclipse.pde.internal.core.FeatureModelManager.findFeatureModel(FeatureModelManager.java:174)
	at org.eclipse.pde.internal.ui.PDELabelProvider.getObjectText(PDELabelProvider.java:388)
	at org.eclipse.pde.internal.ui.editor.category.CategoryLabelProvider.getText(CategoryLabelProvider.java:91)
	at org.eclipse.jface.viewers.WrappedViewerLabelProvider.update(WrappedViewerLabelProvider.java:150)
	at org.eclipse.jface.viewers.AbstractTreeViewer.doUpdateItem(AbstractTreeViewer.java:1005)
	at org.eclipse.jface.viewers.AbstractTreeViewer.createTreeItem(AbstractTreeViewer.java:897)
	at org.eclipse.jface.viewers.AbstractTreeViewer.createChildren(AbstractTreeViewer.java:875)
	at org.eclipse.jface.viewers.AbstractTreeViewer.internalInitializeTree(AbstractTreeViewer.java:1653)
	at org.eclipse.jface.viewers.AbstractTreeViewer.inputChanged(AbstractTreeViewer.java:1632)
	at org.eclipse.jface.viewers.ContentViewer.setInput(ContentViewer.java:279)
	at org.eclipse.jface.viewers.StructuredViewer.setInput(StructuredViewer.java:1640)
	at org.eclipse.pde.internal.ui.editor.category.CategorySection.createClient(CategorySection.java:219)
	at org.eclipse.pde.internal.ui.editor.category.IUsPage$SiteFeaturesBlock.createMasterSection(IUsPage.java:52)
	at org.eclipse.pde.internal.ui.editor.category.IUsPage.createFormContent(IUsPage.java:102)
	at org.eclipse.ui.forms.editor.FormPage.createPartControl(FormPage.java:168)
	at org.eclipse.pde.internal.ui.editor.PDEFormEditor.createPages(PDEFormEditor.java:275)
	at org.eclipse.ui.part.MultiPageEditorPart.createPartControl(MultiPageEditorPart.java:387)
	at org.eclipse.ui.internal.e4.compatibility.CompatibilityPart.createPartControl(CompatibilityPart.java:160)
	...
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:193)
```

And the originally reported manifest editor freeze, through the other manager:

```
"main" #1 prio=6 elapsed=75.24s runnable
   java.lang.Thread.State: RUNNABLE
	at aQute.bnd.osgi.Jar.buildFromZip(Jar.java:304)
	at org.eclipse.m2e.pde.target.shared.MavenBundleWrapper.getCachedJar(MavenBundleWrapper.java:303)
	at org.eclipse.m2e.pde.target.shared.MavenBundleWrapper.getWrappedArtifact(MavenBundleWrapper.java:157)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:281)
	at org.eclipse.m2e.pde.target.MavenTargetBundle.generateOrOverrideManifest(MavenTargetBundle.java:133)
	at org.eclipse.m2e.pde.target.MavenTargetLocation.addBundleForArtifact(MavenTargetLocation.java:394)
	at org.eclipse.m2e.pde.target.MavenTargetLocation.resolveArtifacts(MavenTargetLocation.java:182)
	- locked <a org.eclipse.m2e.pde.target.MavenTargetLocation>
	at org.eclipse.pde.internal.core.target.AbstractBundleContainer.resolve(AbstractBundleContainer.java:96)
	at org.eclipse.pde.internal.core.TargetPlatformHelper.getWorkspaceTargetResolved(TargetPlatformHelper.java:558)
	at org.eclipse.pde.internal.core.PluginModelManager.getExternalBundles(PluginModelManager.java:563)
	at org.eclipse.pde.internal.core.PluginModelManager.initializeTable(PluginModelManager.java:486)
	at org.eclipse.pde.internal.core.PluginModelManager.getEntryTable(PluginModelManager.java:436)
	at org.eclipse.pde.internal.core.PluginModelManager.findEntry(PluginModelManager.java:911)
	- locked <fEntriesSynchronizer>
	at org.eclipse.pde.core.plugin.PluginRegistry.findModel(PluginRegistry.java:387)
	at org.eclipse.pde.internal.core.plugin.ImportObject.findModel(ImportObject.java:92)
	at org.eclipse.pde.internal.core.plugin.PluginReference.isResolved(PluginReference.java:64)
	at org.eclipse.pde.internal.ui.PDELabelProvider.getObjectImage(PDELabelProvider.java:647)
	at org.eclipse.pde.internal.ui.PDELabelProvider.getImage(PDELabelProvider.java:454)
	at org.eclipse.jface.viewers.AbstractTableViewer.doUpdateItem(AbstractTableViewer.java:393)
	at org.eclipse.jface.viewers.AbstractTableViewer.inputChanged(AbstractTableViewer.java:567)
	at org.eclipse.jface.viewers.StructuredViewer.setInput(StructuredViewer.java:1640)
	at org.eclipse.pde.internal.ui.editor.plugin.RequiresSection.initialize(RequiresSection.java:550)
	at org.eclipse.pde.internal.ui.editor.plugin.RequiresSection.createClient(RequiresSection.java:161)
```

Both `isInitialized()` implementations had to become honest and non-blocking, otherwise the guards would have replaced one freeze with another.
`FeatureModelManager` reported success as soon as `fActiveModels` was assigned, which happens long before the external features are read, so a caller could be told the models are there and then block on the `init()` monitor.
It now reports the completion of `init()`.
`PluginModelManager` answered while holding `fEntriesSynchronizer`, which the background job holds for the whole resolution, so asking whether initialization is needed would have waited for exactly that initialization; `fEntries` is volatile now and read without the lock, and it is only ever assigned a fully populated table.

`PDELabelProviderTest` covers both paths.
For plug-ins, an unresolvable import is still decorated once the models are available and gets the plain image while they are not.
For features, the same holds for a product feature, a site feature falls back to its URL while the models are unavailable, and resolves to the label of a workspace feature once they are there.

Manual check: fresh workspace, a target with an m2e Maven location using `dependencyDepth="infinite"` and a cold `~/.m2`, with a category definition editor and a manifest editor open from the previous session.
Both should render immediately with plain labels and fill in once resolution finishes in the background.
