### PR TITLE
Revert "Skip javadoc generation for test bundles"

### DIFF
--- a/apitools/org.eclipse.pde.api.tools.tests/pom.xml
+++ b/apitools/org.eclipse.pde.api.tools.tests/pom.xml
@@ -21,7 +21,6 @@
 	<version>1.4.600-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
 	</properties>
 	<build>

--- a/build/org.eclipse.pde.build.tests/pom.xml
+++ b/build/org.eclipse.pde.build.tests/pom.xml
@@ -13,10 +13,6 @@
 	<version>1.4.1100-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
-	<properties>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
-	</properties>
-
 	<profiles>
 		<profile>
 			<!-- Only enable this for individual bundles builds as otherhwise the ibuild repository is not aviable and we might run into problems -->

--- a/ds/org.eclipse.pde.ds.annotations.tests/build.properties
+++ b/ds/org.eclipse.pde.ds.annotations.tests/build.properties
@@ -4,4 +4,3 @@ bin.includes = META-INF/,\
                tests.jar,\
                test.xml,\
                projects/
-pom.model.property.maven.javadoc.skip = true

--- a/ds/org.eclipse.pde.ds.tck/pom.xml
+++ b/ds/org.eclipse.pde.ds.tck/pom.xml
@@ -13,10 +13,6 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
-	<properties>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/ds/org.eclipse.pde.ds.tests/build.properties
+++ b/ds/org.eclipse.pde.ds.tests/build.properties
@@ -18,4 +18,3 @@ bin.includes = META-INF/,\
                plugin.properties,\
                about.html,\
                test.xml
-pom.model.property.maven.javadoc.skip = true

--- a/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/pom.xml
+++ b/e4tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/pom.xml
@@ -22,7 +22,6 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<skipAPIAnalysis>true</skipAPIAnalysis> <!-- Not in baseline -->
 	</properties>
 

--- a/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/build.properties
+++ b/e4tools/tests/org.eclipse.e4.tools.emf.ui.tests/build.properties
@@ -2,4 +2,3 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
-pom.model.property.maven.javadoc.skip = true

--- a/e4tools/tests/org.eclipse.e4.tools.persistence.tests/pom.xml
+++ b/e4tools/tests/org.eclipse.e4.tools.persistence.tests/pom.xml
@@ -22,7 +22,6 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<skipAPIAnalysis>true</skipAPIAnalysis> <!-- Not in baseline -->
 	</properties>
 

--- a/e4tools/tests/org.eclipse.e4.tools.test/build.properties
+++ b/e4tools/tests/org.eclipse.e4.tools.test/build.properties
@@ -2,4 +2,3 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
-pom.model.property.maven.javadoc.skip = true

--- a/ua/org.eclipse.pde.ua.tests/pom.xml
+++ b/ua/org.eclipse.pde.ua.tests/pom.xml
@@ -22,7 +22,6 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
-  	<maven.javadoc.skip>true</maven.javadoc.skip>
   	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.pde.internal.ua.tests.AllUATests</testClass>
   </properties>

--- a/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
+++ b/ui/org.eclipse.pde.genericeditor.extension.tests/pom.xml
@@ -22,7 +22,6 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
     <testSuite>${project.artifactId}</testSuite>
     <testClass>org.eclipse.pde.genericeditor.extension.tests.AllTargetEditorTests</testClass>

--- a/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
+++ b/ui/org.eclipse.pde.junit.runtime.tests/pom.xml
@@ -26,9 +26,6 @@
 	<artifactId>org.eclipse.pde.junit.runtime.tests</artifactId>
 	<version>3.8.400-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
-	<properties>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
-	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/ui/org.eclipse.pde.ui.templates.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.templates.tests/pom.xml
@@ -22,7 +22,6 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
-  	<maven.javadoc.skip>true</maven.javadoc.skip>
   	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.pde.ui.templates.tests.TestPDETemplates</testClass>
   </properties>

--- a/ui/org.eclipse.pde.ui.tests/pom.xml
+++ b/ui/org.eclipse.pde.ui.tests/pom.xml
@@ -22,7 +22,6 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
       <testSuite>${project.artifactId}</testSuite>
       <testClass>org.eclipse.pde.ui.tests.AllPDETests</testClass>


### PR DESCRIPTION
Reverts https://github.com/eclipse-pde/eclipse.pde/pull/2474 since there is a more general solution
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/4036