### PR TITLE
Fix the broken image in bundle repositories view

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.bnd.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Generic UI components related to BND
 Bundle-SymbolicName: org.eclipse.pde.bnd.ui;singleton:=true
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 1.2.700.qualifier
+Bundle-Version: 1.2.800.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.pde.bnd.ui.autocomplete;version="1.0.0";x-friends:="org.eclipse.pde.ui",
  org.eclipse.pde.bnd.ui.plugins;x-internal:=true,

--- a/ui/org.eclipse.pde.bnd.ui/icons/target_platform_state.svg
+++ b/ui/org.eclipse.pde.bnd.ui/icons/target_platform_state.svg
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       gradientTransform="translate(-1.977903,-1.0442)" />
+    <linearGradient
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.022097,-1.0442)" />
+    <linearGradient
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4317"
+       id="linearGradient4323"
+       x1="19.792524"
+       y1="1061.1602"
+       x2="19.792524"
+       y2="1064.6748"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4317">
+      <stop
+         style="stop-color:#f8e8a8;stop-opacity:1"
+         offset="0"
+         id="stop4319" />
+      <stop
+         id="stop4435"
+         offset="0.26090577"
+         style="stop-color:#f8f0d0;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8e8a8;stop-opacity:1;"
+         offset="0.47367054"
+         id="stop4437" />
+      <stop
+         style="stop-color:#f8e8a8;stop-opacity:1"
+         offset="1"
+         id="stop4321" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4311"
+       id="linearGradient4307"
+       gradientUnits="userSpaceOnUse"
+       x1="18.92688"
+       y1="1060.0144"
+       x2="18.92688"
+       y2="1065.5569" />
+    <linearGradient
+       id="linearGradient4311">
+      <stop
+         id="stop4313"
+         offset="0"
+         style="stop-color:#b88800;stop-opacity:1" />
+      <stop
+         id="stop4315"
+         offset="1"
+         style="stop-color:#a87000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4311"
+       id="linearGradient4309"
+       gradientUnits="userSpaceOnUse"
+       x1="17.04467"
+       y1="1061.905"
+       x2="17.04467"
+       y2="1063.8405" />
+    <linearGradient
+       xlink:href="#linearGradient4258"
+       id="linearGradient4264"
+       x1="17.04467"
+       y1="1061.905"
+       x2="17.04467"
+       y2="1063.8405"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#5888c8;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#4870b8;stop-opacity:1"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4250"
+       id="linearGradient4256"
+       x1="18.92688"
+       y1="1060.0144"
+       x2="18.92688"
+       y2="1065.5569"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4250">
+      <stop
+         style="stop-color:#7090c0;stop-opacity:1"
+         offset="0"
+         id="stop4252" />
+      <stop
+         style="stop-color:#4870b8;stop-opacity:1"
+         offset="1"
+         id="stop4254" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4464"
+       id="linearGradient4470-8-6"
+       x1="9.375"
+       y1="1037.8778"
+       x2="11.359375"
+       y2="1037.8778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74650889,0,0,1,1.5883978,-0.12860153)" />
+    <linearGradient
+       id="linearGradient4464">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4466" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1"
+         id="stop4468" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4464"
+       id="linearGradient4470-8"
+       x1="9.375"
+       y1="1037.8778"
+       x2="11.359375"
+       y2="1037.8778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1033.257,-1043.4262)" />
+    <linearGradient
+       gradientTransform="translate(0,-1.5330059e-6)"
+       xlink:href="#linearGradient4464"
+       id="linearGradient4470"
+       x1="9.375"
+       y1="1037.8778"
+       x2="11.359375"
+       y2="1037.8778"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(1.2394243,0,0,1.2394243,-21.274665,-254.90388)"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="layer1-9"
+       mask="none" />
+    <g
+       style="display:inline"
+       id="g4486"
+       transform="translate(1.9873253,-0.11048548)">
+      <path
+         id="rect4001-3"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         style="display:inline;fill:url(#linearGradient4101);fill-opacity:1;stroke:none" />
+      <path
+         id="path4884"
+         d="m 9.998718,1037.397 0,3.9112 3.977479,0 z"
+         style="display:inline;fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none" />
+      <path
+         id="rect4001"
+         d="m 3.5635737,1037.8597 6.9654753,0 3.062057,3.0066 0,9.9546 -10.0275323,0 z"
+         style="display:inline;fill:none;stroke:#a1813a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4326">
+      <g
+         id="g4336"
+         transform="translate(1.9499054,-16.612568)">
+        <circle
+           r="2.9720583"
+           cy="1062.4495"
+           cx="8.5405245"
+           id="path4320"
+           style="display:inline;opacity:1;fill:#d8e8e0;fill-opacity:1;stroke:#2068a0;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path4322"
+           d="m 8.0064212,1060.9149 0,1.0254 -1.0019532,0 0,1 1.0019532,0 0,0.9785 1,0 0,-0.9785 0.9824218,0 0,-1 -0.9824218,0 0,-1.0254 -1,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#2068a0;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+    </g>
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4470);fill-opacity:1;stroke:none;stroke-width:0.85000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4462"
+       width="4.96875"
+       height="1.03125"
+       x="6.96875"
+       y="1037.3622" />
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4470-8);fill-opacity:1;stroke:none;stroke-width:0.85000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4462-3"
+       width="4.96875"
+       height="1.03125"
+       x="1040.2257"
+       y="-6.0640378"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4470-8-6);fill-opacity:1;stroke:none;stroke-width:0.85000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4462-3-0"
+       width="3.7092161"
+       height="1.03125"
+       x="6.7906003"
+       y="1037.2335" />
+    <g
+       style="display:inline"
+       id="g4246"
+       transform="matrix(1.002061,0,0,0.98928019,-15.081113,-12.239302)">
+      <g
+         id="g4331"
+         transform="translate(0.06615492,0)">
+        <g
+           transform="matrix(-1,0,0,1,41.000091,0)"
+           id="g4266-0"
+           style="display:inline">
+          <path
+             id="path4242-9"
+             d="m 19.520119,1060.4831 c 0.341806,-0.3409 1.0254,0.4474 1.0254,0.9295 l 0,2.9581 c 0,0.5003 -0.709328,1.5082 -1.063991,1.1545 -1.323187,-1.3197 -1.935031,-2.0399 -1.935031,-2.0399 l 0,-0.9787 c 0,0 0.739057,-0.7922 1.973622,-2.0235 z"
+             style="fill:url(#linearGradient4323);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4307);stroke-width:0.89697278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             y="1061.9692"
+             x="16.026852"
+             height="1.9828866"
+             width="1.98809"
+             id="rect4244-5"
+             style="opacity:1;fill:url(#linearGradient4309);fill-opacity:1;stroke:none;stroke-width:0.84714097;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         id="g4266">
+        <rect
+           style="opacity:1;fill:url(#linearGradient4264);fill-opacity:1;stroke:none;stroke-width:0.84714097;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4244"
+           width="1.98809"
+           height="1.9828866"
+           x="16.026852"
+           y="1061.9692" />
+        <path
+           style="fill:#a8c0d8;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4256);stroke-width:0.89697278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 19.520119,1060.4831 c 0.341806,-0.3409 1.0254,1.0466 1.0254,1.5287 l 0,2.4522 c 0,0.5003 -0.709328,1.4149 -1.063991,1.0612 -1.323187,-1.3197 -1.935031,-2.0399 -1.935031,-2.0399 l 0,-0.9787 c 0,0 0.739057,-0.7922 1.973622,-2.0235 z"
+           id="path4242" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/TargetRepository.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/TargetRepository.java
@@ -160,6 +160,11 @@ public class TargetRepository extends BaseRepository implements RepositoryPlugin
 	}
 
 	@Override
+	public String getIcon() {
+		return "target_platform_state.svg"; //$NON-NLS-1$
+	}
+
+	@Override
 	public String getLocation() {
 		return "pde-target-state"; //$NON-NLS-1$
 	}


### PR DESCRIPTION

This PR fixes missing icons and `getIcon` call in the bundle repositories views. This adds missing repository icon to the Bundle Repositories view. This also adds the missing `getIcon` call in the Bundle Repositories view to correctly load the repository icon.

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/2275

Before :

<img width="214" height="133" alt="image" src="https://github.com/user-attachments/assets/b9c9d414-547b-4116-9ea2-dab6dfbd5e12" />

After :

<img width="250" height="150" alt="image" src="https://github.com/user-attachments/assets/1b1cac38-5896-4a29-bd73-176fe49ff2b1" />

