### PR TITLE
Make the XMI tab of the model editor readable on dark themes

### DIFF
--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -27,7 +27,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.pde.core;bundle-version="3.21.200",
  org.eclipse.e4.core.commands;bundle-version="0.10.0",
  org.eclipse.e4.ui.dialogs;bundle-version="1.0.0",
- org.eclipse.ui.forms;bundle-version="3.7.200"
+ org.eclipse.ui.forms;bundle-version="3.7.200",
+ org.eclipse.ui.workbench;bundle-version="3.135.0",
+ org.eclipse.ui.editors;bundle-version="3.18.0"
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/OSGI-INF/resources.properties
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/OSGI-INF/resources.properties
@@ -135,9 +135,3 @@ IMG_org.eclipse.e4.tools.emf.ui.widgets.menu_obj = /icons/full/widgets/menu_obj.
 IMG_org.eclipse.e4.tools.emf.ui.widgets.menubar_obj = /icons/full/widgets/menubar_obj.gif
 IMG_org.eclipse.e4.tools.emf.ui.widgets.menuitem_obj = /icons/full/widgets/menuitem_obj.gif
 IMG_org.eclipse.e4.tools.emf.ui.widgets.menuseparator_obj = /icons/full/widgets/menuseparator_obj.gif
-
-COLOR_org.eclipse.e4.tools.emf.ui.XML_COMMENT=rgb(128, 0, 0)
-COLOR_org.eclipse.e4.tools.emf.ui.PROC_INSTR=rgb(128, 128, 128)
-COLOR_org.eclipse.e4.tools.emf.ui.STRING=rgb(0, 128, 0)
-COLOR_org.eclipse.e4.tools.emf.ui.DEFAULT=rgb(0, 0, 0)
-COLOR_org.eclipse.e4.tools.emf.ui.TAG=rgb(0, 0, 128)

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/css/e4-dark.css
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/css/e4-dark.css
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-e4-tools-emf-ui {
+	preferences:
+		'org.eclipse.e4.tools.emf.ui.color.tag=86,156,214'
+		'org.eclipse.e4.tools.emf.ui.color.string=206,145,120'
+		'org.eclipse.e4.tools.emf.ui.color.comment=96,139,78'
+		'org.eclipse.e4.tools.emf.ui.color.procInstr=128,128,128'
+}

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/plugin.properties
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/plugin.properties
@@ -23,3 +23,9 @@ autosizeColumns_commandName=Autosize Columns
 autosizeColumns_description=Autosizes all columns to their content
 resetToDefault_commandName=Reset To Default
 resetToDefault_description=Resets the table to default values
+
+themeElementCategory.label = EMF ModelTooling XMI Tab
+colorDefinition.tag = XMI tag
+colorDefinition.string = XMI attribute value
+colorDefinition.comment = XMI comment
+colorDefinition.procInstr = XMI processing instruction

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/plugin.xml
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/plugin.xml
@@ -8,6 +8,12 @@
       <stylesheet
             uri="css/default.css">
       </stylesheet>
+      <stylesheet
+            uri="css/e4-dark.css">
+         <themeid
+               refid="org.eclipse.e4.ui.css.theme.e4_dark">
+         </themeid>
+      </stylesheet>
    </extension>
    <extension
          point="org.eclipse.equinox.preferences.preferences">
@@ -22,6 +28,37 @@
             apply="notexists"
             uri="fragment.e4xmi">
       </fragment>
+   </extension>
+   <extension
+         point="org.eclipse.ui.themes">
+      <themeElementCategory
+            id="org.eclipse.e4.tools.emf.ui.presentation"
+            label="%themeElementCategory.label">
+      </themeElementCategory>
+      <colorDefinition
+            categoryId="org.eclipse.e4.tools.emf.ui.presentation"
+            id="org.eclipse.e4.tools.emf.ui.color.tag"
+            label="%colorDefinition.tag"
+            value="0,0,128">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.e4.tools.emf.ui.presentation"
+            id="org.eclipse.e4.tools.emf.ui.color.string"
+            label="%colorDefinition.string"
+            value="0,128,0">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.e4.tools.emf.ui.presentation"
+            id="org.eclipse.e4.tools.emf.ui.color.comment"
+            label="%colorDefinition.comment"
+            value="128,0,0">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.e4.tools.emf.ui.presentation"
+            id="org.eclipse.e4.tools.emf.ui.color.procInstr"
+            label="%colorDefinition.procInstr"
+            value="128,128,128">
+      </colorDefinition>
    </extension>
 
 </plugin>

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/ResourceProvider.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/ResourceProvider.java
@@ -117,9 +117,4 @@ public class ResourceProvider extends BasicResourceProvider {
 	public static final String IMG_Widgets_menuitem_obj = "IMG_org.eclipse.e4.tools.emf.ui.widgets.menuitem_obj"; //$NON-NLS-1$
 	public static final String IMG_Widgets_menuseparator_obj = "IMG_org.eclipse.e4.tools.emf.ui.widgets.menuseparator_obj"; //$NON-NLS-1$
 
-	public static final String COLOR_XML_COMMENT = "COLOR_org.eclipse.e4.tools.emf.ui.XML_COMMENT"; //$NON-NLS-1$
-	public static final String COLOR_PROC_INSTR = "COLOR_org.eclipse.e4.tools.emf.ui.PROC_INSTR"; //$NON-NLS-1$
-	public static final String COLOR_STRING = "COLOR_org.eclipse.e4.tools.emf.ui.STRING"; //$NON-NLS-1$
-	public static final String COLOR_DEFAULT = "COLOR_org.eclipse.e4.tools.emf.ui.DEFAULT"; //$NON-NLS-1$
-	public static final String COLOR_TAG = "COLOR_org.eclipse.e4.tools.emf.ui.TAG"; //$NON-NLS-1$
 }

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
@@ -29,6 +29,8 @@ import org.eclipse.e4.tools.emf.ui.internal.common.xml.XMLPartitionScanner;
 import org.eclipse.e4.tools.services.IResourcePool;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -45,8 +47,12 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.editors.text.EditorsUI;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
