### PR TITLE
Fix NPE caused by stale BundleWiring in dependency resolution

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -128,6 +128,9 @@ public class ClasspathUtilCore {
 		}
 
 		List<BundleWire> wires = wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE);
+		if (wires == null) {
+			return Stream.empty(); // wiring became stale
+		}
 		return wires.stream().filter(wire -> wire.getProviderWiring() != null).map(wire -> {
 			return wire.getProvider();
 		}).distinct().flatMap(provider -> {
@@ -169,6 +172,9 @@ public class ClasspathUtilCore {
 			return Stream.empty();
 		}
 		List<BundleWire> wires = wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE);
+		if (wires == null) {
+			return Stream.empty(); // wiring became stale
+		}
 		return wires.stream().map(wire -> wire.getProviderWiring().getBundle()).distinct()
 				.filter(b -> b.getBundleId() != 0)
 				.flatMap(b -> classpathEntriesForRuntimeBundle(b, extra).stream());

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/DependencyManager.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 
@@ -251,7 +252,11 @@ public class DependencyManager {
 				// Requirements of a fragment are hosted at the host, which
 				// therefore requires the corresponding wires: OSGi Core spec,
 				// chapter 6.4.1 - Hosted Requirements and Capabilities
-				for (BundleWire hostWire : wiring.getRequiredWires(HostNamespace.HOST_NAMESPACE)) {
+				List<BundleWire> hostWires = wiring.getRequiredWires(HostNamespace.HOST_NAMESPACE);
+				if (hostWires == null) {
+					continue; // wiring became stale
+				}
+				for (BundleWire hostWire : hostWires) {
 					// Temporarily remove this fragment's host from the closure
 					// to ensure it's added again below. In the subsequent
 					// processing this fragment's requirements will then also be
@@ -262,8 +267,17 @@ public class DependencyManager {
 				}
 			}
 
-			Iterable<BundleWire> requiredWires = namespaces.isEmpty() ? wiring.getRequiredWires(null)
-					: namespaces.stream().map(wiring::getRequiredWires).flatMap(List::stream)::iterator;
+			Iterable<BundleWire> requiredWires;
+			if (namespaces.isEmpty()) {
+				List<BundleWire> allWires = wiring.getRequiredWires(null);
+				if (allWires == null) {
+					continue; // wiring became stale
+				}
+				requiredWires = allWires;
+			} else {
+				requiredWires = namespaces.stream().map(wiring::getRequiredWires).filter(Objects::nonNull)
+						.flatMap(List::stream)::iterator;
+			}
 			for (BundleWire wire : requiredWires) {
 				BundleRevision declaringBundle = wire.getRequirement().getRevision();
 				if (declaringBundle != bundle && !closure.contains(declaringBundle)


### PR DESCRIPTION
Guard all affected getRequiredWires() call sites in DependencyManager and ClasspathUtilCore against a null return. In DependencyManager, a null result causes the current bundle to be skipped, consistent with the existing isInUse() guard above. In ClasspathUtilCore, a null result returns an empty stream so no classpath entries are produced for the stale wiring.

The per-namespace stream path in DependencyManager also gains a null filter before flatMap to handle the case where a live wiring has no wires for a specific namespace.

The original crash site is covered by a regression test. The remaining sites
require precise timing to reproduce in a test and are fixed defensively.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/2427