### PR TITLE
Remove illegal flags and deprecation warnings from StateTree #2462

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/target/StateTree.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/views/target/StateTree.java
@@ -55,9 +55,8 @@ import org.osgi.framework.Version;
 
 public class StateTree extends FilteredTree {
 
-	@SuppressWarnings("deprecation")
 	public StateTree(Composite parent) {
-		super(parent, SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL | SWT.SINGLE, new PatternFilter(), true);
+		super(parent, SWT.V_SCROLL | SWT.H_SCROLL | SWT.SINGLE, new PatternFilter(), true, true);
 		TreeViewer fTreeViewer = getViewer();
 		fTreeViewer.setContentProvider(new StateContentProvider());
 		fTreeViewer.setLabelProvider(new StateLabelProvider());
@@ -250,7 +249,7 @@ public class StateTree extends FilteredTree {
 
 	protected void handleDoubleClick() {
 		IStructuredSelection selection = getViewer().getStructuredSelection();
-		if (selection.size() == 1) {
+		if (!selection.isEmpty()) {
 			BundleDescription desc = getBundleDescription();
 			if (desc != null) {
 				ManifestEditor.open(desc, false);
@@ -260,7 +259,7 @@ public class StateTree extends FilteredTree {
 
 	public BundleDescription getBundleDescription() {
 		IStructuredSelection selection = getViewer().getStructuredSelection();
-		if (selection.size() == 1) {
+		if (!selection.isEmpty()) {
 			Object obj = selection.getFirstElement();
 			if (obj instanceof BundleSpecification) {
 				obj = ((BundleSpecification) obj).getSupplier();


### PR DESCRIPTION
When both the `SWT.MULTI` and `SWT.SINGLE` bits are set for a viewer, the `SWT.SINGLE` one takes priority. This means the `SWT.MULTI` flag can be removed.

Additionally, the viewer only works on instances of `BundleDescription` and `DependencyGroup`, whose implementations don't override the default `equals` and `hashCode` method. Because the same bundle and/or
dependency group should not appear multiple times in the viewer, the "fast hash-lookup" flag can be set, thus avoiding the deprecated `FilteredTree` constructor.

Given that it is not possible to select more than one element, the checks done on the selection can also be simplified from `selection.size() == 1` to `!selection.isEmpty()`.

Closes https://github.com/eclipse-pde/eclipse.pde/issues/2462