### PR TITLE
Resolve extension ids before the async update in the product editor

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -24,6 +24,7 @@ import org.eclipse.pde.ui.tests.build.properties.AllValidatorTests;
 import org.eclipse.pde.ui.tests.classpathcontributor.ClasspathContributorTest;
 import org.eclipse.pde.ui.tests.classpathresolver.ClasspathResolverTest;
 import org.eclipse.pde.ui.tests.classpathupdater.ClasspathUpdaterTest;
+import org.eclipse.pde.ui.tests.editor.ProductInfoSectionTest;
 import org.eclipse.pde.ui.tests.ee.ExportBundleTests;
 import org.eclipse.pde.ui.tests.imports.AllImportTests;
 import org.eclipse.pde.ui.tests.launcher.AllLauncherTests;
@@ -76,6 +77,7 @@ import org.junit.platform.suite.api.Suite;
 	ProjectSmartImportTest.class, //
 	GatherUnusedDependenciesOperationTest.class, //
 	PDELabelProviderTest.class, //
+	ProductInfoSectionTest.class, //
 })
 public class AllPDETests {
 

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/editor/ProductInfoSectionTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/editor/ProductInfoSectionTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.pde.ui.tests.editor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionDelta;
+import org.eclipse.core.runtime.InvalidRegistryObjectException;
+import org.eclipse.pde.internal.ui.editor.product.ProductInfoSection;
+import org.eclipse.pde.internal.ui.editor.product.ProductInfoSection.ExtensionChange;
+import org.junit.Test;
+
+public class ProductInfoSectionTest {
+
+	@Test
+	public void testInvalidExtensionDoesNotAbortBatch() {
+		IExtensionDelta removed = delta(IExtensionDelta.REMOVED, invalidExtension());
+		IExtensionDelta added = delta(IExtensionDelta.ADDED, extension("org.example.app"));
+
+		List<ExtensionChange> changes = ProductInfoSection.toExtensionChanges(new IExtensionDelta[] { removed, added });
+
+		assertEquals(List.of(new ExtensionChange("org.example.app", true)), changes);
+	}
+
+	@Test
+	public void testKindIsPreserved() {
+		IExtensionDelta removed = delta(IExtensionDelta.REMOVED, extension("org.example.a"));
+		IExtensionDelta added = delta(IExtensionDelta.ADDED, extension("org.example.b"));
+
+		List<ExtensionChange> changes = ProductInfoSection.toExtensionChanges(new IExtensionDelta[] { removed, added });
+
+		assertEquals(List.of(new ExtensionChange("org.example.a", false), new ExtensionChange("org.example.b", true)),
+				changes);
+	}
+
+	@Test
+	public void testMissingIdsAreSkipped() {
+		IExtensionDelta noExtension = delta(IExtensionDelta.ADDED, null);
+		IExtensionDelta noId = delta(IExtensionDelta.ADDED, extension(null));
+
+		List<ExtensionChange> changes = ProductInfoSection
+				.toExtensionChanges(new IExtensionDelta[] { noExtension, noId });
+
+		assertTrue(changes.isEmpty());
+	}
+
+	private static IExtensionDelta delta(int kind, IExtension extension) {
+		IExtensionDelta delta = mock(IExtensionDelta.class);
+		when(delta.getKind()).thenReturn(kind);
+		when(delta.getExtension()).thenReturn(extension);
+		return delta;
+	}
+
+	private static IExtension extension(String id) {
+		IExtension extension = mock(IExtension.class);
+		when(extension.getUniqueIdentifier()).thenReturn(id);
+		return extension;
+	}
+
+	private static IExtension invalidExtension() {
+		IExtension extension = mock(IExtension.class);
+		when(extension.getUniqueIdentifier()).thenThrow(new InvalidRegistryObjectException());
+		return extension;
+	}
+}

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/product/ProductInfoSection.java
@@ -20,12 +20,14 @@ import static org.eclipse.pde.internal.core.iproduct.IProduct.ProductType.FEATUR
 import static org.eclipse.pde.internal.core.iproduct.IProduct.ProductType.MIXED;
 import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionDelta;
 import org.eclipse.core.runtime.IRegistryChangeEvent;
 import org.eclipse.core.runtime.IRegistryChangeListener;
+import org.eclipse.core.runtime.InvalidRegistryObjectException;
 import org.eclipse.jface.action.IStatusLineManager;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
@@ -121,17 +123,10 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 			}
 		}
 