@@ -105,9 +111,10 @@ public class XmiTab extends Composite {
 		sourceViewer = new SourceViewer(this, verticalRuler, styles);
 		sourceViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		sourceViewer.configure(new XMLConfiguration(resourcePool));
+		sourceViewer.configure(new XMLConfiguration());
 		sourceViewer.setEditable(project != null);
 		sourceViewer.getTextWidget().setFont(JFaceResources.getTextFont());
+		applyTextEditorColors(sourceViewer.getTextWidget());
 
 		final IDocument document = emfDocumentProvider.getDocument();
 		final IDocumentPartitioner partitioner = new FastPartitioner(new XMLPartitionScanner(), new String[] {
@@ -138,6 +145,31 @@ public class XmiTab extends Composite {
 		if (property != null || preferences.getBoolean(ModelEditorPreferences.TAB_FORM_SEARCH_SHOW, true)) {
 			sourceViewer.setEditable(false);
 		}
+	}
+
+	/**
+	 * Takes foreground and background from the Text Editors preferences, so that the
+	 * tab follows the active theme instead of the widget defaults.
+	 */
+	private static void applyTextEditorColors(StyledText widget) {
+		final IPreferenceStore store = EditorsUI.getPreferenceStore();
+		final Color foreground = editorColor(store, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND,
+				AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND_SYSTEM_DEFAULT);
+		if (foreground != null) {
+			widget.setForeground(foreground);
+		}
+		final Color background = editorColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND,
+				AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT);
+		if (background != null) {
+			widget.setBackground(background);
+		}
+	}
+
+	private static Color editorColor(IPreferenceStore store, String key, String systemDefaultKey) {
+		if (store.getBoolean(systemDefaultKey)) {
+			return null;
+		}
+		return new Color(PreferenceConverter.getColor(store, key));
 	}
 
 	/**

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLColors.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLColors.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.e4.tools.emf.ui.internal.common.xml;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * The syntax colours of the XMI tab, taken from the active workbench theme.
+ */
+public class XMLColors {
+
+	public static final String TAG = "org.eclipse.e4.tools.emf.ui.color.tag"; //$NON-NLS-1$
+	public static final String STRING = "org.eclipse.e4.tools.emf.ui.color.string"; //$NON-NLS-1$
+	public static final String COMMENT = "org.eclipse.e4.tools.emf.ui.color.comment"; //$NON-NLS-1$
+	public static final String PROC_INSTR = "org.eclipse.e4.tools.emf.ui.color.procInstr"; //$NON-NLS-1$
+
+	private XMLColors() {
+	}
+
+	public static Color get(String colorId) {
+		return PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getColorRegistry().get(colorId);
+	}
+}

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLConfiguration.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLConfiguration.java
@@ -13,8 +13,6 @@
  ******************************************************************************/
 package org.eclipse.e4.tools.emf.ui.internal.common.xml;
 
-import org.eclipse.e4.tools.emf.ui.internal.ResourceProvider;
-import org.eclipse.e4.tools.services.IResourcePool;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextDoubleClickStrategy;
 import org.eclipse.jface.text.TextAttribute;
@@ -29,10 +27,7 @@ public class XMLConfiguration extends SourceViewerConfiguration {
 	private XMLDoubleClickStrategy doubleClickStrategy;
 	private XMLTagScanner tagScanner;
 	private XMLScanner scanner;
-	private final IResourcePool pool;
-
-	public XMLConfiguration(IResourcePool pool) {
-		this.pool = pool;
+	public XMLConfiguration() {
 	}
 
 	@Override
@@ -50,16 +45,17 @@ public class XMLConfiguration extends SourceViewerConfiguration {
 
 	protected XMLScanner getXMLScanner() {
 		if (scanner == null) {
-			scanner = new XMLScanner(pool);
-			scanner.setDefaultReturnToken(new Token(new TextAttribute(pool.getColorUnchecked(ResourceProvider.COLOR_DEFAULT))));
+			scanner = new XMLScanner();
+			// no foreground: the widget's own colour applies, which XmiTab takes from the editor preferences
+			scanner.setDefaultReturnToken(new Token(new TextAttribute(null)));
 		}
 		return scanner;
 	}
 
 	protected XMLTagScanner getXMLTagScanner() {
 		if (tagScanner == null) {
-			tagScanner = new XMLTagScanner(pool);
-			tagScanner.setDefaultReturnToken(new Token(new TextAttribute(pool.getColorUnchecked(ResourceProvider.COLOR_TAG))));
+			tagScanner = new XMLTagScanner();
+			tagScanner.setDefaultReturnToken(new Token(new TextAttribute(XMLColors.get(XMLColors.TAG))));
 		}
 		return tagScanner;
 	}
@@ -76,7 +72,7 @@ public class XMLConfiguration extends SourceViewerConfiguration {
 		reconciler.setDamager(dr, IDocument.DEFAULT_CONTENT_TYPE);
 		reconciler.setRepairer(dr, IDocument.DEFAULT_CONTENT_TYPE);
 
-		NonRuleBasedDamagerRepairer ndr = new NonRuleBasedDamagerRepairer(new TextAttribute(pool.getColorUnchecked(ResourceProvider.COLOR_XML_COMMENT)));
+		NonRuleBasedDamagerRepairer ndr = new NonRuleBasedDamagerRepairer(new TextAttribute(XMLColors.get(XMLColors.COMMENT)));
 		reconciler.setDamager(ndr, XMLPartitionScanner.XML_COMMENT);
 		reconciler.setRepairer(ndr, XMLPartitionScanner.XML_COMMENT);
 

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLScanner.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLScanner.java
@@ -13,8 +13,6 @@
  ******************************************************************************/
 package org.eclipse.e4.tools.emf.ui.internal.common.xml;
 
-import org.eclipse.e4.tools.emf.ui.internal.ResourceProvider;
-import org.eclipse.e4.tools.services.IResourcePool;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.IRule;
 import org.eclipse.jface.text.rules.IToken;
@@ -25,8 +23,8 @@ import org.eclipse.jface.text.rules.WhitespaceRule;
 
 public class XMLScanner extends RuleBasedScanner {
 
-	public XMLScanner(IResourcePool pool) {
-		IToken procInstr = new Token(new TextAttribute(pool.getColorUnchecked(ResourceProvider.COLOR_PROC_INSTR)));
+	public XMLScanner() {
+		IToken procInstr = new Token(new TextAttribute(XMLColors.get(XMLColors.PROC_INSTR)));
 
 		IRule[] rules = new IRule[2];
 		// Add rule for processing instructions

--- a/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLTagScanner.java
+++ b/e4tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/xml/XMLTagScanner.java
@@ -13,8 +13,6 @@
  ******************************************************************************/
 package org.eclipse.e4.tools.emf.ui.internal.common.xml;
 
-import org.eclipse.e4.tools.emf.ui.internal.ResourceProvider;
-import org.eclipse.e4.tools.services.IResourcePool;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.IRule;
 import org.eclipse.jface.text.rules.IToken;
@@ -25,8 +23,8 @@ import org.eclipse.jface.text.rules.WhitespaceRule;
 
 public class XMLTagScanner extends RuleBasedScanner {
 
-	public XMLTagScanner(IResourcePool pool) {
-		IToken string = new Token(new TextAttribute(pool.getColorUnchecked(ResourceProvider.COLOR_STRING)));
+	public XMLTagScanner() {
+		IToken string = new Token(new TextAttribute(XMLColors.get(XMLColors.STRING)));
 
 		IRule[] rules = new IRule[3];
 


### PR DESCRIPTION
On a dark theme the XMI tab renders dark navy tags and dark green attribute values on a dark background. The five XML syntax colours are hardcoded light values in `OSGI-INF/resources.properties` and reach the reconciler through `IResourcePool`, where no stylesheet can see them, and the source viewer never gets a foreground or background at all.

Tag, attribute value, comment and processing instruction become `org.eclipse.ui.themes` `colorDefinition`s, the way `org.eclipse.pde.genericeditor.extension` already does it in this repo, and the source viewer takes its colours from the Text Editors preferences. Any theme can now recolour the tab, which was impossible before.

Independent of #2431; the two share no file.

### Before and after, built-in Dark theme

<!-- vorher: 01-vorher-xmi-tab-dark.png -->

<!-- nachher: 02-nachher-xmi-tab-dark.png -->