### PR TITLE
Skip javadoc generation for test bundles

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools.tests/pom.xml
@@ -21,6 +21,7 @@
 	<version>1.4.600-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
 	</properties>
 	<build>

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -13,6 +13,10 @@
 	<version>1.4.1100-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
+
 	<profiles>
 		<profile>
 			<!-- Only enable this for individual bundles builds as otherhwise the ibuild repository is not aviable and we might run into problems -->

--- a/ds/org.eclipse.pde.ds.annotations.tests/build.properties
+++ b/ds/org.eclipse.pde.ds.annotations.tests/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
                tests.jar,\
                test.xml,\
                projects/
+pom.model.property.maven.javadoc.skip = true

--- a/ds/org.eclipse.pde.ds.tck/pom.xml
+++ b/ds/org.eclipse.pde.ds.tck/pom.xml
@@ -13,6 +13,10 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
+	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/ds/org.eclipse.pde.ds.tests/build.properties
+++ b/ds/org.eclipse.pde.ds.tests/build.properties
@@ -18,3 +18,4 @@ bin.includes = META-INF/,\
                plugin.properties,\
                about.html,\
                test.xml
+pom.model.property.maven.javadoc.skip = true

--- a/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/pom.xml
+++ b/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/pom.xml
@@ -22,6 +22,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<skipAPIAnalysis>true</skipAPIAnalysis> <!-- Not in baseline -->
 	</properties>
 

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/build.properties
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/build.properties
@@ -2,3 +2,4 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+pom.model.property.maven.javadoc.skip = true

--- a/e4tools/tests/org.eclipse.e4.tools.persistence.tests/pom.xml
+++ b/e4tools/tests/org.eclipse.e4.tools.persistence.tests/pom.xml
@@ -22,6 +22,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<skipAPIAnalysis>true</skipAPIAnalysis> <!-- Not in baseline -->
 	</properties>
 

--- a/e4tools/tests/org.eclipse.e4.tools.test/build.properties
+++ b/e4tools/tests/org.eclipse.e4.tools.test/build.properties
@@ -2,3 +2,4 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+pom.model.property.maven.javadoc.skip = true

--- a/ua/org.eclipse.pde.ua.tests/pom.xml
+++ b/ua/org.eclipse.pde.ua.tests/pom.xml
@@ -22,6 +22,7 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
+  	<maven.javadoc.skip>true</maven.javadoc.skip>
   	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.pde.internal.ua.tests.AllUATests</testClass>
   </properties>

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
@@ -22,6 +22,7 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
     <testSuite>${project.artifactId}</testSuite>
     <testClass>org.eclipse.pde.genericeditor.extension.tests.AllTargetEditorTests</testClass>

--- a/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
+++ b/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
@@ -26,6 +26,9 @@
 	<artifactId>org.eclipse.pde.junit.runtime.tests</artifactId>
 	<version>3.8.400-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
+	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/ui/org.eclipse.pde.ui.templates.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.templates.tests/pom.xml
@@ -22,6 +22,7 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
+  	<maven.javadoc.skip>true</maven.javadoc.skip>
   	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.pde.ui.templates.tests.TestPDETemplates</testClass>
   </properties>

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -22,6 +22,7 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
       <testSuite>${project.artifactId}</testSuite>
       <testClass>org.eclipse.pde.ui.tests.AllPDETests</testClass>


### PR DESCRIPTION
The `javadoc` profile that the Jenkins job enables generates and jars API docs for every module in the reactor, including the test bundles and the DS TCK. Nobody publishes those docs and the build throws the jars away, so this turns javadoc off for them and keeps it on for the published bundles, where doclint is the only check CI has on HTML and syntax in doc comments.

Same change as eclipse-platform/eclipse.platform.ui#4358, with one difference: platform.ui is fully pomless, while most PDE test bundles carry an explicit `pom.xml`. `pom.model.property.*` in `build.properties` is only evaluated by the pomless model reader, so those bundles set `maven.javadoc.skip` in the pom instead and only the four pomless ones use the `build.properties` form.

Verified with `mvn help:effective-pom` that all 14 modules resolve `maven.javadoc.skip=true` and that a published bundle such as `org.eclipse.pde.core` is unaffected. No full reactor build was run locally.