-		public void handleExtensionDelta(IExtensionDelta[] deltas) {
-			for (IExtensionDelta delta : deltas) {
-				IExtension extension = delta.getExtension();
-				if (extension == null) {
-					return;
-				}
-				String id = extension.getUniqueIdentifier();
-				if (id == null) {
-					continue;
-				}
-				if (delta.getKind() == IExtensionDelta.ADDED) {
+		public void handleExtensionChanges(List<ExtensionChange> changes) {
+			for (ExtensionChange change : changes) {
+				String id = change.id();
+				if (change.added()) {
 					int index = computeIndex(id);
 					// index of -1 means id is already in combo
 					if (index >= 0) {
@@ -416,19 +411,47 @@ public class ProductInfoSection extends PDESection implements IRegistryChangeLis
 		return c instanceof Text;
 	}
 
+	public record ExtensionChange(String id, boolean added) {
+	}
+
 	@Override
 	public void registryChanged(IRegistryChangeEvent event) {
-		final IExtensionDelta[] applicationDeltas = event.getExtensionDeltas(IPDEBuildConstants.BUNDLE_CORE_RUNTIME,
-				"applications"); //$NON-NLS-1$
-		final IExtensionDelta[] productDeltas = event.getExtensionDeltas(IPDEBuildConstants.BUNDLE_CORE_RUNTIME,
-				"products"); //$NON-NLS-1$
-		if (applicationDeltas.length + productDeltas.length == 0) {
+		List<ExtensionChange> applicationChanges = toExtensionChanges(
+				event.getExtensionDeltas(IPDEBuildConstants.BUNDLE_CORE_RUNTIME, "applications")); //$NON-NLS-1$
+		List<ExtensionChange> productChanges = toExtensionChanges(
+				event.getExtensionDeltas(IPDEBuildConstants.BUNDLE_CORE_RUNTIME, "products")); //$NON-NLS-1$
+		if (applicationChanges.isEmpty() && productChanges.isEmpty()) {
 			return;
 		}
 		Display.getDefault().asyncExec(() -> {
-			fAppCombo.handleExtensionDelta(applicationDeltas);
-			fProductCombo.handleExtensionDelta(productDeltas);
+			fAppCombo.handleExtensionChanges(applicationChanges);
+			fProductCombo.handleExtensionChanges(productChanges);
 		});
+	}
+
+	/**
+	 * Must run inside the registry listener, removed extensions are invalid
+	 * once it returns.
+	 */
+	public static List<ExtensionChange> toExtensionChanges(IExtensionDelta[] deltas) {
+		List<ExtensionChange> changes = new ArrayList<>(deltas.length);
+		for (IExtensionDelta delta : deltas) {
+			IExtension extension = delta.getExtension();
+			if (extension == null) {
+				continue;
+			}
+			String id;
+			try {
+				id = extension.getUniqueIdentifier();
+			} catch (InvalidRegistryObjectException e) {
+				continue;
+			}
+			if (id == null) {
+				continue;
+			}
+			changes.add(new ExtensionChange(id, delta.getKind() == IExtensionDelta.ADDED));
+		}
+		return changes;
 	}
 
 	@Override


### PR DESCRIPTION
The product editor updates its application and product combos asynchronously to avoid a deadlock, so the registry deltas are read after the listener has returned. By then a removed extension is invalid and getUniqueIdentifier() throws an InvalidRegistryObjectException, which also dropped the added entries of the same event.

This change resolves the deltas to plain ids while still inside the listener and passes only those to the asyncExec. Entries that cannot be resolved are skipped instead of aborting the whole batch. A unit test covers the invalid extension, the added/removed kinds and missing ids.

Fixes #2461