### PR TITLE
Remove the dead buildDisabled flag from ApiAnalysisBuilder

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
+++ b/apitools/org.eclipse.pde.api.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.api.tools;singleton:=true
-Bundle-Version: 1.3.1300.qualifier
+Bundle-Version: 1.3.1400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ApiAnalysisBuilder.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/builder/ApiAnalysisBuilder.java
@@ -143,14 +143,6 @@ public class ApiAnalysisBuilder extends IncrementalProjectBuilder {
 	static final String SOURCE = "API Tools"; //$NON-NLS-1$
 
 	/**
-	 * Boolean flag to disable the API builder (the builder will always return
-	 * {@link #NO_PROJECTS}. Not accessible from the UI by default, but can be
-	 * set by other tools. The behaviour is not API and may be changed or
-	 * removed in a future release. See bug 221913.
-	 */
-	private static boolean buildDisabled = false;
-
-	/**
 	 * The current project for which this builder was defined
 	 */
 	private IProject currentproject = null;
@@ -353,7 +345,7 @@ public class ApiAnalysisBuilder extends IncrementalProjectBuilder {
 			return NO_PROJECTS;
 		}
 		this.currentproject = getProject();
-		if (buildDisabled || shouldAbort(this.currentproject)) {
+		if (shouldAbort(this.currentproject)) {
 			return NO_PROJECTS;
 		}
 		// update build time stamp


### PR DESCRIPTION
`ApiAnalysisBuilder.buildDisabled` is a private static field that nothing ever assigns, so the `buildDisabled ||` disjunct in `build()` was always false. Its Javadoc described a flag that other tools could set, which has not been reachable for a long time.

The `DISABLE_API_ANALYSIS_BUILDER` preference, checked a few lines above and exposed as "Disable API analysis builder" on the Plug-in Development preference page, already provides that workspace-wide off switch properly. No behaviour change.