### PR TITLE
Add --enable-native-access=ALL-UNNAMED to default launch VM arguments

### DIFF
--- a/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.pde.launching;singleton:=true
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.jdt.junit.core;bundle-version="[3.6.0,4.0.0)",

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.launching.AbstractVMInstall;
 import org.eclipse.jdt.launching.ExecutionArguments;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.ModelEntry;
 import org.eclipse.pde.core.plugin.PluginRegistry;
@@ -59,6 +60,11 @@ import org.eclipse.pde.launching.IPDELauncherConstants;
 import org.osgi.framework.Bundle;
 
 public class LaunchArgumentsHelper {
+
+	/**
+	 * VM argument that enables native access for all code on the class-path.
+	 */
+	public static final String ENABLE_NATIVE_ACCESS_VM_ARGUMENT = "--enable-native-access=ALL-UNNAMED"; //$NON-NLS-1$
 
 	/**
 	 * Returns the location that will be used as the workspace when launching or
@@ -171,7 +177,34 @@ public class LaunchArgumentsHelper {
 			}
 		}
 
+		if (isNativeAccessArgumentRequired() && result.indexOf("--enable-native-access") == -1) { //$NON-NLS-1$
+			if (result.length() > 0) {
+				result += " "; //$NON-NLS-1$
+			}
+			result += ENABLE_NATIVE_ACCESS_VM_ARGUMENT;
+		}
+
 		return result;
+	}
+
+	/**
+	 * Returns whether {@link #ENABLE_NATIVE_ACCESS_VM_ARGUMENT} should be part
+	 * of the initial VM arguments of a new launch configuration, which is the
+	 * case if the workspace default JRE is Java 24 or newer.
+	 * <p>
+	 * Starting with Java 24 (<a href="https://openjdk.org/jeps/472">JEP 472</a>)
+	 * the JVM prints warnings when code on the class-path uses JNI or the
+	 * Foreign Function &amp; Memory API without native access being enabled.
+	 * Every Eclipse application uses JNI (e.g. through SWT), so the warnings
+	 * would otherwise show up on each launch.
+	 * </p>
+	 */
+	public static boolean isNativeAccessArgumentRequired() {
+		if (JavaRuntime.getDefaultVMInstall() instanceof AbstractVMInstall install) {
+			String vmver = install.getJavaVersion();
+			return vmver != null && JavaCore.compareJavaVersions(vmver, JavaCore.VERSION_24) >= 0;
+		}
+		return false;
 	}
 
 	public static String getInitialProgramArguments() {

--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/LaunchArgumentsHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -169,7 +169,7 @@ public class LaunchArgumentsHelper {
 		}
 
 		if (getAddSwtNonDisposalReportingPreference()) {
-			if (result.indexOf("-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed") == -1) { //$NON-NLS-1$
+			if (!result.contains("-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed")) { //$NON-NLS-1$
 				if (result.length() > 0) {
 					result += " "; //$NON-NLS-1$
 				}
@@ -177,7 +177,7 @@ public class LaunchArgumentsHelper {
 			}
 		}
 
-		if (isNativeAccessArgumentRequired() && result.indexOf("--enable-native-access") == -1) { //$NON-NLS-1$
+		if (isNativeAccessArgumentRequired() && !result.contains("--enable-native-access")) { //$NON-NLS-1$
 			if (result.length() > 0) {
 				result += " "; //$NON-NLS-1$
 			}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/LocalTargetDefinitionTests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/target/LocalTargetDefinitionTests.java
@@ -549,6 +549,11 @@ public class LocalTargetDefinitionTests extends AbstractTargetTest {
 		definition.setVMArguments(vmArgs);
 		assertEquals(vmArgs, definition.getVMArguments());
 
+		// Added to new launch configs when the default JRE is Java 24+
+		String nativeAccess = LaunchArgumentsHelper.isNativeAccessArgumentRequired()
+				? " " + LaunchArgumentsHelper.ENABLE_NATIVE_ACCESS_VM_ARGUMENT
+				: "";
+
 		PDEPreferencesManager prefs = PDELaunchingPlugin.getDefault().getPreferenceManager();
 		try {
 			getTargetService().saveTargetDefinition(definition);
@@ -556,7 +561,7 @@ public class LocalTargetDefinitionTests extends AbstractTargetTest {
 
 			// Check that new launch configs will be prepopulated from target
 			// along with the default preference values
-			assertEquals(vmArgs + " -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true",
+			assertEquals(vmArgs + " -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true" + nativeAccess,
 					LaunchArgumentsHelper.getInitialVMArguments());
 			assertEquals("-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog "
 					.concat(programArgs), LaunchArgumentsHelper.getInitialProgramArguments());
@@ -564,12 +569,12 @@ public class LocalTargetDefinitionTests extends AbstractTargetTest {
 			// Check that new launch configs will be prepopulated from target
 			// along with ADD_SWT_NON_DISPOSAL_REPORTING == false
 			prefs.setValue(ILaunchingPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING, false);
-			assertEquals(vmArgs, LaunchArgumentsHelper.getInitialVMArguments());
+			assertEquals(vmArgs + nativeAccess, LaunchArgumentsHelper.getInitialVMArguments());
 
 			// Check that new launch configs will be prepopulated from target
 			// along with ADD_SWT_NON_DISPOSAL_REPORTING == true
 			prefs.setValue(ILaunchingPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING, true);
-			assertEquals(vmArgs + " -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true",
+			assertEquals(vmArgs + " -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true" + nativeAccess,
 					LaunchArgumentsHelper.getInitialVMArguments());
 
 			// Check that new launch configs will be prepopulated from target
@@ -578,7 +583,14 @@ public class LocalTargetDefinitionTests extends AbstractTargetTest {
 			prefs.setValue(ILaunchingPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING, true);
 			vmArgs = "-testVMArgument -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=false -testVMArgument2";
 			definition.setVMArguments(vmArgs);
-			assertEquals(vmArgs, LaunchArgumentsHelper.getInitialVMArguments());
+			assertEquals(vmArgs + nativeAccess, LaunchArgumentsHelper.getInitialVMArguments());
+
+			// Check that an --enable-native-access argument already set in the
+			// target platform is respected
+			vmArgs = "-testVMArgument --enable-native-access=org.example -testVMArgument2";
+			definition.setVMArguments(vmArgs);
+			assertEquals(vmArgs + " -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true",
+					LaunchArgumentsHelper.getInitialVMArguments());
 		} finally {
 			prefs.setToDefault(ILaunchingPreferenceConstants.ADD_SWT_NON_DISPOSAL_REPORTING);
 			getTargetService().deleteTarget(definition.getHandle());


### PR DESCRIPTION
Add --enable-native-access=ALL-UNNAMED to default launch VM arguments
When the workspace default JRE is Java 24 or newer, new PDE launch
configurations (Eclipse application, OSGi framework, JUnit plug-in
tests) get --enable-native-access=ALL-UNNAMED in their initial VM
arguments. Because it lands in the Arguments tab like the other
defaults, users can edit or remove it per configuration. An existing
--enable-native-access argument in the target platform is respected.

Starting with JDK 24 (JEP 472) the JVM prints warnings like

  WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for
  callers in this module
  WARNING: Restricted methods will be blocked in a future release unless
  native access is enabled

whenever class-path code uses JNI, which every Eclipse application does
through SWT.

Assisted-by: Anthropic Claude Code (claude-fable-5-1)