### PR TITLE
Skip unusable API components instead of failing the baseline restore

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.1300.qualifier
+Bundle-Version: 1.3.1400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/CoreMessages.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/CoreMessages.java
@@ -24,6 +24,7 @@ public class CoreMessages extends NLS {
 	public static String ApiBaseline_4;
 	public static String ApiBaseline_5;
 	public static String ApiBaseline_6;
+	public static String ApiBaseline_7;
 	public static String FilterStore_0;
 	public static String JavadocTagManager_annotation_no_reference;
 	public static String JavadocTagManager_class_no_instantiate;

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/coremessages.properties
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/coremessages.properties
@@ -19,6 +19,7 @@ ApiBaseline_2=Error occurred while binding execution environment
 ApiBaseline_4=Baseline has bundles requiring unavailable execution environments
 ApiBaseline_5={0} is unavailable
 ApiBaseline_6=Baseline not bound - there are no installed VMs compatible with the required execution environments
+ApiBaseline_7=Skipping API component {0} ({1}) of baseline ""{2}"" - the component could not be added to the baseline
 FilterStore_0=Cannot read API problem filters from a null stream
 JavadocTagManager_annotation_no_reference=This annotation is not intended to be referenced by clients.
 JavadocTagManager_class_no_instantiate=This class is not intended to be instantiated by clients.

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/model/ApiBaseline.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
@@ -357,13 +358,19 @@ public class ApiBaseline extends ApiElement implements IApiBaseline, IVMInstallC
 		HashSet<String> ees = new HashSet<>();
 		for (IApiComponent apiComponent : components) {
 			BundleComponent component = (BundleComponent) apiComponent;
-			if (component.isSourceComponent()) {
-				continue;
+			try {
+				if (component.isSourceComponent()) {
+					continue;
+				}
+				BundleDescription description = component.getBundleDescription();
+				getState().addBundle(description);
+				addComponent(component);
+				ees.addAll(component.getExecutionEnvironments());
+			} catch (CoreException | RuntimeException e) {
+				// a single unusable component must not abort the whole baseline
+				ILog.of(ApiBaseline.class).warn(MessageFormat.format(CoreMessages.ApiBaseline_7,
+						component.getSymbolicName(), component.getLocation(), getName()), e);
 			}
-			BundleDescription description = component.getBundleDescription();
-			getState().addBundle(description);
-			addComponent(component);
-			ees.addAll(component.getExecutionEnvironments());
 		}
 		resolveSystemLibrary(ees);
 		getState().resolve();


### PR DESCRIPTION
`ApiBaseline.addApiComponents` added every component to the OSGi state without a guard, so one failing component aborted the whole loop and left `resolveSystemLibrary` and `resolve` unexecuted. The baseline then stayed empty and the user only saw "An internal error occurred during: Performing API Analysis", with nothing pointing at the baseline as the cause.

Each component is now handled individually. A component that cannot be added is skipped and logged with its symbolic name, location and baseline name, so the remaining components still load and the failure is diagnosable from the error log alone. Observed in a workspace where two of 684 bundles threw `IllegalStateException: The bundle belongs to another state` from `State.addBundle` and took the entire baseline down with them.