### PR TITLE
Externalize string in PDE preferences in ui

### DIFF
--- a/ui/org.eclipse.pde.ui/plugin.properties
+++ b/ui/org.eclipse.pde.ui/plugin.properties
@@ -41,6 +41,7 @@ preferences.target.name = Target Platform
 preferences.compilers.name = Compilers
 preferences.editor.name = Editors
 preferences.bnd.templaterepo.name = Bnd Template Repositories
+preferences.pde.Launching.name = Launching
 
 preferenceKeywords.PDE=Plug-in plugin Development PDE
 preferenceKeywords.MainPreferencePage=java search target source dependencies JUnit launch workspace configuration plug-in fragment bundle

--- a/ui/org.eclipse.pde.ui/plugin.xml
+++ b/ui/org.eclipse.pde.ui/plugin.xml
@@ -94,7 +94,7 @@
             category="org.eclipse.pde.ui.MainPreferencePage"
             class="org.eclipse.pde.internal.ui.preferences.LaunchingPreferencePage"
             id="org.eclipse.pde.ui.LaunchingPreferencePage"
-            name="Launching">
+            name="%preferences.pde.Launching.name">
       </page>
    </extension>
    <extension


### PR DESCRIPTION
This PR makes changes for externalizing one of the entries in the UI preference page. the non externalized string generated warning and hence the string has been externalized.