### PR TITLE
Add system property to disable framework state dump in RemotePluginTestRunner

### DIFF
--- a/ui/org.eclipse.pde.junit.runtime/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.junit.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.junit.runtime; singleton:=true
-Bundle-Version: 3.8.300.qualifier
+Bundle-Version: 3.8.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.4.0,4.0.0)",

--- a/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/RemotePluginTestRunner.java
+++ b/ui/org.eclipse.pde.junit.runtime/src/org/eclipse/pde/internal/junit/runtime/RemotePluginTestRunner.java
@@ -37,6 +37,8 @@ import org.osgi.framework.wiring.BundleWiring;
  */
 public class RemotePluginTestRunner extends RemoteTestRunner {
 
+	private static final boolean DISABLE_FRAMEWORK_STATE_DUMP = Boolean.getBoolean("pde.testing.disable.framework.state.dump"); //$NON-NLS-1$
+
 	private static final String ORG_ECLIPSE_JDT_JUNIT5_RUNTIME = "org.eclipse.jdt.junit5.runtime"; //$NON-NLS-1$
 	private static final String ORG_ECLIPSE_JDT_JUNIT6_RUNTIME = "org.eclipse.jdt.junit6.runtime"; //$NON-NLS-1$
 	private static final VersionRange JUNIT5_VERSION_RANGE = new VersionRange("[1.0.0,6.0.0)"); //$NON-NLS-1$
@@ -92,7 +94,7 @@ public class RemotePluginTestRunner extends RemoteTestRunner {
 					failures++;
 				}
 			}
-			if (failures > 0) {
+			if (failures > 0 && !DISABLE_FRAMEWORK_STATE_DUMP) {
 				System.err.println();
 				System.err.println("Current Framework state is:"); //$NON-NLS-1$
 				for (Bundle bundle : bundles) {


### PR DESCRIPTION
Dumping the state of all bundles in `RemotePluginTestRunner` can result in 1000+ lines in the console, when running a single test, making logs more difficult to read.

This change adds a system property to disable the state dump for cases, where unresolvable bundles is a known problem with no pending solution. The unresolvable bundles are still printed on standard error.