### PR TITLE
Activate the workspace target atomically with its handle preference

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.pde.internal.core.EclipseHomeInitializer;
 import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.PDECore;
-import org.eclipse.pde.internal.core.PDEPreferencesManager;
 import org.eclipse.pde.internal.core.target.Messages;
 import org.eclipse.pde.internal.core.target.TargetPlatformService;
 import org.eclipse.pde.internal.core.target.TargetResolveSchedulingRule;
@@ -133,19 +132,9 @@ public class LoadTargetDefinitionJob extends WorkspaceJob {
 			subMon.checkCanceled();
 			subMon.setWorkRemaining(20);
 
-			PDEPreferencesManager preferences = PDECore.getDefault().getPreferencesManager();
-
-			((TargetPlatformService) TargetPlatformService.getDefault()).setWorkspaceTargetDefinition(fTarget, false); // Must be set before preference so listeners can react
-			String memento = fTarget.getHandle().getMemento();
-			if (fNone) {
-				memento = ICoreConstants.NO_TARGET;
-			}
-			// If the same target has been modified, clear the preference so listeners can react to the change
-			if (memento.equals(preferences.getString(ICoreConstants.WORKSPACE_TARGET_HANDLE))) {
-				preferences.setValue(ICoreConstants.WORKSPACE_TARGET_HANDLE, ""); //$NON-NLS-1$
-			}
-			preferences.setValue(ICoreConstants.WORKSPACE_TARGET_HANDLE, memento);
-
+			String memento = fNone ? ICoreConstants.NO_TARGET : fTarget.getHandle().getMemento();
+			((TargetPlatformService) TargetPlatformService.getDefault()).setWorkspaceTargetDefinition(fTarget, memento,
+					false);
 
 			loadJRE(subMon.split(3));
 

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/TargetPlatformHelper.java
@@ -61,6 +61,7 @@ import org.eclipse.pde.internal.build.IPDEBuildConstants;
 import org.eclipse.pde.internal.core.ifeature.IFeatureModel;
 import org.eclipse.pde.internal.core.target.IUBundleContainer;
 import org.eclipse.pde.internal.core.target.TargetDefinition;
+import org.eclipse.pde.internal.core.target.TargetPlatformService;
 import org.eclipse.pde.internal.core.util.CoreUtility;
 import org.eclipse.pde.internal.core.util.ManifestUtils;
 import org.eclipse.pde.internal.core.util.VersionUtil;
@@ -559,15 +560,9 @@ public class TargetPlatformHelper {
 			if (monitor != null && monitor.isCanceled()) {
 				return null;
 			}
-			PDEPreferencesManager preferences = PDECore.getDefault().getPreferencesManager();
-			String memento = target.getHandle().getMemento();
-			if (memento != null && memento.equals(preferences.getString(ICoreConstants.WORKSPACE_TARGET_HANDLE))) {
-				// Same target has been re-resolved upon loading, clear the
-				// preference and update the target so listeners can react to
-				// the change - see TargetStatus
-				preferences.setValue(ICoreConstants.WORKSPACE_TARGET_HANDLE, ""); //$NON-NLS-1$
-				preferences.setValue(ICoreConstants.WORKSPACE_TARGET_HANDLE, memento);
-			}
+			// Same target may have been re-resolved upon loading, re-store the
+			// preference so listeners can react to the change - see TargetStatus
+			((TargetPlatformService) service).refreshWorkspaceTargetHandle(target);
 		}
 		return target;
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/target/TargetPlatformService.java
@@ -335,6 +335,54 @@ public class TargetPlatformService implements ITargetPlatformService {
 		}
 	}
 
+	/**
+	 * Sets the workspace target and stores its handle memento under the lock that
+	 * guards {@link #getWorkspaceTargetDefinition()}, so that method never observes
+	 * a target and a memento that disagree.
+	 *
+	 * @return <code>true</code> if a different target was replaced
+	 */
+	public boolean setWorkspaceTargetDefinition(ITargetDefinition target, String memento, boolean asyncEvents) {
+		ITargetDefinition oldTarget;
+		synchronized (this) {
+			// Must be set before the preference so listeners can react
+			oldTarget = fWorkspaceTarget.getAndSet(target);
+			storeWorkspaceTargetHandle(memento);
+		}
+		boolean changed = !Objects.equals(oldTarget, target);
+		if (changed) {
+			notifyEvent(TargetEvents.TOPIC_WORKSPACE_TARGET_CHANGED, target, asyncEvents);
+		}
+		return changed;
+	}
+
+	/**
+	 * Re-stores the memento of the given target if it is the active one, so that
+	 * preference listeners react to it being re-resolved. Leaves the stored target
+	 * alone and fires no target-changed event.
+	 *
+	 * @return <code>true</code> if the memento was re-stored
+	 */
+	public synchronized boolean refreshWorkspaceTargetHandle(ITargetDefinition target) throws CoreException {
+		String memento = target.getHandle().getMemento();
+		PDEPreferencesManager preferences = PDECore.getDefault().getPreferencesManager();
+		if (memento == null || !memento.equals(preferences.getString(ICoreConstants.WORKSPACE_TARGET_HANDLE))) {
+			return false;
+		}
+		storeWorkspaceTargetHandle(memento);
+		return true;
+	}
+
+	private void storeWorkspaceTargetHandle(String memento) {
+		PDEPreferencesManager preferences = PDECore.getDefault().getPreferencesManager();
+		// Clear first so that listeners still see a change when the same target was
+		// modified or re-resolved - see TargetStatus
+		if (memento.equals(preferences.getString(ICoreConstants.WORKSPACE_TARGET_HANDLE))) {
+			preferences.setValue(ICoreConstants.WORKSPACE_TARGET_HANDLE, ""); //$NON-NLS-1$
+		}
+		preferences.setValue(ICoreConstants.WORKSPACE_TARGET_HANDLE, memento);
+	}
+
 	public static void scheduleEvent(String topic, Object data) {
 		notifyEvent(topic, data, true);
 	}


### PR DESCRIPTION
LoadTargetDefinitionJob stored the new target definition and then wrote its handle memento to the preference in two steps. getWorkspaceTargetDefinition() treats a target whose handle does not match the stored memento as invalid and silently replaces it with a new default target, so a concurrent caller in that gap, such as a builder asking for TargetPlatform.getOS(), swapped the target being loaded for the running platform.

This is the cause of the sporadic PluginBasedLaunchTest failures on Jenkins (for example on #2432 and master 90cb1d22), where the merged bundle map suddenly contains the whole running platform. Both values are now updated under the lock that guards getWorkspaceTargetDefinition(), and TargetPlatformHelper uses the same path when it re-stores the memento of a re-resolved target.