### PR TITLE
Stop Smart Import from proposing projects nested inside bundles

### DIFF
--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -42,6 +42,7 @@ import org.eclipse.pde.ui.tests.target.AllTargetTests;
 import org.eclipse.pde.ui.tests.util.PDELabelProviderTest;
 import org.eclipse.pde.ui.tests.views.log.AllLogViewTests;
 import org.eclipse.pde.ui.tests.wizards.AllNewProjectTests;
+import org.eclipse.ui.tests.smartimport.NestedProjectSmartImportTest;
 import org.eclipse.ui.tests.smartimport.ProjectSmartImportTest;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -75,6 +76,7 @@ import org.junit.platform.suite.api.Suite;
 	BundleErrorReporterTest.class, //
 	AllPDECoreTests.class, //
 	ProjectSmartImportTest.class, //
+	NestedProjectSmartImportTest.class, //
 	GatherUnusedDependenciesOperationTest.class, //
 	PDELabelProviderTest.class, //
 	ProductInfoSectionTest.class, //

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/ui/tests/smartimport/NestedProjectSmartImportTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/ui/tests/smartimport/NestedProjectSmartImportTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.ui.tests.smartimport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.pde.ui.tests.PDETestCase;
+import org.eclipse.pde.ui.tests.util.ProjectUtils;
+import org.eclipse.ui.internal.wizards.datatransfer.SmartImportJob;
+import org.eclipse.ui.wizards.datatransfer.ProjectConfigurator;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Smart Import must not propose projects nested below a bundle or feature, but
+ * still finds those below a plain project.
+ */
+@RunWith(Parameterized.class)
+public class NestedProjectSmartImportTest {
+
+	@Parameters(name = "{0}")
+	public static Object[][] projects() {
+		return new Object[][] { //
+			{ "BundleWithNestedProject", List.of(""), List.of("BundleWithNestedProject") }, //
+			{ "FeatureWithNestedProject", List.of(""), List.of("FeatureWithNestedProject") }, //
+			{ "PlainProjectWithNestedProject", List.of("", "nested/NestedProject"),
+					List.of("PlainProjectWithNestedProject", "NestedProject") }, //
+		};
+	}
+
+	@ClassRule
+	public static TemporaryFolder workingDirectory = new TemporaryFolder();
+
+	@Parameter(0)
+	public String rootName;
+	@Parameter(1)
+	public List<String> expectedProposals;
+	@Parameter(2)
+	public List<String> expectedProjects;
+
+	@BeforeClass
+	public static void setupClass() throws Exception {
+		PDETestCase.copyFromThisBundleInto("tests/smartImport", workingDirectory.getRoot().toPath());
+		ProjectUtils.deleteAllWorkspaceProjects();
+	}
+
+	@After
+	public void cleanup() throws Exception {
+		ProjectUtils.deleteAllWorkspaceProjects();
+	}
+
+	@Test
+	public void testNestedProjectsBelowBundlesAreNotImported() throws Exception {
+		File root = new File(workingDirectory.getRoot(), rootName);
+		SmartImportJob job = new SmartImportJob(root, null, true, true);
+
+		Map<File, List<ProjectConfigurator>> proposals = job.getImportProposals(new NullProgressMonitor());
+
+		Path rootPath = root.toPath().toAbsolutePath().normalize();
+		List<Path> proposedPaths = proposals.keySet().stream().map(file -> file.toPath().toAbsolutePath().normalize())
+				.toList();
+		assertThat(proposedPaths).containsExactlyInAnyOrderElementsOf(expectedProposals.stream().map(rootPath::resolve).toList());
+
+		job.setDirectoriesToImport(proposals.keySet());
+		job.run(new NullProgressMonitor());
+		job.join();
+
+		IWorkspaceRoot workspace = ResourcesPlugin.getWorkspace().getRoot();
+		List<String> projectNames = Arrays.stream(workspace.getProjects()).map(IProject::getName).toList();
+		assertThat(projectNames).containsExactlyInAnyOrderElementsOf(expectedProjects);
+	}
+
+}

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>BundleWithNestedProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle with nested project
+Bundle-SymbolicName: BundleWithNestedProject
+Bundle-Version: 1.0.0.qualifier

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/fixtures/NestedProject/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/BundleWithNestedProject/fixtures/NestedProject/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>NestedProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>FeatureWithNestedProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/build.properties
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/feature.xml
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/feature.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="FeatureWithNestedProject"
+      label="FeatureWithNestedProject"
+      version="1.0.0.qualifier">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+</feature>

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/fixtures/NestedProject/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/FeatureWithNestedProject/fixtures/NestedProject/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>NestedProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/PlainProjectWithNestedProject/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/PlainProjectWithNestedProject/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>PlainProjectWithNestedProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui.tests/tests/smartImport/PlainProjectWithNestedProject/nested/NestedProject/.project
+++ b/ui/org.eclipse.pde.ui.tests/tests/smartImport/PlainProjectWithNestedProject/nested/NestedProject/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>NestedProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+
+	</natures>
+</projectDescription>

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/BundleProjectConfigurator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/BundleProjectConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 Red Hat Inc., and others
+ * Copyright (c) 2014, 2026 Red Hat Inc., and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,13 +14,18 @@
 package org.eclipse.pde.internal.ui.wizards;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.jar.Manifest;
 
 import org.eclipse.core.resources.IContainer;
