### PR TITLE
Do not use o.e.ant.optional.junit in PublishingTests

### DIFF
--- a/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
+++ b/build/org.eclipse.pde.build.tests/src/org/eclipse/pde/build/internal/tests/p2/PublishingTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which accompanies this distribution,
@@ -605,14 +605,6 @@ public class PublishingTests extends P2TestCase {
 		IInstallableUnit iu = getIU(repository, "a");
 		assertEquals("1.0.0", iu.getVersion().toString());
 
-		iu = getIU(repository, "org.eclipse.ant.optional.junit");
-		assertNotNull(iu);
-		entries.add("plugins/org.eclipse.ant.optional.junit_" + iu.getVersion() + ".jar");
-		IFile file = buildFolder
-				.getFile("buildRepo/plugins/org.eclipse.ant.optional.junit_" + iu.getVersion() + ".jar");
-		assertTrue(file.exists());
-		assertJarVerifies(file.getLocation().toFile());
-
 		iu = getIU(repository, "org.eclipse.test");
 		assertNotNull(iu);
 		entries.add("plugins/org.eclipse.test_" + iu.getVersion() + ".jar");
@@ -630,7 +622,7 @@ public class PublishingTests extends P2TestCase {
 				"buildRepo/plugins/org.eclipse.test.performance.win32_" + iu.getVersion() + ".jar");
 
 		iu = getIU(repository, "org.eclipse.test.feature.jar");
-		file = buildFolder.getFile("buildRepo/features/org.eclipse.test_" + iu.getVersion() + ".jar");
+		IFile file = buildFolder.getFile("buildRepo/features/org.eclipse.test_" + iu.getVersion() + ".jar");
 		assertTrue(file.exists());
 		entries.add("features/org.eclipse.test_" + iu.getVersion() + ".jar");
 		assertJarVerifies(file.getLocation().toFile());


### PR DESCRIPTION
This one is to be removed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/4022 as it's no longer serving any purpose. The rest of the test already verifies the same things with other bundles so test coverage is not reduced.