### PR TITLE
Drop the unused timestamp in ConfigurationParser.processConfig

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/update/configurator/ConfigurationParser.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/update/configurator/ConfigurationParser.java
@@ -298,12 +298,9 @@ class ConfigurationParser extends DefaultHandler implements IConfigurationConsta
 		if (date == null || date.trim().length() == 0) {
 			config = new Configuration(); // constructed with current date
 		} else {
-			long time = 0;
 			try {
-				time = Long.parseLong(date);
-				config = new Configuration(new Date(time));
+				config = new Configuration(new Date(Long.parseLong(date)));
 			} catch (NumberFormatException e1) {
-				time = new Date().getTime();
 				Utils.log(NLS.bind(Messages.InstalledSiteParser_date, (new String[] { date })));
 				config = new Configuration(); // constructed with current date
 			}


### PR DESCRIPTION
The catch block for an unparsable configuration date stored a current-time value in a local that nothing reads afterwards, because the `Configuration` created there already sets the current date itself. With that gone the parsed value is the local's only use, so it is inlined.

No behaviour change, one local and one throwaway `Date` allocation less.