@@ -136,15 +141,52 @@ public class BundleProjectConfigurator implements ProjectConfigurator {
 	private boolean hasOSGiManifest(IContainer container) {
 		IFile manifestResource = container.getFile(IPath.fromOSString(ICoreConstants.BUNDLE_FILENAME_DESCRIPTOR));
 		if (manifestResource.exists()) {
-			Manifest manifest = new Manifest();
 			try (InputStream stream = manifestResource.getContents()) {
-				manifest.read(stream);
-				return manifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME) != null;
+				return hasSymbolicName(stream);
 			} catch (CoreException | IOException ex) {
 				PDEPlugin.log(ex);
 			}
 		}
 		return false;
+	}
+
+	private static boolean hasOSGiManifest(File directory) {
+		File manifestFile = new File(directory, ICoreConstants.BUNDLE_FILENAME_DESCRIPTOR);
+		if (manifestFile.isFile()) {
+			try (InputStream stream = new FileInputStream(manifestFile)) {
+				return hasSymbolicName(stream);
+			} catch (IOException ex) {
+				PDEPlugin.log(ex);
+			}
+		}
+		return false;
+	}
+
+	private static boolean hasSymbolicName(InputStream manifestStream) throws IOException {
+		Manifest manifest = new Manifest(manifestStream);
+		return manifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME) != null;
+	}
+
+	@Override
+	public void removeDirtyDirectories(Map<File, List<ProjectConfigurator>> proposals) {
+		removeProposalsNestedIn(proposals, BundleProjectConfigurator::hasOSGiManifest);
+	}
+
+	/**
+	 * Drops every proposal that lies strictly below a proposal accepted by the
+	 * given predicate.
+	 */
+	static void removeProposalsNestedIn(Map<File, List<ProjectConfigurator>> proposals, Predicate<File> isProject) {
+		List<Path> roots = proposals.keySet().stream().filter(isProject).map(BundleProjectConfigurator::toPath)
+				.toList();
+		proposals.keySet().removeIf(directory -> {
+			Path path = toPath(directory);
+			return roots.stream().anyMatch(root -> !root.equals(path) && path.startsWith(root));
+		});
+	}
+
+	private static Path toPath(File directory) {
+		return directory.getAbsoluteFile().toPath().normalize();
 	}
 
 	@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/FeatureProjectConfigurator.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/FeatureProjectConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 Red Hat Inc., and others
+ * Copyright (c) 2014, 2026 Red Hat Inc., and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@
 package org.eclipse.pde.internal.ui.wizards;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.resources.IContainer;
@@ -62,6 +64,12 @@ public class FeatureProjectConfigurator implements ProjectConfigurator {
 	@Override
 	public Set<IFolder> getFoldersToIgnore(IProject project, IProgressMonitor monitor) {
 		return null;
+	}
+
+	@Override
+	public void removeDirtyDirectories(Map<File, List<ProjectConfigurator>> proposals) {
+		BundleProjectConfigurator.removeProposalsNestedIn(proposals,
+				directory -> new File(directory, ICoreConstants.FEATURE_FILENAME_DESCRIPTOR).isFile());
 	}
 
 	@Override


### PR DESCRIPTION
The Smart Import wizard scans for every `.project` file and proposes each one, so test fixtures below a bundle or feature (for example under `org.eclipse.pde.ui.tests/tests/projects`) end up imported as real projects. Importing the platform aggregator this way yields hundreds of such fixture projects.

This makes PDE treat a bundle or feature project as a leaf for Smart Import: `BundleProjectConfigurator` and `FeatureProjectConfigurator` drop every proposal that lies strictly below a bundle or feature, while nested projects below plain projects such as an aggregator root are still proposed. Nesting a bundle inside another bundle does build and work, so this is a deliberate PDE decision rather than a rule imposed from outside: the fixture noise is far more common than the nested-bundle layout, and anyone who does want the nested projects can still use the classic Import Projects wizard, which is unchanged.

Covered by a new `NestedProjectSmartImportTest` with bundle, feature and plain-project fixtures. Touched bundles compile locally with Tycho.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/2466
