### PR TITLE
Force qualifier update after compiler change

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/forceQualifierUpdate.txt
+++ b/ui/org.eclipse.pde.bnd.ui/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/17
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2995
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3814
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3975


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5206 
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3975