### PR TITLE
Update test projects to JavaSE-21 execution environment

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/tests/projects/classpathresolver/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/classpathresolver/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ui/org.eclipse.pde.ui.tests/tests/projects/classpathresolver/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/projects/classpathresolver/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: library.jar,
  .
 Require-Bundle: org.eclipse.pde.core;bundle-version="3.9.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/JavaEclipseProject/.classpath
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/JavaEclipseProject/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
The smart-import test project `JavaEclipseProject` was still pinned to `JavaSE-1.8` and `classpathresolver` to `J2SE-1.4`. Java 8 is currently the lowest source level ecj still accepts, so `ProjectSmartImportTest`, which asserts that the imported project has no error markers, would start failing as soon as that floor is raised. Updating now avoids that.

`classpathresolver` is a plug-in project, where the BREE is the source of truth: `ClasspathComputer` derives the JRE container from it and falls back to the default JRE when it is absent. Its manifest had no BREE at all, so this adds one rather than relying on the `.classpath` entry alone, which would otherwise be silently replaced on the next classpath update.

`JavaSE-21` matches the execution environment of `org.eclipse.pde.ui.tests` itself and of the other test projects under `tests/projects`, so the JRE container always resolves strictly compatible. `ProjectSmartImportTest` and `ClasspathResolverTest` pass locally.