### PR TITLE
Report a missing layout in the layout spy output

### DIFF
--- a/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.tools.layout.spy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.tools.layout.spy;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jface.databinding;bundle-version="1.9.0",

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
@@ -553,8 +553,11 @@ public class LayoutSpyDialog {
 
 		StringBuilder node = new StringBuilder();
 		describeControlGeometry(node, control);
-		node.append("Layout:\n"); //$NON-NLS-1$
-		describeControlLayout(node, control);
+		// Only composites can carry a layout, so the section stays out of the tree for leaf controls
+		if (control instanceof Composite) {
+			node.append("Layout:\n"); //$NON-NLS-1$
+			describeControlLayout(node, control);
+		}
 		for (String line : node.toString().split("\n")) { //$NON-NLS-1$
 			if (line.isEmpty()) {
 				builder.append("\n"); //$NON-NLS-1$
@@ -913,52 +916,53 @@ public class LayoutSpyDialog {
 			return;
 		}
 
-		Rectangle parentBounds = GeometryUtil.getDisplayBounds(parent);
 		Layout layout = parent.getLayout();
+		if (layout == null) {
+			builder.append(Messages.LayoutSpyDialog_label_no_layout);
+			return;
+		}
 
-		if (layout != null) {
-			if (layout instanceof GridLayout grid) {
-				builder.append(GridLayoutFactory.createFrom(grid));
+		if (!(layout instanceof GridLayout grid)) {
+			describeObject(builder, "layout", layout); //$NON-NLS-1$
+			return;
+		}
 
-				boolean hasVerticallyTruncadeControls = false;
-				boolean hasHorizontallyTruncadeControls = false;
+		builder.append(GridLayoutFactory.createFrom(grid));
 
-				boolean hasHorizontalGrab = false;
-				boolean hasVerticalGrab = false;
-				for (Control next : parent.getChildren()) {
-					@Nullable
-					GridData data = (GridData) next.getLayoutData();
-					if (data == null) {
-						continue;
-					}
+		Rectangle parentBounds = GeometryUtil.getDisplayBounds(parent);
+		boolean hasVerticallyTruncadeControls = false;
+		boolean hasHorizontallyTruncadeControls = false;
 
-					Rectangle childBounds = GeometryUtil.getDisplayBounds(parent);
-					Rectangle intersection = childBounds.intersection(parentBounds);
-
-					if (intersection.width < childBounds.width) {
-						hasHorizontallyTruncadeControls = true;
-					}
-
-					if (intersection.height < childBounds.height) {
-						hasVerticallyTruncadeControls = true;
-					}
-
-					hasHorizontalGrab = hasHorizontalGrab || data.grabExcessHorizontalSpace;
-					hasVerticalGrab = hasVerticalGrab || data.grabExcessVerticalSpace;
-				}
-
-				if (hasHorizontallyTruncadeControls && !hasHorizontalGrab) {
-					builder.append(getWarningMessage(
-							Messages.LayoutSpyDialog_warning_not_grabbing_horizontally));
-				}
-
-				if (hasVerticallyTruncadeControls && !hasVerticalGrab) {
-					builder.append(getWarningMessage(
-							Messages.LayoutSpyDialog_warning_not_grabbing_vertically));
-				}
-			} else {
-				describeObject(builder, "layout", layout); //$NON-NLS-1$
+		boolean hasHorizontalGrab = false;
+		boolean hasVerticalGrab = false;
+		for (Control next : parent.getChildren()) {
+			@Nullable
+			GridData data = (GridData) next.getLayoutData();
+			if (data == null) {
+				continue;
 			}
+
+			Rectangle childBounds = GeometryUtil.getDisplayBounds(next);
+			Rectangle intersection = childBounds.intersection(parentBounds);
+
+			if (intersection.width < childBounds.width) {
+				hasHorizontallyTruncadeControls = true;
+			}
+
+			if (intersection.height < childBounds.height) {
+				hasVerticallyTruncadeControls = true;
+			}
+
+			hasHorizontalGrab = hasHorizontalGrab || data.grabExcessHorizontalSpace;
+			hasVerticalGrab = hasVerticalGrab || data.grabExcessVerticalSpace;
+		}
+
+		if (hasHorizontallyTruncadeControls && !hasHorizontalGrab) {
+			builder.append(getWarningMessage(Messages.LayoutSpyDialog_warning_not_grabbing_horizontally));
+		}
+
+		if (hasVerticallyTruncadeControls && !hasVerticalGrab) {
+			builder.append(getWarningMessage(Messages.LayoutSpyDialog_warning_not_grabbing_vertically));
 		}
 	}
 

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/Messages.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/Messages.java
@@ -31,6 +31,7 @@ public class Messages extends NLS {
 	public static String LayoutSpyDialog_menu_copy_widget_info;
 	public static String LayoutSpyDialog_label_no_control_selected;
 	public static String LayoutSpyDialog_label_not_a_composite;
+	public static String LayoutSpyDialog_label_no_layout;
 	public static String LayoutSpyDialog_label_control_disposed;
 	public static String LayoutSpyDialog_warning_bounds_outside_parent;
 	public static String LayoutSpyDialog_warning_control_overlaps_siblings;

--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/messages.properties
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/messages.properties
@@ -11,6 +11,7 @@ LayoutSpyDialog_model_prompt=Press "Find Class" and then click a view, editor or
 LayoutSpyDialog_menu_copy_widget_info=Copy &Widget Info
 LayoutSpyDialog_label_no_control_selected=No control selected
 LayoutSpyDialog_label_not_a_composite=Selected control is not a Composite, so it has no layout.
+LayoutSpyDialog_label_no_layout=getLayout() == null
 LayoutSpyDialog_label_control_disposed=Selected control has been disposed. Press Refresh to update the tree.
 LayoutSpyDialog_warning_bounds_outside_parent=Control is located outside the bounds of its parent
 LayoutSpyDialog_warning_control_overlaps_siblings=Control overlaps one of its visible siblings


### PR DESCRIPTION
The layout section of the layout spy stayed empty for composites that have no layout, both in the details panel and in the copied widget tree. That looks like a broken spy rather than like a statement about the widget, so it now prints `getLayout() == null`, mirroring the `getLayoutData() == null` line right above it. For leaf controls the section is dropped completely instead of repeating "not a Composite" for every label and button in a tree dump.

While in there: the truncation check for grid layouts intersected the parent bounds with themselves instead of with the child bounds, so the intersection always matched and the warnings about missing grab flags could never be shown.