### PR TITLE
Validate public access modifier for DS constructor injection

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.annotations/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.pde.ds.annotations;singleton:=true
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Bundle-Activator: org.eclipse.pde.ds.internal.annotations.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.105.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/AnnotationVisitor.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/AnnotationVisitor.java
@@ -239,7 +239,8 @@ public class AnnotationVisitor extends ASTVisitor {
 					|| (isAbstract = Modifier.isAbstract(type.getModifiers()))
 					|| (isNested = (!type.isPackageMemberTypeDeclaration() && !isNestedPublicStatic(type)))
 					|| (noDefaultConstructor = !(hasDefaultConstructor(type)
-							|| (hasInjectableConstructor = hasInjectableConstructor(type, problemReporter))))) {
+							|| (hasInjectableConstructor = hasInjectableConstructor(type,
+									DSAnnotationVersion.V1_4.isEqualOrHigherThan(specVersion)))))) {
 				// interfaces, abstract types, non-static/non-public nested types, or types with no default constructor cannot be components
 				if (!errorLevel.isIgnore()) {
 					if (isInterface) {
@@ -249,11 +250,18 @@ public class AnnotationVisitor extends ASTVisitor {
 					} else if (isNested) {
 						problemReporter.reportProblem(annotation, null, NLS.bind(Messages.AnnotationProcessor_invalidCompImplClass_notTopLevel, type.getName().getIdentifier()), type.getName().getIdentifier());
 					} else if (noDefaultConstructor) {
-						if (specVersion.isEqualOrHigherThan(DSAnnotationVersion.V1_4)) {
-							problemReporter.reportProblem(annotation, null,
-									NLS.bind(Messages.AnnotationProcessor_invalidCompImplClass_compatibleConstructor,
-											type.getName().getIdentifier()),
-									type.getName().getIdentifier());
+						if (DSAnnotationVersion.V1_4.isEqualOrHigherThan(specVersion)) {
+							if (hasInjectableConstructor(type, false)) {
+								problemReporter.reportProblem(annotation, null,
+										NLS.bind(Messages.AnnotationProcessor_invalidConstructorNotPublic,
+												type.getName().getIdentifier()),
+										type.getName().getIdentifier());
+							} else {
+								problemReporter.reportProblem(annotation, null,
+										NLS.bind(Messages.AnnotationProcessor_invalidCompImplClass_compatibleConstructor,
+												type.getName().getIdentifier()),
+										type.getName().getIdentifier());
+							}
 						} else {
 							if (hasInjectableConstructor) {
 								// TODO we should add an error marker that offers a quickfix to upgrade the spec
@@ -2214,15 +2222,18 @@ public class AnnotationVisitor extends ASTVisitor {
 	}
 
 	/**
-	 * An injectable constructor is one annotated with <code>@Activate</code>
-	 *
+	 * An injectable constructor is one annotated with <code>@Activate</code> This
+	 * also checks whether the constructor is public as only public constructors are
+	 * considered for constructor injection.
+	 * 
 	 * @param type
-	 * @param problemReporter2
+	 * @param requirePublic
 	 * @return
 	 */
-	private static boolean hasInjectableConstructor(TypeDeclaration type, ProblemReporter problemReporter) {
+	private static boolean hasInjectableConstructor(TypeDeclaration type, boolean requirePublic) {
 		for (MethodDeclaration method : type.getMethods()) {
 			if (method.isConstructor()
+					&& (!requirePublic || Modifier.isPublic(method.getModifiers()))
 					&& annotations(method.modifiers()).map(Annotation::resolveAnnotationBinding)
 							.anyMatch(AnnotationVisitor::isActivateAnnotation)) {
 				return true;

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/Messages.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/Messages.java
@@ -69,6 +69,8 @@ public class Messages extends NLS {
 
 	public static String AnnotationProcessor_invalidConstructorArgument;
 
+	public static String AnnotationProcessor_invalidConstructorNotPublic;
+
 	public static String AnnotationProcessor_invalidComponentProperty_nameRequired;
 
 	public static String AnnotationProcessor_invalidComponentProperty_valueRequired;

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/messages.properties
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/messages.properties
@@ -36,6 +36,7 @@ AnnotationProcessor_invalidComponentName=Invalid component name: {0}
 AnnotationProcessor_invalidActivate=Invalid usage of @Activate
 AnnotationProcessor_invalidActivateField=Field {0} is not an Activation Object, must be either org.osgi.service.component.ComponentContext, org.osgi.framework.BundleContext, java.util.Map or a component property type
 AnnotationProcessor_invalidConstructorArgument=Invalid constructor parameter '{0}' at index {1}, must be either @Reference annotated, org.osgi.service.component.ComponentContext, org.osgi.framework.BundleContext, or java.util.Map
+AnnotationProcessor_invalidConstructorNotPublic=Constructor used for injection in component ''{0}'' must be public.
 AnnotationProcessor_invalidComponentProperty_nameRequired=Invalid component property: name is required.
 AnnotationProcessor_invalidComponentProperty_valueRequired=Invalid component property: value is required.
 AnnotationProcessor_invalidComponentPropertyFile=Component {1} file ''{0}'' does not exist.


### PR DESCRIPTION
This PR provides a validation check for DS constructor injection for a non-public injectable constructor. when an injectable constructor is found but is not public, a specific error message is reported to clearly indicate that the constructor must be public. 

Fixes: https://github.com/eclipse-pde/eclipse.pde/issues/1218

Before :


https://github.com/user-attachments/assets/0b609e5f-6c45-4437-8f6d-25f08ac93055





After : 


https://github.com/user-attachments/assets/3cdfc06c-7a7e-4d29-979c-187898cc4e9b

