### PR TITLE
Stop the model editor stylesheet from painting over every theme

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/css/default.css
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/css/default.css
@@ -1,27 +1,7 @@
-.headerSectionContainer {
-	background-color: gradient #575757 #101010 100%;
-}
-
+/*
+ * Contributed to every theme, so it must not set colours: the model editor
+ * inherits them from the active theme instead.
+ */
 .sectionHeader {
 	font-weight: bold;
-	font-size: 15pt;
-	color: white;
-}
-
-.subSectionHeader {
-	background-color: gradient #575757 #101010 100%;
-}
-
-
-.contentContainer {
-	background-color: #fff #fff #cccccc 20% 80%;
-}
-
-.formContainer {
-	background-color: #fff;
-}
-
-/* SingleSourcing Container */
-.E4WorkbenchModelEditor {
-	background-color: #fff;
 }


### PR DESCRIPTION
The `css/default.css` of `org.eclipse.e4.tools.emf.ui` is contributed without a `themeid`, so it applies in every theme, third-party ones included. It painted three hard `#fff` areas and a fixed grey gradient over whatever the active theme had chosen, and pinned the section header to 15pt regardless of the font size the user picked. Every other stylesheet in this repo binds itself to `e4_default` or `e4_dark`.

Rather than adding a `themeid` and a dark counterpart, which would still leave third-party themes unstyled, this drops the colours and the font size so the editor simply inherits from the active theme. The `.subSectionHeader` and `.contentContainer` rules go with them: no widget carries those classes, they are never assigned anywhere in the repo. Only `font-weight` remains, which no theme needs to override.

Verified in a running IDE against the built-in Light and Dark themes.